### PR TITLE
Add live energy feed reconciliation and sharded fabric telemetry to Kardashev-II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
@@ -171,6 +171,20 @@ flowchart TD
 * **Compute rollup** – All compute capacity is measured in exaFLOPs and agent counts. A reconciliation matrix confirms that per-region totals equal the Interstellar Council view and Dyson programme requirements.
 * **Probabilistic assurance** – Monte Carlo simulations (256 deterministic runs) estimate breach probability vs the 1% tolerance. Results surface in the UI and `output/kardashev-monte-carlo.json`; any breach probability above tolerance halts orchestration.
 
+## ⚡ Live energy feed reconciliation
+
+* **Triple-source telemetry** – `config/energy-feeds.json` lists per-federation solar/fusion/microwave feeds with tolerances. The orchestrator ingests the file, compares live MW readings (nominal + buffer) against manifest GW, and refuses to emit artefacts if drift exceeds the configured 5% tolerance or the 8.5% alert band.
+* **Deterministic ledger** – `output/kardashev-energy-feeds.json` captures calibration timestamps, tolerances, and per-feed deltas so guardians can diff on-chain energy oracles against the generated Safe batch.
+* **UI feedback loop** – The dashboard renders a “Live energy feeds” card highlighting Δ%, latency, and feed health. Any drift beyond tolerance immediately flips the badge red, ensuring non-technical owners see energy anomalies before executing Safe payloads.
+* **Scenario rehearsal** – The new “energy-feed-drift” scenario stresses a simultaneous feed spike; mitigation guidance is embedded into the scenario sweep and operator briefing so owners can rehearse throttling or rebalancing the Dyson thermostat.
+
+## 🕸️ Sharded job fabric & routing ledger
+
+* **Fabric validation** – `config/fabric.json` defines regional job registries, guardian councils, and sentinel quorums. The orchestrator cross-checks shard domains and sentinels against the manifest; mismatches surface as warnings, and `output/kardashev-fabric-ledger.json` records the diff for audits.
+* **Coverage telemetry** – Telemetry now includes `orchestrationFabric.coverage`, tracking domain alignment, sentinel parity, unmatched federations, and shard latency envelopes. The stability ledger adds a dedicated check so fabric drift blocks deployments.
+* **Dashboard card** – A new “Sharded registry fabric” panel visualises shard registries, latencies, and issues (e.g., missing domains or sentinel drift) with colour-coded badges so non-technical stewards can direct remediation instantly.
+* **Scenario integration** – Scenario 8 (“Primary compute plane offline”) now draws on shard coverage data, while the new fabric check feeds the unstoppable consensus score to guarantee routing health before executing multi-planet jobs.
+
 ## 🎛️ Mission directives & verification dashboards
 
 * **Operator briefing pack** – `output/kardashev-operator-briefing.md` condenses owner powers, escalation pathways, drill cadence, and verification status so non-technical stewards can sign off in under two minutes.
@@ -221,6 +235,8 @@ flowchart TD
 | `output/kardashev-operator-briefing.md` | Mission directives pack consolidating owner powers, escalation, and verification state. |
 | `output/kardashev-stability-ledger.json` | Composite consensus ledger blending deterministic, redundant, and thermodynamic verifications. |
 | `output/kardashev-monte-carlo.json` | Monte Carlo summary (runs, breach probability, percentiles) validating the energy thermostat tolerance. |
+| `output/kardashev-energy-feeds.json` | Snapshot of per-federation energy feeds, tolerances, and drift calculations backing the dashboard feed badges. |
+| `output/kardashev-fabric-ledger.json` | Registry shard ledger capturing domain coverage, sentinel parity, unmatched federations, and latency envelope. |
 | `output/kardashev-owner-proof.json` | Owner override proof deck with selector coverage, pause embeddings, target isolation, and unstoppable control score. |
 | `output/kardashev-safe-transaction-batch.json` | Safe payload bundling global parameters, sentinel bindings, capital streams, and pause toggles. |
 | `index.html` | Zero-build dashboard that renders telemetry, Mermaid diagrams, and operator controls in any static server. |

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/config/energy-feeds.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/config/energy-feeds.json
@@ -1,27 +1,33 @@
 {
+  "tolerancePct": 5.0,
+  "driftAlertPct": 8.5,
+  "calibrationISO8601": "2025-02-28T18:00:00Z",
   "feeds": [
     {
+      "federationSlug": "earth",
       "region": "earth-grid",
       "telemetry": "https://energy.example/earth/live",
       "type": "solar",
-      "nominalMw": 145000,
-      "bufferMw": 12000,
+      "nominalMw": 81500000,
+      "bufferMw": 500000,
       "latencyMs": 1200
     },
     {
+      "federationSlug": "mars",
       "region": "mars-dome",
       "telemetry": "https://energy.example/mars/live",
       "type": "fusion",
-      "nominalMw": 18000,
-      "bufferMw": 2200,
+      "nominalMw": 23600000,
+      "bufferMw": 400000,
       "latencyMs": 720000
     },
     {
+      "federationSlug": "orbital",
       "region": "orbital-swarm",
       "telemetry": "https://energy.example/orbital/live",
       "type": "microwave-solar",
-      "nominalMw": 450000,
-      "bufferMw": 50000,
+      "nominalMw": 134500000,
+      "bufferMw": 1500000,
       "latencyMs": 3200
     }
   ]

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/config/fabric.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/config/fabric.json
@@ -2,40 +2,37 @@
   "shards": [
     {
       "id": "earth",
-      "jobRegistry": "0x000000000000000000000000000000000000eAr1",
+      "jobRegistry": "0xea000000000000000000000000000000000000a1",
       "latencyMs": 40,
-      "domains": ["finance", "health", "infrastructure"],
-      "guardianCouncil": "0x00000000000000000000000000000000000EaRdg",
+      "domains": ["earth.finance", "earth.infrastructure"],
+      "guardianCouncil": "0xea0000000000000000000000000000000000b0a1",
       "sentinels": [
-        "0x0000000000000000000000000000000000EaR51",
-        "0x0000000000000000000000000000000000EaR52"
+        "0x9d7d49c1c0ce2709f50af6b456b8a2a5d23fd9a1"
       ]
     },
     {
       "id": "mars",
-      "jobRegistry": "0x000000000000000000000000000000000000MaRS",
+      "jobRegistry": "0xea000000000000000000000000000000000000b1",
       "latencyMs": 720000,
-      "domains": ["terraforming", "resource-extraction", "biosafety"],
-      "guardianCouncil": "0x0000000000000000000000000000000000MarDG",
+      "domains": ["mars.terraforming"],
+      "guardianCouncil": "0xea0000000000000000000000000000000000b0b1",
       "sentinels": [
-        "0x0000000000000000000000000000000000Mar51",
-        "0x0000000000000000000000000000000000Mar52"
+        "0x71f3c9d8b9e7a0f3dc5b4215df9e8f531c7c2f91"
       ]
     },
     {
       "id": "orbital",
-      "jobRegistry": "0x0000000000000000000000000000000000000rb1",
+      "jobRegistry": "0xea000000000000000000000000000000000000c1",
       "latencyMs": 1200,
-      "domains": ["dyson-swarm", "astro-logistics"],
-      "guardianCouncil": "0x0000000000000000000000000000000000OrbDG",
+      "domains": ["orbital.defense", "orbital.research"],
+      "guardianCouncil": "0xea0000000000000000000000000000000000b0c1",
       "sentinels": [
-        "0x0000000000000000000000000000000000Orb51",
-        "0x0000000000000000000000000000000000Orb52"
+        "0x4b6d8f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e"
       ]
     }
   ],
-  "knowledgeGraph": "0x0000000000000000000000000000000000Kn0wG",
-  "energyOracle": "0x0000000000000000000000000000000000En0rg",
-  "rewardEngine": "0x0000000000000000000000000000000000Therm",
-  "phase8Manager": "0x0000000000000000000000000000000000Ph8Mgr"
+  "knowledgeGraph": "0xea0000000000000000000000000000000000d0a1",
+  "energyOracle": "0xea0000000000000000000000000000000000d0b1",
+  "rewardEngine": "0xea0000000000000000000000000000000000d0c1",
+  "phase8Manager": "0xea0000000000000000000000000000000000d0d1"
 }

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -55,6 +55,12 @@
           <p>Status: <span id="energy-monte-carlo-status">…</span></p>
         </article>
         <article class="card">
+          <h2>Live energy feeds</h2>
+          <p id="energy-feed-compliance">…</p>
+          <p id="energy-feed-latency">…</p>
+          <ul id="energy-feed-list" class="feed-list"></ul>
+        </article>
+        <article class="card">
           <h2>Compute delta</h2>
           <p id="compute-deviation">…</p>
         </article>
@@ -85,6 +91,15 @@
         <p id="fabric-summary" class="lede">…</p>
         <ul id="fabric-planes" class="fabric-list"></ul>
         <p class="fabric-meta" id="fabric-meta">…</p>
+      </section>
+
+      <section class="card">
+        <div class="section-title">
+          <h2>Sharded registry fabric</h2>
+        </div>
+        <p id="fabric-federation-summary" class="lede">…</p>
+        <p id="fabric-latency-summary">…</p>
+        <ul id="fabric-shards" class="fabric-list"></ul>
       </section>
 
       <section class="card">

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-energy-feeds.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-energy-feeds.json
@@ -1,0 +1,46 @@
+{
+  "calibrationISO8601": "2025-02-28T18:00:00Z",
+  "tolerancePct": 5,
+  "driftAlertPct": 8.5,
+  "feeds": [
+    {
+      "region": "earth-grid",
+      "federationSlug": "earth",
+      "type": "solar",
+      "telemetry": "https://energy.example/earth/live",
+      "manifestGw": 82000,
+      "feedGw": 82000,
+      "deltaGw": 0,
+      "deltaPct": 0,
+      "latencyMs": 1200,
+      "withinTolerance": true,
+      "driftAlert": false
+    },
+    {
+      "region": "mars-dome",
+      "federationSlug": "mars",
+      "type": "fusion",
+      "telemetry": "https://energy.example/mars/live",
+      "manifestGw": 24000,
+      "feedGw": 24000,
+      "deltaGw": 0,
+      "deltaPct": 0,
+      "latencyMs": 720000,
+      "withinTolerance": true,
+      "driftAlert": false
+    },
+    {
+      "region": "orbital-swarm",
+      "federationSlug": "orbital",
+      "type": "microwave-solar",
+      "telemetry": "https://energy.example/orbital/live",
+      "manifestGw": 136000,
+      "feedGw": 136000,
+      "deltaGw": 0,
+      "deltaPct": 0,
+      "latencyMs": 3200,
+      "withinTolerance": true,
+      "driftAlert": false
+    }
+  ]
+}

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-fabric-ledger.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-fabric-ledger.json
@@ -1,0 +1,84 @@
+{
+  "coverage": {
+    "domainsOk": true,
+    "sentinelsOk": true,
+    "federationsOk": true,
+    "unmatchedFederations": [],
+    "unmatchedShards": [],
+    "averageLatencyMs": 240413.33333333334,
+    "maxLatencyMs": 720000
+  },
+  "shards": [
+    {
+      "id": "earth",
+      "jobRegistry": "0xea000000000000000000000000000000000000a1",
+      "latencyMs": 40,
+      "domains": [
+        "earth.finance",
+        "earth.infrastructure"
+      ],
+      "missingDomains": [],
+      "orphanDomains": [],
+      "guardianCouncil": "0xea0000000000000000000000000000000000b0a1",
+      "sentinelMatches": [
+        {
+          "address": "0x9d7d49c1c0ce2709f50af6b456b8a2a5d23fd9a1",
+          "registered": true
+        }
+      ],
+      "sentinelsOk": true,
+      "federationFound": true,
+      "governanceSafe": "0xaaccfefb5b833b41c1a6ff1d4a20e2f91b9fa5c2",
+      "domainCoverageOk": true
+    },
+    {
+      "id": "mars",
+      "jobRegistry": "0xea000000000000000000000000000000000000b1",
+      "latencyMs": 720000,
+      "domains": [
+        "mars.terraforming"
+      ],
+      "missingDomains": [],
+      "orphanDomains": [],
+      "guardianCouncil": "0xea0000000000000000000000000000000000b0b1",
+      "sentinelMatches": [
+        {
+          "address": "0x71f3c9d8b9e7a0f3dc5b4215df9e8f531c7c2f91",
+          "registered": true
+        }
+      ],
+      "sentinelsOk": true,
+      "federationFound": true,
+      "governanceSafe": "0x7b0f87d532f43c4a0e7816d9d7806f48a9c3f2d1",
+      "domainCoverageOk": true
+    },
+    {
+      "id": "orbital",
+      "jobRegistry": "0xea000000000000000000000000000000000000c1",
+      "latencyMs": 1200,
+      "domains": [
+        "orbital.defense",
+        "orbital.research"
+      ],
+      "missingDomains": [],
+      "orphanDomains": [],
+      "guardianCouncil": "0xea0000000000000000000000000000000000b0c1",
+      "sentinelMatches": [
+        {
+          "address": "0x4b6d8f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e",
+          "registered": true
+        }
+      ],
+      "sentinelsOk": true,
+      "federationFound": true,
+      "governanceSafe": "0x1b3da8f56e47c29e8ceaff4b2d9c8b5d7ae2c6f4",
+      "domainCoverageOk": true
+    }
+  ],
+  "contracts": {
+    "knowledgeGraph": "0xea0000000000000000000000000000000000d0a1",
+    "energyOracle": "0xea0000000000000000000000000000000000d0b1",
+    "rewardEngine": "0xea0000000000000000000000000000000000d0c1",
+    "phase8Manager": "0xea0000000000000000000000000000000000d0d1"
+  }
+}

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
@@ -18,9 +18,10 @@
 * Energy models (regionalSum, dysonProjection, thermostatBudget) aligned: true
 * Monte Carlo breach 0.00% (≤ 1% tolerance): true
 * Compute deviation 0.45% (tolerance 0.75%): true
+* Energy feed drift ≤ 5%: true
 * Bridge latency tolerance (120s): true
 * Owner override unstoppable score 100.00% (selectors true, pause true, resume true, secondary aligned @ 100.00%).
-* Scenario sweep: 5/7 nominal, 2 warning, 0 critical.
+* Scenario sweep: 6/8 nominal, 2 warning, 0 critical.
   - Interplanetary bridge outage simulation: Failover latency 180s breaches 120s failsafe.
   - Compute drawdown (15%) resilience: Deviation 14.62% exceeds tolerance 0.75%.
 * Audit checklist: ipfs://QmKardashevAuditChecklist
@@ -34,6 +35,7 @@
 * Failover capacity 44.50 EF vs quorum 42.90 EF; within quorum true.
 * Average plane availability 98.23% (planes 3).
 * Lead plane Solara Earth Core (Earth orbit low-latency ring) capacity 38.00 EF, partner sol-mars.
+* Sharded registry fabric domains OK · sentinels OK · federations OK.
 
 ## Federation snapshot
 * **Earth Sovereign Federation** (chain 1) — Safe 0xaaccfefb5b833b41c1a6ff1d4a20e2f91b9fa5c2, energy 82000 GW, compute 18.4 EF.

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
@@ -20,6 +20,8 @@
 * Regional availability: earth 82000 GW · mars 24000 GW · orbital 136000 GW.
 * Monte Carlo breach probability 0.00% (runs 256, tolerance 1.00%).
 * Demand percentiles: P95 251,695.495 GW · P99 255,130.151 GW.
+* Live feeds (≤ 5%): earth-grid Δ 0.00% · mars-dome Δ 0.00% · orbital-swarm Δ 0.00%.
+* Feed latency: avg 241467 ms · max 720000 ms (calibrated 2025-02-28T18:00:00Z).
 
 ---
 
@@ -47,6 +49,8 @@
 * **Solara Earth Core** (Earth orbit low-latency ring) – scheduler 0x2f4a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f34, capacity 38.00 EF, latency 38 ms, availability 98.60%, failover partner sol-mars.
 * **Ares Horizon Fabric** (Mars synchronous polar array) – scheduler 0x4d6e8f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d61, capacity 18.50 EF, latency 112 ms, availability 97.20%, failover partner sol-orbital.
 * **Helios Orbital Halo** (Dyson swarm maintenance lattice) – scheduler 0x7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e78, capacity 26.00 EF, latency 24 ms, availability 98.90%, failover partner sol-earth.
+* Sharded registry fabric health — domains aligned, sentinels aligned, federations aligned.
+* Fabric latency: avg 240413 ms · max 720000 ms.
 
 ---
 
@@ -87,6 +91,12 @@
   - Tolerance: 120 ppm (ok)
   - Anchors at quorum: 3/3 (ok)
   - Recommended: Execute fallback ENS registrar policy if forged rate exceeds tolerance. · Rotate identity anchors using Safe batch identity transactions.
+* **Live energy feed drift shock** — status NOMINAL (confidence 100.0%) · Live feeds remain within tolerance bands.
+  - Max drift: 0.00% (ok)
+  - Tolerance: 5% (ok)
+  - Drift alert: 8.5% (ok)
+  - Average latency: 241467 ms (check)
+  - Recommended: Trigger energy oracle recalibration from mission directives. · Rebalance Dyson thermostat inputs toward the affected federation until drift subsides.
 * **Primary compute plane offline** — status NOMINAL (confidence 100.0%) · Failover capacity 44.50 EF covers quorum.
   - Largest plane: Solara Earth Core (ok)
   - Failover capacity: 44.50 EF (ok)

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-scenario-sweep.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-scenario-sweep.json
@@ -204,6 +204,40 @@
     ]
   },
   {
+    "id": "energy-feed-drift",
+    "title": "Live energy feed drift shock",
+    "status": "nominal",
+    "summary": "Live feeds remain within tolerance bands.",
+    "confidence": 1,
+    "impact": "Feeds drift but remain serviceable; monitor and prepare calibration update.",
+    "metrics": [
+      {
+        "label": "Max drift",
+        "value": "0.00%",
+        "ok": true
+      },
+      {
+        "label": "Tolerance",
+        "value": "5%",
+        "ok": true
+      },
+      {
+        "label": "Drift alert",
+        "value": "8.5%",
+        "ok": true
+      },
+      {
+        "label": "Average latency",
+        "value": "241467 ms",
+        "ok": false
+      }
+    ],
+    "recommendedActions": [
+      "Trigger energy oracle recalibration from mission directives.",
+      "Rebalance Dyson thermostat inputs toward the affected federation until drift subsides."
+    ]
+  },
+  {
     "id": "compute-plane-failover",
     "title": "Primary compute plane offline",
     "status": "nominal",

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
@@ -29,7 +29,7 @@
       },
       {
         "method": "scenario-sweep",
-        "score": 0.7929052035435014,
+        "score": 0.8187920531005637,
         "explanation": "Average confidence across Kardashev-II surge, bridge, sentinel, compute, identity, and schedule stressors."
       },
       {
@@ -112,6 +112,14 @@
       "evidence": "breach 0.00% (runs 256)"
     },
     {
+      "id": "energy-feeds",
+      "title": "Live energy feeds within tolerance",
+      "severity": "high",
+      "status": true,
+      "weight": 0.85,
+      "evidence": "earth-grid 0.00% · mars-dome 0.00% · orbital-swarm 0.00%"
+    },
+    {
       "id": "energy-margin",
       "title": "Dyson thermostat buffer intact",
       "severity": "medium",
@@ -168,6 +176,14 @@
       "evidence": "failover 44.50 EF vs required 42.90 EF"
     },
     {
+      "id": "orchestration-fabric",
+      "title": "Sharded registry fabric aligned",
+      "severity": "medium",
+      "status": true,
+      "weight": 0.75,
+      "evidence": "unmatched federations: 0 · unmatched shards: 0"
+    },
+    {
       "id": "bridge-latency",
       "title": "Bridge latency ≤ tolerance",
       "severity": "high",
@@ -181,16 +197,16 @@
       "severity": "medium",
       "status": true,
       "weight": 0.8,
-      "evidence": "5/7 nominal · 2 warning · 0 critical"
+      "evidence": "6/8 nominal · 2 warning · 0 critical"
     }
   ],
   "alerts": [],
   "scenarioSweep": {
-    "total": 7,
-    "nominal": 5,
+    "total": 8,
+    "nominal": 6,
     "warning": 2,
     "critical": 0,
-    "averageConfidence": 0.7929052035435014,
+    "averageConfidence": 0.8187920531005637,
     "entries": [
       {
         "id": "energy-demand-surge",
@@ -233,6 +249,13 @@
         "status": "nominal",
         "confidence": 1,
         "summary": "Revocation network absorbs infiltration within tolerance."
+      },
+      {
+        "id": "energy-feed-drift",
+        "title": "Live energy feed drift shock",
+        "status": "nominal",
+        "confidence": 1,
+        "summary": "Live feeds remain within tolerance bands."
       },
       {
         "id": "compute-plane-failover",

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
@@ -77,6 +77,56 @@
       "averageGw": 236494.16525702746,
       "withinTolerance": true,
       "tolerance": 0.01
+    },
+    "liveFeeds": {
+      "calibrationISO8601": "2025-02-28T18:00:00Z",
+      "tolerancePct": 5,
+      "driftAlertPct": 8.5,
+      "feeds": [
+        {
+          "region": "earth-grid",
+          "federationSlug": "earth",
+          "type": "solar",
+          "telemetry": "https://energy.example/earth/live",
+          "manifestGw": 82000,
+          "feedGw": 82000,
+          "deltaGw": 0,
+          "deltaPct": 0,
+          "latencyMs": 1200,
+          "withinTolerance": true,
+          "driftAlert": false
+        },
+        {
+          "region": "mars-dome",
+          "federationSlug": "mars",
+          "type": "fusion",
+          "telemetry": "https://energy.example/mars/live",
+          "manifestGw": 24000,
+          "feedGw": 24000,
+          "deltaGw": 0,
+          "deltaPct": 0,
+          "latencyMs": 720000,
+          "withinTolerance": true,
+          "driftAlert": false
+        },
+        {
+          "region": "orbital-swarm",
+          "federationSlug": "orbital",
+          "type": "microwave-solar",
+          "telemetry": "https://energy.example/orbital/live",
+          "manifestGw": 136000,
+          "feedGw": 136000,
+          "deltaGw": 0,
+          "deltaPct": 0,
+          "latencyMs": 3200,
+          "withinTolerance": true,
+          "driftAlert": false
+        }
+      ],
+      "allWithinTolerance": true,
+      "driftAlerts": [],
+      "averageLatencyMs": 241466.66666666666,
+      "maxLatencyMs": 720000
     }
   },
   "compute": {
@@ -269,6 +319,88 @@
       "layeredHierarchies": 3,
       "auditURI": "ipfs://QmKardashevComputeAudit",
       "energyBalancing": "Dyson thermostat dispatch dynamically shifts GW budget to the active failover plane."
+    }
+  },
+  "orchestrationFabric": {
+    "knowledgeGraph": "0xea0000000000000000000000000000000000d0a1",
+    "energyOracle": "0xea0000000000000000000000000000000000d0b1",
+    "rewardEngine": "0xea0000000000000000000000000000000000d0c1",
+    "phase8Manager": "0xea0000000000000000000000000000000000d0d1",
+    "shards": [
+      {
+        "id": "earth",
+        "jobRegistry": "0xea000000000000000000000000000000000000a1",
+        "latencyMs": 40,
+        "domains": [
+          "earth.finance",
+          "earth.infrastructure"
+        ],
+        "missingDomains": [],
+        "orphanDomains": [],
+        "guardianCouncil": "0xea0000000000000000000000000000000000b0a1",
+        "sentinelMatches": [
+          {
+            "address": "0x9d7d49c1c0ce2709f50af6b456b8a2a5d23fd9a1",
+            "registered": true
+          }
+        ],
+        "sentinelsOk": true,
+        "federationFound": true,
+        "governanceSafe": "0xaaccfefb5b833b41c1a6ff1d4a20e2f91b9fa5c2",
+        "domainCoverageOk": true
+      },
+      {
+        "id": "mars",
+        "jobRegistry": "0xea000000000000000000000000000000000000b1",
+        "latencyMs": 720000,
+        "domains": [
+          "mars.terraforming"
+        ],
+        "missingDomains": [],
+        "orphanDomains": [],
+        "guardianCouncil": "0xea0000000000000000000000000000000000b0b1",
+        "sentinelMatches": [
+          {
+            "address": "0x71f3c9d8b9e7a0f3dc5b4215df9e8f531c7c2f91",
+            "registered": true
+          }
+        ],
+        "sentinelsOk": true,
+        "federationFound": true,
+        "governanceSafe": "0x7b0f87d532f43c4a0e7816d9d7806f48a9c3f2d1",
+        "domainCoverageOk": true
+      },
+      {
+        "id": "orbital",
+        "jobRegistry": "0xea000000000000000000000000000000000000c1",
+        "latencyMs": 1200,
+        "domains": [
+          "orbital.defense",
+          "orbital.research"
+        ],
+        "missingDomains": [],
+        "orphanDomains": [],
+        "guardianCouncil": "0xea0000000000000000000000000000000000b0c1",
+        "sentinelMatches": [
+          {
+            "address": "0x4b6d8f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e",
+            "registered": true
+          }
+        ],
+        "sentinelsOk": true,
+        "federationFound": true,
+        "governanceSafe": "0x1b3da8f56e47c29e8ceaff4b2d9c8b5d7ae2c6f4",
+        "domainCoverageOk": true
+      }
+    ],
+    "coverage": {
+      "domainsOk": true,
+      "sentinelsOk": true,
+      "federationsOk": true,
+      "unmatchedFederations": [],
+      "unmatchedShards": [],
+      "averageLatencyMs": 240413.33333333334,
+      "maxLatencyMs": 720000
     }
   },
   "dominance": {
@@ -529,6 +661,54 @@
         "p99": 255130.15072335023
       }
     },
+    "energyFeeds": {
+      "tolerancePct": 5,
+      "driftAlertPct": 8.5,
+      "calibrationISO8601": "2025-02-28T18:00:00Z",
+      "feeds": [
+        {
+          "region": "earth-grid",
+          "federationSlug": "earth",
+          "type": "solar",
+          "telemetry": "https://energy.example/earth/live",
+          "manifestGw": 82000,
+          "feedGw": 82000,
+          "deltaGw": 0,
+          "deltaPct": 0,
+          "latencyMs": 1200,
+          "withinTolerance": true,
+          "driftAlert": false
+        },
+        {
+          "region": "mars-dome",
+          "federationSlug": "mars",
+          "type": "fusion",
+          "telemetry": "https://energy.example/mars/live",
+          "manifestGw": 24000,
+          "feedGw": 24000,
+          "deltaGw": 0,
+          "deltaPct": 0,
+          "latencyMs": 720000,
+          "withinTolerance": true,
+          "driftAlert": false
+        },
+        {
+          "region": "orbital-swarm",
+          "federationSlug": "orbital",
+          "type": "microwave-solar",
+          "telemetry": "https://energy.example/orbital/live",
+          "manifestGw": 136000,
+          "feedGw": 136000,
+          "deltaGw": 0,
+          "deltaPct": 0,
+          "latencyMs": 3200,
+          "withinTolerance": true,
+          "driftAlert": false
+        }
+      ],
+      "allWithinTolerance": true,
+      "driftAlerts": []
+    },
     "compute": {
       "tolerancePct": 0.75,
       "deviationPct": 0.45008183306055416,
@@ -566,6 +746,13 @@
       "failoverCapacityExaflops": 44.5,
       "requiredFailoverCapacity": 42.9,
       "averageAvailabilityPct": 0.9823333333333334
+    },
+    "orchestrationFabric": {
+      "domainsOk": true,
+      "sentinelsOk": true,
+      "federationsOk": true,
+      "unmatchedFederations": [],
+      "unmatchedShards": []
     },
     "auditChecklistURI": "ipfs://QmKardashevAuditChecklist"
   },
@@ -772,6 +959,40 @@
       "recommendedActions": [
         "Execute fallback ENS registrar policy if forged rate exceeds tolerance.",
         "Rotate identity anchors using Safe batch identity transactions."
+      ]
+    },
+    {
+      "id": "energy-feed-drift",
+      "title": "Live energy feed drift shock",
+      "status": "nominal",
+      "summary": "Live feeds remain within tolerance bands.",
+      "confidence": 1,
+      "impact": "Feeds drift but remain serviceable; monitor and prepare calibration update.",
+      "metrics": [
+        {
+          "label": "Max drift",
+          "value": "0.00%",
+          "ok": true
+        },
+        {
+          "label": "Tolerance",
+          "value": "5%",
+          "ok": true
+        },
+        {
+          "label": "Drift alert",
+          "value": "8.5%",
+          "ok": true
+        },
+        {
+          "label": "Average latency",
+          "value": "241467 ms",
+          "ok": false
+        }
+      ],
+      "recommendedActions": [
+        "Trigger energy oracle recalibration from mission directives.",
+        "Rebalance Dyson thermostat inputs toward the affected federation until drift subsides."
       ]
     },
     {

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/ci-validate.ts
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/ci-validate.ts
@@ -33,6 +33,8 @@ function validateReadme() {
     "## 🪪 Identity lattice & trust fabric",
     "## 🛰️ Compute fabric hierarchy",
     "## 🔌 Energy & compute governance",
+    "## ⚡ Live energy feed reconciliation",
+    "## 🕸️ Sharded job fabric & routing ledger",
     "## 🎛️ Mission directives & verification dashboards",
     "## 🔭 Scenario stress sweep",
     "## 🧬 Stability ledger & unstoppable consensus",

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css
@@ -206,7 +206,8 @@ button:hover {
 }
 
 .identity-list,
-.fabric-list {
+.fabric-list,
+.feed-list {
   list-style: none;
   padding: 0;
   margin: 12px 0 0 0;
@@ -216,12 +217,20 @@ button:hover {
 }
 
 .identity-list li,
-.fabric-list li {
+.fabric-list li,
+.feed-list li {
   background: rgba(15, 23, 42, 0.5);
   border: 1px solid rgba(99, 102, 241, 0.25);
   border-radius: 14px;
   padding: 12px 16px;
   line-height: 1.5;
+}
+
+.feed-list li {
+  font-family: "IBM Plex Mono", "Fira Mono", monospace;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .identity-meta,


### PR DESCRIPTION
## Summary
- add live energy feed reconciliation docs, config, telemetry exports, and dashboard card for Kardashev-II demo
- extend orchestrator to validate sharded fabric, emit new ledgers, scenarios, and briefing updates
- refresh CI heading checks, static UI, and generated outputs to surface energy/fabric readiness to operators

## Testing
- npm run demo:kardashev-ii:ci

------
https://chatgpt.com/codex/tasks/task_e_68fd5ceb3dd8833382dad220f446d67f