### PR TITLE
Add tertiary owner override decoder to Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
@@ -281,7 +281,7 @@ flowchart TD
 | `output/kardashev-energy-schedule.json` | Deterministic energy window plan with per-federation coverage, reliability, and job cadence recommendations. |
 | `output/kardashev-settlement-ledger.json` | Settlement protocol ledger detailing finality, tolerance, coverage, slippage, and risk posture for forex bridges. |
 | `output/kardashev-fabric-ledger.json` | Registry shard ledger capturing domain coverage, sentinel parity, unmatched federations, and latency envelope. |
-| `output/kardashev-owner-proof.json` | Owner override proof deck with selector coverage, pause embeddings, target isolation, and unstoppable control score. |
+| `output/kardashev-owner-proof.json` | Owner override proof deck with selector coverage, pause embeddings, target isolation, unstoppable control score, and triple-check decoder evidence (primary, secondary, tertiary). |
 | `output/kardashev-safe-transaction-batch.json` | Safe payload bundling global parameters, sentinel bindings, capital streams, and pause toggles. |
 | `index.html` | Zero-build dashboard that renders telemetry, Mermaid diagrams, and operator controls in any static server. |
 | `ui/` | Assets powering the static dashboard (styles, JavaScript modules). |
@@ -294,14 +294,14 @@ flowchart TD
 * **Redundant verification vectors** – The ledger records independent confidence methods: boolean consensus, redundant telemetry agreement, and residual Dyson thermostat buffer. Operators can inspect divergences instantly.
 * **Alert surfacing** – Any failing check propagates into an `alerts` array consumed by the UI and CI. No Safe batch is marked deployable if a single high-severity invariant breaks.
 * **Owner lever audit** – Manager, guardian council, system pause, and pause/resume calldata inclusion are mirrored in the ledger so non-technical governors can assert absolute control before execution.
-* **Dual unstoppable verification** – A secondary decoder replays the Safe batch, recomputes selectors and pause embeddings, and records the corroborating unstoppable score next to the primary proof so drift is impossible to miss.
+* **Triple unstoppable verification** – The ledger now persists primary selector checks, a secondary decoder replay, and a tertiary interface-level replay that fails if any pause/resume embed mis-decodes or if decode failures occur, placing all unstoppable scores side-by-side.
 * **Monte Carlo sentinel** – The ledger adds a dedicated check gating execution on the 1% breach tolerance, with confidence vectors publishing the simulated demand percentiles for guardian review.
 
 ---
 
 ## 🧪 Verification rituals
 
-1. **Local** – run `npm run demo:kardashev-ii:orchestrate` and confirm no warnings. Inspect `output/kardashev-telemetry.json` and ensure `energy.tripleCheck === true`, `verification.energyModels.withinMargin === true`, `verification.energyMonteCarlo.withinTolerance === true`, `governance.ownerOverridesReady === true`, `governance.ownerProof.secondary.matchesPrimaryScore === true`, and every entry in `scenarioSweep` reports `status !== "critical"`.
+1. **Local** – run `npm run demo:kardashev-ii:orchestrate` and confirm no warnings. Inspect `output/kardashev-telemetry.json` and ensure `energy.tripleCheck === true`, `verification.energyModels.withinMargin === true`, `verification.energyMonteCarlo.withinTolerance === true`, `governance.ownerOverridesReady === true`, `governance.ownerProof.secondary.matchesPrimaryScore === true`, `governance.ownerProof.tertiary.decodeFailures === 0`, `governance.ownerProof.tertiary.matchesPrimaryScore === true`, and every entry in `scenarioSweep` reports `status !== "critical"`.
 2. **CI** – `npm run demo:kardashev-ii:ci` executes the orchestrator in check mode, validates README headings, ensures Mermaid code fences exist, and fails on drift.
 3. **Runtime** – Serve the UI and click “Trigger Pause Simulation” to confirm pause/unpause calldata toggles update the status badge, review the Dyson timeline, and verify each owner directive matches `kardashev-operator-briefing.md`.
 4. **Manual** – Operators copy/paste the Safe batch into a production Safe, verify the prefilled manager/system pause addresses, and stage the transaction.

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
@@ -23,7 +23,7 @@
 * Bridge latency tolerance (120s): true
 * Settlement finality 5.23 min (max 10.00 min) · slippage threshold 75 bps.
 * Logistics corridors 3 active — avg reliability 98.50% · min buffer 14.00d · watchers 9 (nominal).
-* Owner override unstoppable score 100.00% (selectors true, pause true, resume true, secondary aligned @ 100.00%).
+* Owner override unstoppable score 100.00% (selectors true, pause true, resume true, secondary aligned @ 100.00%, tertiary aligned @ 100.00% · decode failures 0).
 * Scenario sweep: 6/11 nominal, 4 warning, 1 critical.
   - Interplanetary bridge outage simulation: Failover latency 180s breaches 120s failsafe.
   - Compute drawdown (15%) resilience: Deviation 14.62% exceeds tolerance 0.75%.

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
@@ -10,7 +10,7 @@
 2. Verify manager, guardian council, and system pause addresses in review modals.
 3. Stage pause + resume transactions but leave them unsent until incident drills.
 4. Confirm self-improvement plan hash matches guardian-approved digest.
-5. Confirm unstoppable owner score 100.00% (pause true, resume true, secondary corroboration aligned @ 100.00%).
+5. Confirm unstoppable owner score 100.00% (pause true, resume true, secondary corroboration aligned @ 100.00%, tertiary decode aligned @ 100.00% · decode failures 0).
 
 ---
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-owner-proof.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-owner-proof.json
@@ -102,6 +102,156 @@
     "unstoppableScore": 1,
     "matchesPrimaryScore": true
   },
+  "tertiaryVerification": {
+    "selectorsMatch": true,
+    "pauseDecoded": true,
+    "resumeDecoded": true,
+    "singleOwnerTargets": true,
+    "unstoppableScore": 1,
+    "matchesPrimaryScore": true,
+    "matchesSecondaryScore": true,
+    "decodeFailures": 0,
+    "decodedCalls": [
+      {
+        "index": 0,
+        "signature": "setGlobalParameters((address,address,address,address,address,address,uint64,uint64,uint256,string,bytes32))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 1,
+        "signature": "setGuardianCouncil(address)",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 2,
+        "signature": "setSystemPause(address)",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 3,
+        "signature": "setSelfImprovementPlan((string,bytes32,uint64,uint64,string))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 4,
+        "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 5,
+        "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 6,
+        "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 7,
+        "signature": "setSentinelDomains(bytes32,bytes32[])",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 8,
+        "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 9,
+        "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 10,
+        "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 11,
+        "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 12,
+        "signature": "setSentinelDomains(bytes32,bytes32[])",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 13,
+        "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 14,
+        "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 15,
+        "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 16,
+        "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 17,
+        "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 18,
+        "signature": "setSentinelDomains(bytes32,bytes32[])",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 19,
+        "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 20,
+        "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 21,
+        "signature": "forwardPauseCall(bytes)",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      },
+      {
+        "index": 22,
+        "signature": "forwardPauseCall(bytes)",
+        "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+        "matched": true
+      }
+    ]
+  },
   "calls": [
     {
       "index": 0,

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
@@ -3,13 +3,13 @@
   "manifestVersion": "agi-jobs.kardashev-ii.demo.v1",
   "dominanceScore": 90,
   "confidence": {
-    "compositeScore": 0.960591133004926,
+    "compositeScore": 0.9618138424821002,
     "quorum": true,
     "summary": "Manual review required for 1 check(s).",
     "methods": [
       {
         "method": "deterministic-consensus",
-        "score": 0.960591133004926,
+        "score": 0.9618138424821002,
         "explanation": "Weighted boolean consensus across critical governance, energy, and compute checks."
       },
       {
@@ -56,6 +56,11 @@
         "method": "owner-control-secondary",
         "score": 1,
         "explanation": "Independent decode of Safe batch confirms unstoppable levers match primary proof."
+      },
+      {
+        "method": "owner-control-tertiary",
+        "score": 1,
+        "explanation": "Interface-level replay validates pause/resume embeds with zero decode failures."
       }
     ]
   },
@@ -91,6 +96,14 @@
       "status": true,
       "weight": 0.7,
       "evidence": "secondary 100.0% vs primary 100.0%"
+    },
+    {
+      "id": "owner-control-tertiary",
+      "title": "Owner override decode consensus",
+      "severity": "medium",
+      "status": true,
+      "weight": 0.65,
+      "evidence": "tertiary 100.0% · decode failures 0"
     },
     {
       "id": "guardian-coverage",
@@ -377,6 +390,156 @@
       "resumeDecoded": true,
       "unstoppableScore": 1,
       "matchesPrimaryScore": true
+    },
+    "tertiary": {
+      "selectorsMatch": true,
+      "pauseDecoded": true,
+      "resumeDecoded": true,
+      "singleOwnerTargets": true,
+      "unstoppableScore": 1,
+      "matchesPrimaryScore": true,
+      "matchesSecondaryScore": true,
+      "decodeFailures": 0,
+      "decodedCalls": [
+        {
+          "index": 0,
+          "signature": "setGlobalParameters((address,address,address,address,address,address,uint64,uint64,uint256,string,bytes32))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 1,
+          "signature": "setGuardianCouncil(address)",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 2,
+          "signature": "setSystemPause(address)",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 3,
+          "signature": "setSelfImprovementPlan((string,bytes32,uint64,uint64,string))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 4,
+          "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 5,
+          "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 6,
+          "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 7,
+          "signature": "setSentinelDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 8,
+          "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 9,
+          "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 10,
+          "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 11,
+          "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 12,
+          "signature": "setSentinelDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 13,
+          "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 14,
+          "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 15,
+          "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 16,
+          "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 17,
+          "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 18,
+          "signature": "setSentinelDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 19,
+          "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 20,
+          "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 21,
+          "signature": "forwardPauseCall(bytes)",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 22,
+          "signature": "forwardPauseCall(bytes)",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        }
+      ]
     }
   },
   "safety": {

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
@@ -29,6 +29,156 @@
         "resumeDecoded": true,
         "unstoppableScore": 1,
         "matchesPrimaryScore": true
+      },
+      "tertiary": {
+        "selectorsMatch": true,
+        "pauseDecoded": true,
+        "resumeDecoded": true,
+        "singleOwnerTargets": true,
+        "unstoppableScore": 1,
+        "matchesPrimaryScore": true,
+        "matchesSecondaryScore": true,
+        "decodeFailures": 0,
+        "decodedCalls": [
+          {
+            "index": 0,
+            "signature": "setGlobalParameters((address,address,address,address,address,address,uint64,uint64,uint256,string,bytes32))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 1,
+            "signature": "setGuardianCouncil(address)",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 2,
+            "signature": "setSystemPause(address)",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 3,
+            "signature": "setSelfImprovementPlan((string,bytes32,uint64,uint64,string))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 4,
+            "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 5,
+            "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 6,
+            "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 7,
+            "signature": "setSentinelDomains(bytes32,bytes32[])",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 8,
+            "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 9,
+            "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 10,
+            "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 11,
+            "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 12,
+            "signature": "setSentinelDomains(bytes32,bytes32[])",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 13,
+            "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 14,
+            "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 15,
+            "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 16,
+            "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 17,
+            "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 18,
+            "signature": "setSentinelDomains(bytes32,bytes32[])",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 19,
+            "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 20,
+            "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 21,
+            "signature": "forwardPauseCall(bytes)",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          },
+          {
+            "index": 22,
+            "signature": "forwardPauseCall(bytes)",
+            "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+            "matched": true
+          }
+        ]
       }
     }
   },
@@ -1104,6 +1254,156 @@
       "resumeDecoded": true,
       "unstoppableScore": 1,
       "matchesPrimaryScore": true
+    },
+    "tertiary": {
+      "selectorsMatch": true,
+      "pauseDecoded": true,
+      "resumeDecoded": true,
+      "singleOwnerTargets": true,
+      "unstoppableScore": 1,
+      "matchesPrimaryScore": true,
+      "matchesSecondaryScore": true,
+      "decodeFailures": 0,
+      "decodedCalls": [
+        {
+          "index": 0,
+          "signature": "setGlobalParameters((address,address,address,address,address,address,uint64,uint64,uint256,string,bytes32))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 1,
+          "signature": "setGuardianCouncil(address)",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 2,
+          "signature": "setSystemPause(address)",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 3,
+          "signature": "setSelfImprovementPlan((string,bytes32,uint64,uint64,string))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 4,
+          "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 5,
+          "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 6,
+          "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 7,
+          "signature": "setSentinelDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 8,
+          "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 9,
+          "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 10,
+          "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 11,
+          "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 12,
+          "signature": "setSentinelDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 13,
+          "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 14,
+          "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 15,
+          "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 16,
+          "signature": "registerDomain((string,string,string,address,address,address,address,uint64,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 17,
+          "signature": "registerSentinel((string,string,string,address,uint64,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 18,
+          "signature": "setSentinelDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 19,
+          "signature": "registerCapitalStream((string,string,string,address,uint256,uint256,bool))",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 20,
+          "signature": "setCapitalStreamDomains(bytes32,bytes32[])",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 21,
+          "signature": "forwardPauseCall(bytes)",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        },
+        {
+          "index": 22,
+          "signature": "forwardPauseCall(bytes)",
+          "to": "0x8f9c10b7d9a1ed2f2fa9c42c0f2d4a5e3b7c2a10",
+          "matched": true
+        }
+      ]
     }
   },
   "missionDirectives": {


### PR DESCRIPTION
## Summary
- extend the Kardashev II command deck to compute a tertiary, interface-level owner override proof with decoded call traces and zero-decode monitoring
- surface the tertiary consensus in telemetry, the stability ledger, runbook, and operator briefing so non-technical owners see triple unstoppable verification
- document the new triple-check workflow and ensure generated artefacts capture the additional governance evidence

## Testing
- npm run demo:kardashev-ii:orchestrate
- npm run demo:kardashev-ii:ci

------
https://chatgpt.com/codex/tasks/task_e_68fe1ee87f708333bfc8273a0f464988