### PR TITLE
Add audit trail controls to Kardashev-II Omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/README.md
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/README.md
@@ -8,6 +8,7 @@
 - **Recursive job graph** – agents continuously decompose work into sub-jobs with full validator oversight.
 - **Tokenised resource economy** – energy & compute scarcity dynamically reprice AGIALPHA rewards and stakes.
 - **A2A mesh & governance** – asynchronous pub/sub messaging, commit–reveal validation, pausing & live parameter control.
+- **Tamper-evident audit** – optional BLAKE3 (or BLAKE2b fallback) message hashing to JSONL for compliance-grade traceability.
 - **Planetary simulations** – plug-in hooks for economic/energy simulators powering adaptive strategies.
 
 ```mermaid
@@ -41,7 +42,7 @@ flowchart LR
 
    ```bash
    cd AGIJobsv0
-   demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/bin/run.sh --cycles 200 --config demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/config/default.json
+   demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/bin/run.sh --cycles 200 --audit-log logs/omega-audit.jsonl --config demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/config/default.json
    ```
 
    - `--cycles 0` keeps the orchestrator running indefinitely (perfect for multi-day missions).
@@ -75,6 +76,12 @@ flowchart LR
 - `set_account` hot-patches individual agent treasuries or quotas (tokens, locked stakes, energy/compute allowances).
 - `cancel_job` immediately halts any job (even mid-validation), returning rewards to the employer and releasing all stakes.
 - Every adjustment is logged as structured JSON (`governance_parameters_updated`, `resource_parameters_updated`, `job_cancelled`) for compliance auditing.
+
+## 📜 Audit Ledger
+
+- Supply `--audit-log audit.jsonl` (or set `"audit_log_path"` in JSON config) to activate the append-only ledger.
+- Each message bus publication is canonicalised, hashed (BLAKE3 if available, BLAKE2b-256 otherwise), and written as JSONL with timestamp, topic, publisher, and digest.
+- The ledger is safe for hot-rotation; records are flushed immediately for non-technical operators tailing the file.
 
 ## 🧪 CI & Validation
 

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/config/default.json
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/config/default.json
@@ -1,5 +1,5 @@
 {
-  "mission_name": "Kardashev-II Omega-Grade α-AGI Business 3",
+  "mission_name": "Kardashev-II Omega-Grade \u03b1-AGI Business 3",
   "checkpoint_path": "checkpoint.json",
   "enable_simulation": true,
   "resume_from_checkpoint": true,
@@ -9,8 +9,14 @@
     "supply-chain": 1.2,
     "validator-ops": 1.0
   },
-  "validator_names": ["validator-1", "validator-2", "validator-3"],
-  "strategist_names": ["macro-strategist"],
+  "validator_names": [
+    "validator-1",
+    "validator-2",
+    "validator-3"
+  ],
+  "strategist_names": [
+    "macro-strategist"
+  ],
   "governance": {
     "worker_stake_ratio": 0.2,
     "validator_stake": 100,
@@ -19,5 +25,23 @@
     "approvals_required": 2,
     "pause_enabled": true,
     "slash_ratio": 0.5
-  }
+  },
+  "audit_log_path": "logs/omega-audit.jsonl",
+  "initial_jobs": [
+    {
+      "title": "Planetary Dyson Swarm Expansion",
+      "description": "Coordinate planetary-scale infrastructure deployment leveraging recursive AGI labour markets.",
+      "required_skills": [
+        "energy-architect"
+      ],
+      "reward_tokens": 5000.0,
+      "deadline_hours": 12,
+      "validation_window_hours": 1,
+      "energy_budget": 50000.0,
+      "compute_budget": 100000.0,
+      "metadata": {
+        "employer": "operator"
+      }
+    }
+  ]
 }

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/audit.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/audit.py
@@ -1,0 +1,82 @@
+"""Audit trail utilities for the Kardashev-II Omega-Grade demo."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import weakref
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+try:  # pragma: no cover - optional dependency
+    from blake3 import blake3 as _blake3_hash  # type: ignore
+except Exception:  # pragma: no cover - fallback when BLAKE3 wheel unavailable
+    _blake3_hash = None
+
+from hashlib import blake2b
+
+
+def _encode_payload(payload: Dict[str, Any]) -> bytes:
+    """Serialise a payload to canonical UTF-8 JSON bytes."""
+
+    return json.dumps(payload, sort_keys=True, default=str, ensure_ascii=False).encode("utf-8")
+
+
+def _compute_digest(payload: Dict[str, Any]) -> Tuple[str, str]:
+    """Return a (digest_hex, algorithm) tuple for the payload."""
+
+    data = _encode_payload(payload)
+    if _blake3_hash is not None:
+        return _blake3_hash(data).hexdigest(), "BLAKE3"
+    # Deterministic fallback when the optional dependency is not installed.
+    return blake2b(data, digest_size=32).hexdigest(), "BLAKE2b-256"
+
+
+@dataclass(slots=True, weakref_slot=True)
+class AuditTrail:
+    """Append-only JSONL audit log capturing every bus message."""
+
+    path: Path
+    ensure_parent: bool = True
+    flush: bool = True
+    _handle: Any = field(init=False, repr=False)
+    _lock: asyncio.Lock = field(init=False, repr=False)
+    _closed: bool = field(init=False, repr=False, default=False)
+    _finalizer: weakref.finalize = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.ensure_parent:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self.path.open("a", encoding="utf-8")
+        self._lock = asyncio.Lock()
+        self._closed = False
+        self._finalizer = weakref.finalize(self, self._handle.close)
+
+    async def record_message(self, topic: str, payload: Dict[str, Any], publisher: str) -> None:
+        """Persist a digest of the message for tamper-evident auditing."""
+
+        digest, algorithm = _compute_digest(payload)
+        record = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "topic": topic,
+            "publisher": publisher,
+            "digest": digest,
+            "algorithm": algorithm,
+            "payload_preview": json.dumps(payload, ensure_ascii=False, default=str)[:512],
+        }
+        async with self._lock:
+            if self._closed:
+                return
+            self._handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+            if self.flush:
+                self._handle.flush()
+
+    async def close(self) -> None:
+        async with self._lock:
+            if self._closed:
+                return
+            self._handle.close()
+            self._finalizer.detach()
+            self._closed = True

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
@@ -21,6 +21,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-sim", action="store_true", help="Disable the synthetic planetary simulation")
     parser.add_argument("--control", type=Path, default=Path("control-channel.jsonl"), help="Control channel file path")
     parser.add_argument("--insight-interval", type=int, default=30, help="Seconds between strategic insight broadcasts")
+    parser.add_argument("--audit-log", type=Path, help="JSONL audit log output path")
     parser.add_argument("--config", type=Path, help="Optional JSON file overriding orchestrator configuration")
     return parser
 
@@ -35,8 +36,8 @@ async def _run_async(args: argparse.Namespace) -> None:
         if not args.config.exists():
             raise FileNotFoundError(f"Config file not found: {args.config}")
         data = json.loads(args.config.read_text(encoding="utf-8"))
-        for path_field in ("checkpoint_path", "control_channel_file"):
-            if path_field in data:
+        for path_field in ("checkpoint_path", "control_channel_file", "audit_log_path"):
+            if path_field in data and data[path_field] is not None:
                 data[path_field] = Path(data[path_field])
         if "governance" in data:
             gov_data = dict(data["governance"])
@@ -54,6 +55,7 @@ async def _run_async(args: argparse.Namespace) -> None:
         "enable_simulation": not args.no_sim,
         "control_channel_file": args.control,
         "insight_interval_seconds": args.insight_interval,
+        "audit_log_path": args.audit_log,
     }
     params.update(overrides)
 

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/ui/dashboard.html
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/ui/dashboard.html
@@ -104,5 +104,18 @@ Validator Stakes: automatically rehydrated on restart
 { "action": "cancel_job", "job_id": "deadbeefcafebabe" }
       </pre>
     </section>
+
+    <section class="card">
+      <h2>Immutable Audit Trail</h2>
+      <p>Every message on the A2A mesh is hashed (BLAKE3 when the optional module is installed, BLAKE2b-256 otherwise) and appended to a JSONL ledger for provable governance.</p>
+      <pre>
+$ tail -f logs/omega-audit.jsonl
+{"timestamp": "2025-01-01T12:00:00+00:00",
+ "topic": "jobs:energy-architect",
+ "publisher": "orchestrator",
+ "digest": "54c0...",
+ "algorithm": "BLAKE3"}
+      </pre>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add an audit trail module and wire it into the message bus so every publication is hashed and persisted
- extend the orchestrator configuration, CLI, and defaults to support initial job seeding and operator-provided audit logs
- update UI, README, and test coverage to document and validate the new audit and listener capabilities

## Testing
- npm run demo:kardashev-omega-iii:ci

------
https://chatgpt.com/codex/tasks/task_e_68fe56cb19908333b04dc410611eefde