### PR TITLE
Enhance Phase 8 bootstrap automation

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/README.md
+++ b/demo/Phase-8-Universal-Value-Dominance/README.md
@@ -20,7 +20,7 @@ Phase-8-Universal-Value-Dominance/
 │   ├── governance-policies.json  # Governance toggles & emergency levers
 │   └── model-adapters.json       # Registry of pluggable model adapters with health scores
 ├── scripts/
-│   ├── bootstrap-demo.ts         # End-to-end setup script (node + tsx)
+│   ├── bootstrap-demo.ts         # Governance bootstrap planner (dry-run + optional on-chain execution)
 │   ├── monitors.ts               # Safety tripwires, logging fan-out, budget watchdogs
 │   └── evaluation-pipeline.ts    # Continuous evaluation harness for new models
 ├── ui/
@@ -84,8 +84,9 @@ This graph is mirrored in the UI dashboard, giving non-technical operators a tac
 ## Quickstart (10 Minutes, Zero Solidity)
 
 1. **Install deps:** `npm install`
-2. **Copy environment template:** `cp .env.example .env` and fill RPC URLs + private keys.
+2. **Copy environment template:** `cp .env.example .env` and fill RPC URLs + private keys (set `PHASE8_MANAGER_ADDRESS` if the manifest should be overridden).
 3. **Run bootstrapper:** `npx tsx demo/Phase-8-Universal-Value-Dominance/scripts/bootstrap-demo.ts`
+   - The command performs a dry run, regenerates governance artifacts, and prints call groups. Add `--execute` (optionally `-y`) once you are ready to broadcast transactions with the owner key.
 4. **Open dashboard:** `npx serve demo/Phase-8-Universal-Value-Dominance/ui` and navigate to `http://localhost:3000`
 5. **Activate mission:** Load `configs/job.multi-agent.json` in the dashboard, toggle governance presets, and press **Launch Mission**.
 6. **Observe autonomy:** Watch live checkpoints, validator interventions, budget tripwires, and milestone payouts in the dashboard timeline.

--- a/demo/Phase-8-Universal-Value-Dominance/configs/governance-policies.json
+++ b/demo/Phase-8-Universal-Value-Dominance/configs/governance-policies.json
@@ -1,14 +1,14 @@
 {
-  "owner": "0xOwnerProxy",
+  "owner": "0x1111111111111111111111111111111111111111",
   "governanceCouncil": [
-    "0xCouncilMember1",
-    "0xCouncilMember2",
-    "0xCouncilMember3"
+    "0x4444444444444444444444444444444444444444",
+    "0x5555555555555555555555555555555555555555",
+    "0x6666666666666666666666666666666666666666"
   ],
   "globalPause": false,
-  "pauseGuardian": "0xPauseGuardian",
+  "pauseGuardian": "0x2222222222222222222222222222222222222222",
   "tripwireSensitivity": "HIGH",
-  "validatorGuild": "0xValidatorGuildMultisig",
+  "validatorGuild": "0x3333333333333333333333333333333333333333",
   "humanCoPilotRequired": true,
   "budgetCapUSD": 7500,
   "stakeTiers": {

--- a/demo/Phase-8-Universal-Value-Dominance/playbook.md
+++ b/demo/Phase-8-Universal-Value-Dominance/playbook.md
@@ -7,7 +7,7 @@ This playbook lets a non-technical operator spin up a **Universal Value Dominanc
 
 1. **Wallet & Funding**
    - Top up the operator wallet with ETH for gas + $AGIα for staking rewards.
-   - Assign the wallet as `OWNER_ADDRESS` in `.env` (used by the bootstrap script to exercise governance calls).
+   - Assign the wallet as `OWNER_ADDRESS` in `.env` (used by the bootstrap script to exercise governance calls) and set `PHASE8_MANAGER_ADDRESS` if the manifest does not already contain the active manager contract.
 2. **Environment**
    - `npm install`
    - `npx hardhat compile`
@@ -20,11 +20,15 @@ This playbook lets a non-technical operator spin up a **Universal Value Dominanc
 
 1. **Bootstrap Contracts & Services**
    ```bash
-   npx tsx demo/Phase-8-Universal-Value-Dominance/scripts/bootstrap-demo.ts --network mainnet
+   # Dry run: regenerate artifacts + inspect governance call plan
+   npx tsx demo/Phase-8-Universal-Value-Dominance/scripts/bootstrap-demo.ts
+
+   # After review: broadcast the encoded calls with the owner key
+   npx tsx demo/Phase-8-Universal-Value-Dominance/scripts/bootstrap-demo.ts --execute -y
    ```
-   - Deploys/updates governance extensions (pause controller, stake scaler, milestone escrow).
-   - Registers latest model adapters defined in `configs/model-adapters.json`.
-   - Seeds validator guild registry with multisig addresses from `configs/governance-policies.json`.
+   - Generates fresh governance artifacts (Safe batch, emergency overrides, runbooks) and prints the encoded call groups.
+   - Registers the latest model adapters defined in `configs/model-adapters.json` and validates governance control surface.
+   - Seeds validator guild registry with multisig addresses from `configs/governance-policies.json`, logging receipts to `output/phase8-bootstrap-history.jsonl` when executed.
 
 2. **Activate Monitoring Suite**
    ```bash

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/bootstrap-demo.test.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/bootstrap-demo.test.ts
@@ -1,0 +1,37 @@
+require("ts-node/register/transpile-only");
+
+const { describe, beforeAll, afterAll, it, expect } = require("@jest/globals");
+const { mkdtempSync, rmSync, existsSync } = require("node:fs");
+const { join } = require("node:path");
+const { tmpdir } = require("node:os");
+
+const { buildBootstrapPlan } = require("../bootstrap-demo");
+
+describe("Phase 8 bootstrap planner", () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "phase8-bootstrap-"));
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("generates governance artifacts and call groups", async () => {
+    const plan = await buildBootstrapPlan({ outputDir: tempDir });
+    expect(plan.entries.length).toBeGreaterThan(0);
+    expect(plan.callGroups.length).toBeGreaterThan(0);
+    expect(plan.managerAddress).toMatch(/^0x[0-9a-f]{40}$/);
+    expect(plan.metrics.dominanceScore).toBeGreaterThan(0);
+    for (const file of Object.values(plan.exports)) {
+      expect(existsSync(file)).toBe(true);
+    }
+  });
+
+  it("can skip artifact generation for dry runs", async () => {
+    const plan = await buildBootstrapPlan({ skipArtifacts: true, outputDir: tempDir });
+    expect(Object.keys(plan.exports)).toHaveLength(0);
+    expect(plan.entries.length).toBeGreaterThan(0);
+  });
+});

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/bootstrap-demo.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/bootstrap-demo.ts
@@ -1,9 +1,23 @@
 #!/usr/bin/env ts-node
 import { promises as fs } from "fs";
 import path from "path";
-import { fileURLToPath } from "url";
 import { ethers } from "ethers";
 import prompts from "prompts";
+
+import {
+  calldata,
+  crossVerifyMetrics,
+  flattenCalldataEntries,
+  loadConfig,
+  resolveEnvironment,
+  writeArtifacts,
+  type CalldataEntry,
+  type Phase8Config,
+} from "./run-phase8-demo";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const CONFIG_DIR = path.resolve(__dirname, "../configs");
+const OUTPUT_DIR = path.resolve(__dirname, "../output");
 
 interface GovernancePolicies {
   owner: string;
@@ -12,10 +26,7 @@ interface GovernancePolicies {
   validatorGuild: string;
   globalPause: boolean;
   budgetCapUSD: number;
-  ci: {
-    workflow: string;
-    requireStatusChecks: string[];
-  };
+  ci: { workflow: string; requireStatusChecks: string[] };
   upgradeHooks: Record<string, string>;
 }
 
@@ -29,102 +40,314 @@ interface ModelAdapterConfig {
   lastValidated: string;
 }
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+interface CallGroupSummary {
+  label: string;
+  count: number;
+  targets: string[];
+}
 
-const CONFIG_DIR = path.resolve(__dirname, "../configs");
+interface BootstrapPlan {
+  config: Phase8Config;
+  metrics: ReturnType<typeof crossVerifyMetrics>["metrics"];
+  environment: ReturnType<typeof resolveEnvironment>;
+  entries: CalldataEntry[];
+  callGroups: CallGroupSummary[];
+  managerAddress: string;
+  exports: Record<string, string>;
+  governance: GovernancePolicies;
+  adapters: ModelAdapterConfig[];
+  outputDir: string;
+}
+
+interface BuildPlanOptions {
+  outputDir?: string;
+  environment?: NodeJS.ProcessEnv;
+  skipArtifacts?: boolean;
+}
+
+interface CliOptions {
+  execute: boolean;
+  yes: boolean;
+  outputDir?: string;
+  skipArtifacts: boolean;
+}
+
+function normalizeAddress(value: unknown): string {
+  if (typeof value !== "string") return ZERO_ADDRESS;
+  const trimmed = value.trim();
+  if (!/^0x[a-fA-F0-9]{40}$/.test(trimmed)) return ZERO_ADDRESS;
+  return trimmed.toLowerCase();
+}
 
 async function readJSON<T>(file: string): Promise<T> {
   const buffer = await fs.readFile(path.join(CONFIG_DIR, file), "utf8");
   return JSON.parse(buffer) as T;
 }
 
-async function ensureEnv(key: string): Promise<string> {
-  const value = process.env[key];
-  if (!value) {
-    throw new Error(`Missing required environment variable ${key}`);
+function groupEntries(entries: CalldataEntry[]): CallGroupSummary[] {
+  const groups = new Map<string, { count: number; targets: Set<string> }>();
+  for (const entry of entries) {
+    const key = entry.label;
+    const current = groups.get(key) ?? { count: 0, targets: new Set<string>() };
+    current.count += 1;
+    if (entry.slug) {
+      current.targets.add(String(entry.slug).toLowerCase());
+    }
+    groups.set(key, current);
   }
-  return value;
+  return Array.from(groups.entries())
+    .map(([label, value]) => ({
+      label,
+      count: value.count,
+      targets: Array.from(value.targets.values()).sort(),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function resolveManagerAddress(config: Phase8Config, environmentManager?: string): string {
+  const envAddress = normalizeAddress(environmentManager ?? "");
+  if (envAddress !== ZERO_ADDRESS) {
+    return envAddress;
+  }
+  const manifestAddress = normalizeAddress(config.global?.phase8Manager ?? "");
+  if (manifestAddress !== ZERO_ADDRESS) {
+    return manifestAddress;
+  }
+  throw new Error(
+    "Phase 8 manager address is not configured. Set PHASE8_MANAGER_ADDRESS or provide global.phase8Manager in the manifest.",
+  );
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { execute: false, yes: false, outputDir: undefined, skipArtifacts: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--execute":
+        options.execute = true;
+        break;
+      case "--dry-run":
+        options.execute = false;
+        break;
+      case "--yes":
+      case "-y":
+        options.yes = true;
+        break;
+      case "--output":
+      case "-o":
+        options.outputDir = path.resolve(argv[i + 1] ?? "");
+        i += 1;
+        break;
+      case "--skip-artifacts":
+        options.skipArtifacts = true;
+        break;
+      default:
+        if (arg.startsWith("-")) {
+          console.warn(`Unknown option ${arg} — ignoring.`);
+        }
+        break;
+    }
+  }
+  return options;
+}
+
+function mapExports(entries: { label: string; path: string }[]): Record<string, string> {
+  return entries.reduce<Record<string, string>>((acc, entry) => {
+    acc[entry.label] = entry.path;
+    return acc;
+  }, {});
+}
+
+export async function buildBootstrapPlan(options: BuildPlanOptions = {}): Promise<BootstrapPlan> {
+  const config = loadConfig();
+  const environment = resolveEnvironment(options.environment ?? process.env);
+  const { metrics } = crossVerifyMetrics(config);
+  const data = calldata(config);
+  const entries = flattenCalldataEntries(data);
+  if (entries.length === 0) {
+    throw new Error("Manifest did not produce any governance calldata entries.");
+  }
+
+  const exports = options.skipArtifacts
+    ? []
+    : writeArtifacts(config, metrics, data, environment, {
+        outputDir: options.outputDir,
+        managerAddress: environment.managerAddress,
+        chainId: environment.chainId,
+      });
+
+  const managerAddress = resolveManagerAddress(config, environment.managerAddress);
+  const governance = await readJSON<GovernancePolicies>("governance-policies.json");
+  const adapters = (await readJSON<ModelAdapterConfig[]>("model-adapters.json")).sort(
+    (a, b) => b.safetyScore - a.safetyScore,
+  );
+  const callGroups = groupEntries(entries);
+  return {
+    config,
+    metrics,
+    environment,
+    entries,
+    callGroups,
+    managerAddress,
+    exports: mapExports(exports),
+    governance,
+    adapters,
+    outputDir: options.outputDir ? path.resolve(options.outputDir) : OUTPUT_DIR,
+  };
 }
 
 async function connectProvider() {
-  const rpcUrl = await ensureEnv("RPC_URL");
-  const privateKey = await ensureEnv("OWNER_PRIVATE_KEY");
+  const rpcUrl = process.env.RPC_URL;
+  const privateKey = process.env.OWNER_PRIVATE_KEY;
+  if (!rpcUrl) {
+    throw new Error("RPC_URL is required to execute governance transactions.");
+  }
+  if (!privateKey) {
+    throw new Error("OWNER_PRIVATE_KEY is required to sign governance transactions.");
+  }
   const provider = new ethers.JsonRpcProvider(rpcUrl);
   const wallet = new ethers.Wallet(privateKey, provider);
   return { provider, wallet };
 }
 
-async function confirmIntent(policies: GovernancePolicies) {
-  console.log("\n=== Phase 8 Bootstrap ===\n");
+function formatUSD(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  if (value >= 1e12) return `$${(value / 1e12).toFixed(2)}T`;
+  if (value >= 1e9) return `$${(value / 1e9).toFixed(2)}B`;
+  if (value >= 1e6) return `$${(value / 1e6).toFixed(2)}M`;
+  return `$${value.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
+}
+
+function logPlanSummary(plan: BootstrapPlan) {
+  console.log("\n=== Phase 8 Bootstrap Planner ===\n");
+
+  console.table([
+    { Metric: "Dominance score", Value: `${plan.metrics.dominanceScore.toFixed(1)} / 100` },
+    { Metric: "Monthly value flow", Value: formatUSD(plan.metrics.totalMonthlyUSD) },
+    { Metric: "Annual treasury", Value: formatUSD(plan.metrics.annualBudget) },
+    { Metric: "Guardian coverage", Value: `${plan.metrics.guardianCoverageMinutes.toFixed(1)} min` },
+    { Metric: "Minimum coverage adequacy", Value: `${(plan.metrics.minimumCoverageAdequacy * 100).toFixed(1)}%` },
+    { Metric: "Max autonomy", Value: `${(plan.metrics.maxAutonomy / 100).toFixed(2)}%` },
+    { Metric: "AI teams", Value: `${plan.config.aiTeams?.length ?? 0}` },
+    { Metric: "Safety tripwires", Value: `${plan.metrics.safetyTripwireCount}` },
+  ]);
+
+  console.log("\nGovernance control surface:");
   console.table({
-    Owner: policies.owner,
-    PauseGuardian: policies.pauseGuardian,
-    ValidatorGuild: policies.validatorGuild,
-    BudgetCapUSD: policies.budgetCapUSD
+    Owner: plan.governance.owner,
+    GuardianCouncil: plan.config.global?.guardianCouncil ?? "—",
+    PauseGuardian: plan.governance.pauseGuardian,
+    ValidatorGuild: plan.governance.validatorGuild,
+    Manager: plan.managerAddress,
   });
 
+  console.log("\nCalldata manifest:");
+  console.table(
+    plan.callGroups.map((group) => ({
+      Call: group.label,
+      Count: group.count,
+      Targets: group.targets.length > 0 ? group.targets.join(" · ") : "—",
+    })),
+  );
+
+  console.log("\nModel adapter readiness:");
+  console.table(
+    plan.adapters.map((adapter) => ({
+      Adapter: adapter.id,
+      Provider: adapter.provider,
+      "Ctx tokens": adapter.maxContext,
+      Safety: adapter.safetyScore.toFixed(2),
+      "Cost/1K": `$${adapter.costUSDPer1KTokens.toFixed(3)}`,
+      "Last validated": adapter.lastValidated,
+    })),
+  );
+
+  if (Object.keys(plan.exports).length > 0) {
+    console.log("\nArtifacts refreshed:");
+    Object.entries(plan.exports).forEach(([label, file]) => {
+      console.log(` - ${label}: ${file}`);
+    });
+  } else {
+    console.log("\nArtifacts skipped (use without --skip-artifacts to regenerate outputs).");
+  }
+
+  console.log(`\nTotal encoded calls: ${plan.entries.length}`);
+}
+
+async function confirmExecution(plan: BootstrapPlan, autoApprove: boolean): Promise<boolean> {
+  if (autoApprove) return true;
   const response = await prompts({
     type: "confirm",
     name: "ready",
-    message: "Proceed with governance + infrastructure bootstrap?",
-    initial: true
+    message: `Broadcast ${plan.entries.length} governance call(s) to ${plan.managerAddress}?`,
+    initial: false,
   });
-
-  if (!response.ready) {
-    console.log("Aborted by operator.");
-    process.exit(0);
-  }
+  return Boolean(response.ready);
 }
 
-async function pushGovernanceUpdates(wallet: ethers.Wallet, policies: GovernancePolicies) {
-  console.log("\n[1/3] Updating governance policies...");
-  // Placeholder for actual contract interactions.
-  // In production this would use typed contract factories generated by TypeChain.
-  console.log(` - Setting pause guardian (${policies.pauseGuardian}) via owner proxy ${policies.owner}`);
-  console.log(` - Syncing validator guild multisig ${policies.validatorGuild}`);
-  console.log(` - Enforcing CI workflow ${policies.ci.workflow}`);
-  console.log(` - Registering upgrade hooks: ${Object.values(policies.upgradeHooks).join(", ")}`);
-  await wallet.getNonce(); // Dummy chain interaction to ensure connection works.
+async function recordExecution(outputDir: string, record: any) {
+  const historyFile = path.join(outputDir, "phase8-bootstrap-history.jsonl");
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.appendFile(historyFile, `${JSON.stringify(record)}\n`, "utf8");
 }
 
-async function registerModelAdapters(wallet: ethers.Wallet, adapters: ModelAdapterConfig[]) {
-  console.log("\n[2/3] Registering model adapters...");
-  adapters
-    .sort((a, b) => b.safetyScore - a.safetyScore)
-    .forEach((adapter, index) => {
-      console.log(
-        ` ${index + 1}. ${adapter.id} (provider=${adapter.provider}, context=${adapter.maxContext}, safety=${adapter.safetyScore})`
-      );
+async function executePlan(plan: BootstrapPlan, wallet: ethers.Wallet) {
+  console.log("\nExecuting governance transactions...");
+  for (const entry of plan.entries) {
+    const label = `${entry.label}${entry.slug ? ` (${entry.slug})` : ""}`;
+    const tx = await wallet.sendTransaction({ to: plan.managerAddress, data: entry.data });
+    console.log(` - ${label}: ${tx.hash}`);
+    const receipt = await tx.wait();
+    await recordExecution(plan.outputDir, {
+      label: entry.label,
+      slug: entry.slug ?? null,
+      hash: tx.hash,
+      blockNumber: receipt?.blockNumber ?? null,
+      timestamp: new Date().toISOString(),
     });
-  console.log(" - Pushing adapters to ModelRegistry...");
-  await wallet.getBalance(); // Connection health check.
-}
-
-async function seedValidatorGuild(wallet: ethers.Wallet, policies: GovernancePolicies) {
-  console.log("\n[3/3] Seeding validator guild registry...");
-  policies.governanceCouncil.forEach((member) => {
-    console.log(` - Adding council member ${member}`);
-  });
-  console.log(` - Linking guild ${policies.validatorGuild} with attestation service.`);
-  await wallet.getAddress();
+  }
+  console.log("\nBroadcast complete. Execution receipts stored in phase8-bootstrap-history.jsonl.");
 }
 
 async function main() {
-  const policies = await readJSON<GovernancePolicies>("governance-policies.json");
-  const adapters = await readJSON<ModelAdapterConfig[]>("model-adapters.json");
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const plan = await buildBootstrapPlan({
+      outputDir: options.outputDir,
+      skipArtifacts: options.skipArtifacts,
+    });
 
-  await confirmIntent(policies);
-  const { wallet } = await connectProvider();
+    logPlanSummary(plan);
 
-  await pushGovernanceUpdates(wallet, policies);
-  await registerModelAdapters(wallet, adapters);
-  await seedValidatorGuild(wallet, policies);
+    if (!options.execute) {
+      console.log("\nDry run mode: no transactions broadcast. Use --execute to push calls on-chain.");
+      return;
+    }
 
-  console.log("\nBootstrap complete. Proceed to launch the mission via UI or CLI.");
+    if (!(await confirmExecution(plan, options.yes))) {
+      console.log("Execution aborted by operator.");
+      return;
+    }
+
+    const { wallet } = await connectProvider();
+    if (wallet.address.toLowerCase() !== plan.governance.owner.toLowerCase()) {
+      console.warn(
+        `Warning: signer ${wallet.address} does not match governance owner ${plan.governance.owner}. Ensure permissions are correc` +
+          "t before proceeding.",
+      );
+    }
+    await executePlan(plan, wallet);
+  } catch (error) {
+    console.error("\nPhase 8 bootstrap failed:");
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error(error);
+    }
+    process.exitCode = 1;
+  }
 }
 
-main().catch((error) => {
-  console.error("Bootstrap failed:", error);
-  process.exit(1);
-});
+if (require.main === module) {
+  main();
+}

--- a/package.json
+++ b/package.json
@@ -262,6 +262,7 @@
     "demo:phase6:apply": "npx hardhat run --no-compile scripts/phase6/apply-config.ts",
     "demo:phase6:did": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-6-Scaling-Multi-Domain-Expansion/scripts/phase6-did-audit.ts",
     "demo:phase8:orchestrate": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-8-Universal-Value-Dominance/scripts/run-phase8-demo.ts",
+    "demo:phase8:bootstrap": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-8-Universal-Value-Dominance/scripts/bootstrap-demo.ts",
     "demo:phase8:ci": "ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/Phase-8-Universal-Value-Dominance/scripts/validate-phase8-config.ts",
     "demo:kardashev-ii:orchestrate": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/run-kardashev-demo.ts",
     "demo:kardashev-ii:ci": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/ci-validate.ts",


### PR DESCRIPTION
## Summary
- rebuild the Phase 8 bootstrap CLI around the orchestration manifest so it regenerates governance artifacts, summarizes metrics, and optionally executes transactions with receipt logging
- replace placeholder governance policy addresses with checksum-safe values and document the new bootstrap flow for operators
- add an npm helper script plus Jest coverage for the bootstrap planner to keep the new workflow stable

## Testing
- npx jest --config demo/Phase-8-Universal-Value-Dominance/jest.config.cjs --runTestsByPath demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/bootstrap-demo.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fe557a3438833395c7700daf125900