### PR TITLE
Fix Kardashev-II Omega demo staking accounting

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -265,6 +265,8 @@ class Orchestrator:
                 jobs=len(list(self.job_registry.iter_jobs())),
                 energy_available=snapshot.energy_available,
                 compute_available=snapshot.compute_available,
+                token_supply=snapshot.token_supply,
+                locked_supply=snapshot.locked_supply,
             )
 
     def _rehydrate_jobs(self, serialized: Dict[str, Any]) -> List[JobRecord]:

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/ui/dashboard.html
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/ui/dashboard.html
@@ -77,6 +77,7 @@ AGIALPHA Supply: dynamic
 Energy Availability: simulation-driven scarcity pricing (Dyson swarm growth × scale)
 Compute Availability: prosperity × sustainability weighted scaling
 Validator Stakes: automatically rehydrated on restart
+Locked Stakes: escrow tracked separately from circulating supply for precise slashing economics
       </pre>
     </section>
 


### PR DESCRIPTION
## Summary
- correct staking flows in the Kardashev-II Omega demo so locked stakes no longer deflate token supply and expose locked totals
- surface the locked stake inventory in checkpoint telemetry and the operator dashboard for better mission control visibility
- extend demo unit tests to exercise the revised accounting semantics

## Testing
- npm run demo:kardashev-omega-iii:ci
- python -m unittest test.demo.test_kardashev_ii_omega_grade_alpha_agi_business_3_demo.ResourceManagerTests


------
https://chatgpt.com/codex/tasks/task_e_68fe6f7819b88333a96cb72b51b861b7