### PR TITLE
Ensure omega audit trail closes cleanly

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/audit.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/audit.py
@@ -80,3 +80,9 @@ class AuditTrail:
             self._handle.close()
             self._finalizer.detach()
             self._closed = True
+
+    @property
+    def is_closed(self) -> bool:
+        """Return ``True`` when the audit trail is no longer writable."""
+
+        return self._closed

--- a/test/demo/test_kardashev_ii_omega_grade_alpha_agi_business_3_demo.py
+++ b/test/demo/test_kardashev_ii_omega_grade_alpha_agi_business_3_demo.py
@@ -238,11 +238,15 @@ class OrchestratorTests(unittest.IsolatedAsyncioTestCase):
             )
             orchestrator = Orchestrator(config)
             await orchestrator.start()
+            self.assertIsNotNone(orchestrator.audit)
+            self.assertFalse(orchestrator.audit.is_closed)  # type: ignore[union-attr]
             await asyncio.sleep(0.3)
             await orchestrator.shutdown()
             ledger = [json.loads(line) for line in audit.read_text().strip().splitlines() if line.strip()]
             self.assertTrue(ledger)
             self.assertIn(ledger[0]["algorithm"], {"BLAKE3", "BLAKE2b-256"})
+            assert orchestrator.audit is not None
+            self.assertTrue(orchestrator.audit.is_closed)
 
     async def test_control_updates_parameters(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- expose an `is_closed` property on the Kardashev-II Omega audit trail so operators can confirm ledger shutdown status
- extend the omega demo regression suite to assert the audit trail opens and closes correctly during orchestrator runs

## Testing
- python -m unittest test.demo.test_kardashev_ii_omega_grade_alpha_agi_business_3_demo
- python -m compileall demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo


------
https://chatgpt.com/codex/tasks/task_e_68fe796ef610833382829f76a1cd9f40