### PR TITLE
Add streaming status snapshots for Omega-grade demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/README.md
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/README.md
@@ -49,6 +49,7 @@ flowchart LR
    - `--cycles 0` keeps the orchestrator running indefinitely (perfect for multi-day missions).
    - The config file contains every knob (staking ratios, validator set, worker profiles, simulation scaling) – edit JSON values and rerun to update.
    - Use `--simulation-tick`, `--simulation-hours`, `--simulation-energy-scale`, and `--simulation-compute-scale` for rapid experimentation without editing files.
+   - Append `--status-output logs/omega-status.jsonl` to stream machine-readable mission snapshots for dashboards or external automations.
 
 3. **Live control** – stream JSON commands into `control-channel.jsonl`:
 
@@ -85,6 +86,7 @@ flowchart LR
 - Supply `--audit-log audit.jsonl` (or set `"audit_log_path"` in JSON config) to activate the append-only ledger.
 - Each message bus publication is canonicalised, hashed (BLAKE3 if available, BLAKE2b-256 otherwise), and written as JSONL with timestamp, topic, publisher, and digest.
 - The ledger is safe for hot-rotation; records are flushed immediately for non-technical operators tailing the file.
+- Pair with `--status-output` to obtain high-level mission snapshots (job counts, resource balances, governance settings) that external BI tools can ingest in real time.
 
 ## 🧪 CI & Validation
 

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/config/default.json
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/config/default.json
@@ -31,6 +31,7 @@
     "slash_ratio": 0.5
   },
   "audit_log_path": "logs/omega-audit.jsonl",
+  "status_output_path": "logs/omega-status.jsonl",
   "initial_jobs": [
     {
       "title": "Planetary Dyson Swarm Expansion",

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
@@ -38,6 +38,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Multiplier applied to prosperity/sustainability derived compute capacity",
     )
     parser.add_argument("--audit-log", type=Path, help="JSONL audit log output path")
+    parser.add_argument(
+        "--status-output",
+        type=Path,
+        help="Optional JSONL file receiving continuous status snapshots",
+    )
     parser.add_argument("--config", type=Path, help="Optional JSON file overriding orchestrator configuration")
     return parser
 
@@ -52,7 +57,7 @@ async def _run_async(args: argparse.Namespace) -> None:
         if not args.config.exists():
             raise FileNotFoundError(f"Config file not found: {args.config}")
         data = json.loads(args.config.read_text(encoding="utf-8"))
-        for path_field in ("checkpoint_path", "control_channel_file", "audit_log_path"):
+        for path_field in ("checkpoint_path", "control_channel_file", "audit_log_path", "status_output_path"):
             if path_field in data and data[path_field] is not None:
                 data[path_field] = Path(data[path_field])
         if "governance" in data:
@@ -76,6 +81,7 @@ async def _run_async(args: argparse.Namespace) -> None:
         "simulation_energy_scale": args.simulation_energy_scale,
         "simulation_compute_scale": args.simulation_compute_scale,
         "audit_log_path": args.audit_log,
+        "status_output_path": args.status_output,
     }
     params.update(overrides)
 

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/ui/dashboard.html
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/ui/dashboard.html
@@ -78,6 +78,7 @@ Energy Availability: simulation-driven scarcity pricing (Dyson swarm growth × s
 Compute Availability: prosperity × sustainability weighted scaling
 Validator Stakes: automatically rehydrated on restart
 Locked Stakes: escrow tracked separately from circulating supply for precise slashing economics
+Status Stream: logs/omega-status.jsonl (JSONL snapshots for dashboards & automations)
       </pre>
     </section>
 


### PR DESCRIPTION
## Summary
- add a configurable status snapshot pipeline that records mission state to JSONL for dashboards
- wire the new status output through the CLI, default config, README guidance, and dashboard UI copy
- extend automated coverage with a test that validates the snapshot stream

## Testing
- npm run demo:kardashev-omega-iii:ci

------
https://chatgpt.com/codex/tasks/task_e_68fe878d1ff48333bc0a980e057486b7