### PR TITLE
Enhance omega demo with persistent scheduler

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/README.md
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/README.md
@@ -11,6 +11,7 @@
 - **A2A mesh & governance** – asynchronous pub/sub messaging, commit–reveal validation, pausing & live parameter control.
 - **Tamper-evident audit** – optional BLAKE3 (or BLAKE2b fallback) message hashing to JSONL for compliance-grade traceability.
 - **Planetary simulations** – plug-in hooks for economic/energy simulators powering adaptive strategies.
+- **Resilient mission scheduler** – checkpointed event graph restarts instantly with deadlines, validation windows, and control events intact.
 
 ```mermaid
 flowchart LR
@@ -80,6 +81,7 @@ flowchart LR
 - `cancel_job` immediately halts any job (even mid-validation), returning rewards to the employer and releasing all stakes.
 - Every adjustment is logged as structured JSON (`governance_parameters_updated`, `resource_parameters_updated`, `job_cancelled`) for compliance auditing.
 - `simulation_energy_scale`, `simulation_compute_scale`, and `simulation_tick_seconds` can be adjusted live to model external energy or demand shocks.
+- `scheduler` snapshots (visible via `--status-output`) expose pending deadlines & validation windows, allowing operators to time new sub-jobs or pauses precisely.
 
 ## 📜 Audit Ledger
 
@@ -137,6 +139,11 @@ capacities in real time, which in turn updates scarcity pricing and validator/wo
 - **Stake management** for workers and validators backed by the `ResourceManager` ledger.
 - **Emergency pause / resume / shutdown** via file-based control channel for air-gapped operations.
 - **Checkpointing** ensures instant crash recovery with zero operator intervention.
+
+## ♾️ Persistent Scheduler Telemetry
+
+- `scheduler.json` payloads saved inside checkpoints now persist every in-flight deadline, commit window, and finalisation timer; restarts simply resume the queue.
+- The status stream’s `scheduler` object surfaces pending counts and the next scheduled event with an ETA, enabling dashboards to highlight looming risk.
 
 ## 📈 Extending the Demo
 

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/checkpoint.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/checkpoint.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import json
 from dataclasses import asdict
 from pathlib import Path
-from typing import Dict, Iterable, Mapping
+from typing import TYPE_CHECKING, Dict, Iterable, Mapping, Optional
 
 from .jobs import JobRecord
 from .resources import ResourceManager
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing aid
+    from .scheduler import EventScheduler
 
 
 class CheckpointManager:
@@ -17,12 +21,20 @@ class CheckpointManager:
     def __init__(self, path: Path) -> None:
         self.path = path
 
-    def save(self, jobs: Mapping[str, JobRecord], resources: ResourceManager) -> None:
+    def save(
+        self,
+        jobs: Mapping[str, JobRecord],
+        resources: ResourceManager,
+        *,
+        scheduler: Optional["EventScheduler"] = None,
+    ) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
             "jobs": {job_id: record.to_serializable() for job_id, record in jobs.items()},
             "resources": resources.to_serializable(),
         }
+        if scheduler is not None:
+            payload["scheduler"] = scheduler.to_serializable()
         tmp_path = self.path.with_suffix(".tmp")
         tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
         tmp_path.replace(self.path)

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/jobs.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/jobs.py
@@ -140,6 +140,11 @@ class JobRecord:
     validator_commits: Dict[str, str] = field(default_factory=dict)
     validator_votes: Dict[str, bool] = field(default_factory=dict)
     validators_with_stake: Set[str] = field(default_factory=set)
+    deadline_event_id: Optional[str] = None
+    commit_event_id: Optional[str] = None
+    finalization_event_id: Optional[str] = None
+    commit_deadline: Optional[datetime] = None
+    reveal_deadline: Optional[datetime] = None
 
     def to_serializable(self) -> Dict[str, object]:
         return {
@@ -155,6 +160,11 @@ class JobRecord:
             "validator_commits": dict(self.validator_commits),
             "validator_votes": dict(self.validator_votes),
             "validators_with_stake": list(self.validators_with_stake),
+            "deadline_event_id": self.deadline_event_id,
+            "commit_event_id": self.commit_event_id,
+            "finalization_event_id": self.finalization_event_id,
+            "commit_deadline": self.commit_deadline.isoformat() if self.commit_deadline else None,
+            "reveal_deadline": self.reveal_deadline.isoformat() if self.reveal_deadline else None,
         }
 
 

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/scheduler.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/scheduler.py
@@ -1,0 +1,140 @@
+"""Asynchronous scheduler for long-lived orchestrator events."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, Iterable, Mapping, Optional
+
+
+@dataclass
+class ScheduledEvent:
+    """Container describing a timed orchestrator action."""
+
+    event_id: str
+    event_type: str
+    execute_at: datetime
+    payload: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "event_type": self.event_type,
+            "execute_at": self.execute_at.isoformat(),
+            "payload": dict(self.payload),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, event_id: str, payload: Mapping[str, Any]) -> "ScheduledEvent":
+        execute_at_raw = payload.get("execute_at")
+        if isinstance(execute_at_raw, str):
+            execute_at = datetime.fromisoformat(execute_at_raw)
+        elif isinstance(execute_at_raw, datetime):  # pragma: no cover - defensive branch
+            execute_at = execute_at_raw
+        else:  # pragma: no cover - configuration should guarantee serialised strings
+            raise ValueError("execute_at must be an ISO-8601 string")
+        if execute_at.tzinfo is None:
+            execute_at = execute_at.replace(tzinfo=timezone.utc)
+        return cls(
+            event_id=event_id,
+            event_type=str(payload.get("event_type", "")),
+            execute_at=execute_at,
+            payload=dict(payload.get("payload", {})),
+            metadata=dict(payload.get("metadata", {})),
+        )
+
+
+class EventScheduler:
+    """Minimal persistent scheduler that survives restarts via checkpoints."""
+
+    def __init__(self, dispatcher: Callable[[ScheduledEvent], Awaitable[None]]) -> None:
+        self._dispatcher = dispatcher
+        self._events: Dict[str, ScheduledEvent] = {}
+        self._tasks: Dict[str, asyncio.Task[None]] = {}
+        self._preserve_events = False
+
+    def _create_task(self, event: ScheduledEvent) -> asyncio.Task[None]:
+        return asyncio.create_task(self._run_event(event), name=f"event:{event.event_id}")
+
+    async def _run_event(self, event: ScheduledEvent) -> None:
+        delay = max(0.0, (event.execute_at - datetime.now(timezone.utc)).total_seconds())
+        try:
+            await asyncio.sleep(delay)
+            if event.event_id not in self._events:
+                return
+            await self._dispatcher(event)
+        except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
+            return
+        finally:
+            if not self._preserve_events:
+                self._events.pop(event.event_id, None)
+            self._tasks.pop(event.event_id, None)
+
+    def to_serializable(self) -> Dict[str, Dict[str, Any]]:
+        return {event_id: event.to_dict() for event_id, event in self._events.items()}
+
+    async def schedule(
+        self,
+        event_type: str,
+        execute_at: datetime,
+        payload: Optional[Dict[str, Any]] = None,
+        *,
+        event_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> ScheduledEvent:
+        if execute_at.tzinfo is None:
+            execute_at = execute_at.replace(tzinfo=timezone.utc)
+        event = ScheduledEvent(
+            event_id=event_id or uuid.uuid4().hex,
+            event_type=event_type,
+            execute_at=execute_at,
+            payload=dict(payload or {}),
+            metadata=dict(metadata or {}),
+        )
+        self._events[event.event_id] = event
+        self._tasks[event.event_id] = self._create_task(event)
+        return event
+
+    async def cancel(self, event_id: Optional[str]) -> bool:
+        if not event_id:
+            return False
+        event = self._events.pop(event_id, None)
+        task = self._tasks.pop(event_id, None)
+        if task:
+            task.cancel()
+        return event is not None
+
+    async def rehydrate(self, payload: Mapping[str, Mapping[str, Any]]) -> None:
+        for event_id, data in payload.items():
+            event = ScheduledEvent.from_dict(event_id, data)
+            self._events[event_id] = event
+            self._tasks[event_id] = self._create_task(event)
+
+    async def shutdown(self) -> None:
+        snapshot = list(self._events.values())
+        self._preserve_events = True
+        try:
+            for task in list(self._tasks.values()):
+                task.cancel()
+            if self._tasks:
+                await asyncio.gather(*self._tasks.values(), return_exceptions=True)
+        finally:
+            self._tasks.clear()
+            self._preserve_events = False
+            # restore event objects to ensure references remain intact post-shutdown
+            self._events = {event.event_id: event for event in snapshot}
+
+    def pending_events(self) -> Iterable[ScheduledEvent]:
+        return list(self._events.values())
+
+    def peek_next(self) -> Optional[ScheduledEvent]:
+        if not self._events:
+            return None
+        return min(self._events.values(), key=lambda evt: evt.execute_at)
+
+    def has_event(self, event_id: Optional[str]) -> bool:
+        return bool(event_id and event_id in self._events)
+


### PR DESCRIPTION
## Summary
- add a persistent event scheduler that serialises deadlines, validation timers, and rehydrates them on restart
- integrate the scheduler into the omega orchestrator with job-level event tracking, checkpoint persistence, and richer status telemetry
- document the new scheduler lifecycle and extend the automated tests to cover scheduler behaviour and checkpoint contents

## Testing
- python -m unittest test.demo.test_kardashev_ii_omega_grade_alpha_agi_business_3_demo

------
https://chatgpt.com/codex/tasks/task_e_68fe93e4c4848333b012b8bd41d92e43