### PR TITLE
Add job-level pause controls to trustless core demo

### DIFF
--- a/demo/Trustless-Economic-Core-v0/README.md
+++ b/demo/Trustless-Economic-Core-v0/README.md
@@ -8,7 +8,7 @@
 - **Stake-backed agents** whose collateral is locked, released, or slashed entirely by policy-driven rules.
 - **ENS-gated participation**: agents and validators must prove identity before touching funds.
 - **Validator economies** that stream protocol-grade rewards every time progress is validated.
-- **Governance-grade pause** flow that halts value transfer instantly and resumes on demand.
+- **Dual-layer pause controls** for job-specific halts and system-wide emergency freezes.
 - **Misconduct autopsy**: deliberate slashing showcases how the platform punishes failure while refunding employers and rewarding validators.
 
 Everything is orchestrated through `npm run run:trustless-core`, which drives an end-to-end Hardhat scenario and exports artefacts for reporting.
@@ -123,11 +123,12 @@ All parameters are reconfigurable by the governance owner via simple function ca
 
 ## 🎯 Scenario timeline
 
-1. **Milestone 1** – Validators 1 & 2 approve, agent receives 83 $AGIALPHA, each validator gets 5, treasury 5, burn 2.
-2. **Global Pause** – Governance executes `pauseAll`, blocking any transfer while investigation occurs.
-3. **Milestone 2** – After `unpauseAll`, Validators 2 & 3 approve, duplicating the trustless payout cadence.
-4. **Fraud attempt** – Agent fails Milestone 3. Governance slashes 60 $AGIALPHA of stake, distributing 30 to employer, 12 to validators (4 each), 12 to treasury, and burning 6.
-5. **Employer Exit** – Employer cancels job and receives the remaining 100 $AGIALPHA escrow.
+1. **Targeted job pause** – Governance halts the specific job, proving per-job control before any milestone work.
+2. **Milestone 1** – Validators 1 & 2 approve, agent receives 83 $AGIALPHA, each validator gets 5, treasury 5, burn 2.
+3. **Global Pause** – Governance executes `pauseAll`, blocking any transfer while investigation occurs.
+4. **Milestone 2** – After `unpauseAll`, Validators 2 & 3 approve, duplicating the trustless payout cadence.
+5. **Fraud attempt** – Agent fails Milestone 3. Governance slashes 60 $AGIALPHA of stake, distributing 30 to employer, 12 to validators (4 each), 12 to treasury, and burning 6.
+6. **Employer Exit** – Employer cancels job and receives the remaining 100 $AGIALPHA escrow.
 
 ## 🧾 Artefact index
 

--- a/demo/Trustless-Economic-Core-v0/scripts/runScenario.ts
+++ b/demo/Trustless-Economic-Core-v0/scripts/runScenario.ts
@@ -454,6 +454,32 @@ async function main() {
     createJobReceipt
   );
 
+  const pauseJobTx = await demo.connect(owner).pauseJob(jobId);
+  recordStep(
+    'Governance pauses job-specific flow',
+    labelFor(owner.address),
+    ['Milestone approvals disabled for this job only.'],
+    await pauseJobTx.wait()
+  );
+
+  try {
+    await demo.connect(validator1).approveMilestone(jobId, 0);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    recordStep('Job-level pause rejects approval', labelFor(validator1.address), [
+      'Custom error captured: JobPausedOrCancelled',
+      message.split('\n')[0],
+    ]);
+  }
+
+  const resumeJobTx = await demo.connect(owner).resumeJob(jobId);
+  recordStep(
+    'Governance resumes job-specific flow',
+    labelFor(owner.address),
+    ['Validator approvals re-enabled for the job.'],
+    await resumeJobTx.wait()
+  );
+
   async function approveMilestone(actor: typeof validator1, milestoneId: number) {
     const tx = await demo.connect(actor).approveMilestone(jobId, milestoneId);
     const receipt = await tx.wait();

--- a/test/demo/trustlessEconomicCoreDemo.test.ts
+++ b/test/demo/trustlessEconomicCoreDemo.test.ts
@@ -88,6 +88,14 @@ describe('TrustlessEconomicCoreDemo', function () {
     const agentInitialBalance = await token.balanceOf(agent.address);
     const treasuryInitialBalance = await token.balanceOf(treasury.address);
 
+    // Job-level pause and resume before approvals
+    await expect(demo.connect(owner).pauseJob(jobId)).to.emit(demo, 'JobPaused');
+    await expect(demo.connect(v1).approveMilestone(jobId, 0)).to.be.revertedWithCustomError(
+      demo,
+      'JobPausedOrCancelled'
+    );
+    await expect(demo.connect(owner).resumeJob(jobId)).to.emit(demo, 'JobResumed');
+
     // Milestone 1 approvals and release
     await expect(demo.connect(v1).approveMilestone(jobId, 0)).to.emit(
       demo,


### PR DESCRIPTION
## Summary
- add a dedicated paused flag to job state and gate milestone approvals and cancellation logic
- extend the Hardhat scenario runner and tests to exercise job-specific pause and resume flows
- highlight the dual-layer pause controls in the demo documentation for non-technical operators

## Testing
- npm run test:trustless-core
- npm run run:trustless-core

------
https://chatgpt.com/codex/tasks/task_e_68fedf36dd788333b7d29c329660eafb