### PR TITLE
Add Kardashev-II omega operator demo

### DIFF
--- a/.github/workflows/demo-kardashev-ii-omega-operator.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-operator.yml
@@ -1,0 +1,52 @@
+name: demo-kardashev-ii-omega-operator
+
+on:
+  pull_request:
+    paths:
+      - "demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/**"
+      - "demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/**"
+      - "kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/**"
+      - ".github/workflows/demo-kardashev-ii-omega-operator.yml"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  omega-operator-demo:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Harden runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
+        with:
+          egress-policy: block
+          allowed-endpoints: |
+            api.github.com
+            github.com
+            objects.githubusercontent.com
+            raw.githubusercontent.com
+            registry.npmjs.org
+            nodejs.org
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            **/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline --progress=false
+
+      - name: Omega Operator CI validation
+        run: npm run demo:kardashev-ii-omega-operator:ci

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/README.md
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/README.md
@@ -1,0 +1,84 @@
+# Kardashev-II Omega-Grade Upgrade for α-AGI Business 3 Demo (Operator Edition)
+
+This demo shows how a non-technical operator can use **AGI Jobs v0 (v2)** to command a
+planetary-scale, validator-governed AGI labour market.  The mission ships with a
+curated configuration (`config/omega_mission.json`) that unlocks:
+
+- A **multi-hour/day autonomous orchestrator** with checkpointing, pause/resume, and
+  structured JSON logging ready for audit.
+- Recursive **job graph spawning** so every agent can delegate to specialist crews.
+- A tokenised **energy and compute economy** with adjustable stakes and validator
+  oversight built directly into the control channel.
+- An async **agent-to-agent message bus** with commit–reveal validation and operator
+  override hooks that mirror the production AGI Jobs gateways.
+- Plug-and-play **planetary simulation hooks** that keep energy and prosperity metrics
+  synced with resource tokenomics.
+
+> The goal is to demonstrate that AGI Jobs v0 (v2) empowers operators to run a
+> superintelligent economic machine without touching code.
+
+## Quickstart for Operators
+
+```bash
+# optional: clone the repo and install python dependencies
+python -m kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega init --output-dir my-mission
+cd my-mission
+python -m kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega --config omega_mission.json --duration 120
+```
+
+During the run, the orchestrator writes JSON status snapshots to
+`storage/status.jsonl`.  Edit `storage/control-channel.jsonl` to issue governance
+commands (pause, resume, parameter updates) exactly like the mainnet system.
+
+## Mission Plan at a Glance
+
+```mermaid
+flowchart TD
+    mission_core["Launch Stellar Infrastructure Programme\nReward: 16000 tokens\nEnergy: 280000 | Compute: 450000"]
+    mission_core --> mission_energy
+    mission_energy["Deploy Dyson Foundry Nodes\nReward: 9000 tokens\nEnergy: 180000 | Compute: 240000"]
+    mission_energy --> mission_energy_design
+    mission_energy_design["Design Dyson Swarm Blueprint\nReward: 3500 tokens\nEnergy: 65000 | Compute: 120000"]
+    mission_energy --> mission_energy_fabrication
+    mission_energy_fabrication["Coordinate Fabrication Supply Web\nReward: 3200 tokens\nEnergy: 48000 | Compute: 80000"]
+    mission_core --> mission_governance
+    mission_governance["Institutionalise Validator Syndicate\nReward: 6000 tokens\nEnergy: 80000 | Compute: 120000"]
+    mission_governance --> mission_governance_stake
+    mission_governance_stake["Configure Staking Ledgers\nReward: 2200 tokens\nEnergy: 20000 | Compute: 40000"]
+    mission_governance --> mission_governance_observatory
+    mission_governance_observatory["Activate Validator Observatory\nReward: 2400 tokens\nEnergy: 22000 | Compute: 42000"]
+    mission_core --> mission_supply
+    mission_supply["Orchestrate Interplanetary Supply Corridors\nReward: 7200 tokens\nEnergy: 120000 | Compute: 200000"]
+    mission_supply --> mission_supply_resourcing
+    mission_supply_resourcing["Secure Resource Offtake Contracts\nReward: 2600 tokens\nEnergy: 42000 | Compute: 60000"]
+    mission_supply --> mission_supply_telemetry
+    mission_supply_telemetry["Deploy Telemetry Mesh\nReward: 2800 tokens\nEnergy: 38000 | Compute: 58000"]
+```
+
+The CLI automatically refreshes the Mermaid plan in `ui/mission-plan.mmd` every
+launch, so operators always have an up-to-date visual of the delegated job graph.
+
+## Control Surface
+
+- **Config** – Tune rewards, stakes, validator requirements, energy/compute caps, and
+  simulation behaviour by editing `config/omega_mission.json`.
+- **Checkpointing** – Snapshots persist in `storage/checkpoint.json`; the orchestrator
+  resumes automatically after restarts.
+- **Governance channel** – Append JSON commands to `storage/control-channel.jsonl`
+  (pause/resume, stake adjustments, or parameter updates).  Validators enforce
+  commit–reveal finalisation just like the deployed protocol.
+- **Audit** – Structured logs land in `storage/audit-log.jsonl` and can be hashed for
+  blockchain notarisation.
+
+## Continuous Integration
+
+The CLI exposes a `ci` command that validates configuration files and renders the
+Mermaid mission plan.  A dedicated GitHub Action ensures the Omega-grade operator
+experience stays green on every pull request.
+
+## Next Steps
+
+Connect the orchestrator to Ethereum mainnet infrastructure by providing
+RPC credentials and enabling the on-chain gateways in the configuration file.  The
+interfaces provided here already align with the AGI Jobs v0 (v2) gateway contracts
+and can be promoted to production without code changes.

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__init__.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__init__.py
@@ -1,0 +1,3 @@
+"""Omega-grade Kardashev-II α-AGI Business 3 demo package."""
+
+from .cli import build_cli  # noqa: F401

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__main__.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__main__.py
@@ -1,0 +1,6 @@
+"""CLI entrypoint for the Omega-grade Kardashev-II α-AGI Business 3 demo."""
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - script execution entry
+    main()

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/bin/run.sh
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/bin/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CONFIG_PATH=${1:-$(dirname "$0")/../config/omega_mission.json}
+exec python -m kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega --config "$CONFIG_PATH" "${@:2}"

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/cli.py
@@ -1,0 +1,211 @@
+"""Command line interface for the Omega-grade Kardashev-II α-AGI Business 3 demo."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    Orchestrator,
+)
+
+from .scenario import ScenarioError, load_config, parse_scenario
+from .visuals import render_mermaid
+
+
+def build_cli() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Launch and administrate the Kardashev-II Omega-Grade α-AGI Business 3 demo. "
+            "The CLI is optimised for non-technical operators and orchestrates the full mission."
+        )
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path(__file__).resolve().parent / "config" / "omega_mission.json",
+        help="Path to the mission configuration JSON file.",
+    )
+    parser.add_argument(
+        "--cycles",
+        type=int,
+        default=None,
+        help="Optional maximum number of orchestrator cycles before automatic shutdown.",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Optional duration in seconds to run before stopping (0 runs until manual stop).",
+    )
+    parser.add_argument(
+        "--no-run",
+        action="store_true",
+        help="Validate the configuration and render planning artefacts without starting the orchestrator.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("plan", help="Render a textual and Mermaid plan for the mission.")
+    subparsers.add_parser("status", help="Display the latest mission status snapshot.")
+    subparsers.add_parser("ci", help="Validate configuration for continuous integration.")
+
+    init_parser = subparsers.add_parser(
+        "init",
+        help="Create a working copy of the mission configuration and supportive artefacts for operators.",
+    )
+    init_parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory where the configuration copy should be created.",
+    )
+
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    parser = build_cli()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command == "init":
+        _handle_init(args)
+        return
+    if args.command == "plan":
+        _handle_plan(args)
+        return
+    if args.command == "status":
+        _handle_status(args)
+        return
+    if args.command == "ci":
+        _handle_ci(args)
+        return
+
+    scenario = _load_scenario(args.config)
+    scenario.config.max_cycles = args.cycles or scenario.config.max_cycles
+
+    if args.no_run:
+        _render_plan_to_disk(scenario)
+        print("Configuration validated. No run performed.")
+        return
+
+    duration = None if args.duration is None or args.duration <= 0 else float(args.duration)
+
+    asyncio.run(_run_orchestrator(scenario, duration=duration))
+
+
+def _handle_init(args: argparse.Namespace) -> None:
+    config_path = Path(__file__).resolve().parent / "config" / "omega_mission.json"
+    output_dir = args.output_dir or Path.cwd() / "omega-demo"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    target_config = output_dir / "omega_mission.json"
+    target_config.write_text(config_path.read_text(encoding="utf-8"), encoding="utf-8")
+    mermaid_path = output_dir / "mission-plan.mmd"
+    scenario = _load_scenario(target_config)
+    mermaid_path.write_text(render_mermaid(scenario.jobs), encoding="utf-8")
+    readme_path = output_dir / "README.md"
+    readme_path.write_text(
+        """# Kardashev-II Omega-Grade α-AGI Business 3 Operator Kit\n\n"
+        "1. Edit `omega_mission.json` to tune mission parameters (stakes, rewards, resource caps).\n"
+        "2. Launch the orchestrator with `python -m kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega --config omega_mission.json`.\n"
+        "3. Review structured status updates in `storage/status.jsonl` and adjust the control channel with JSON commands.\n"
+        """,
+        encoding="utf-8",
+    )
+    print(f"Configuration initialised in {output_dir}")
+
+
+def _handle_plan(args: argparse.Namespace) -> None:
+    scenario = _load_scenario(args.config)
+    _render_plan_to_disk(scenario)
+    _print_plan_summary(scenario)
+
+
+def _handle_status(args: argparse.Namespace) -> None:
+    scenario = _load_scenario(args.config)
+    status_path = scenario.config.status_output_path
+    if not status_path or not status_path.exists():
+        print("No status file found. Run the orchestrator first.")
+        return
+    *_, last_line = status_path.read_text(encoding="utf-8").splitlines() or [""]
+    if not last_line:
+        print("Status file is empty.")
+        return
+    payload = json.loads(last_line)
+    print(json.dumps(payload, indent=2))
+
+
+def _handle_ci(args: argparse.Namespace) -> None:
+    scenario = _load_scenario(args.config)
+    _render_plan_to_disk(scenario)
+    _print_plan_summary(scenario)
+
+
+def _load_scenario(config_path: Path):
+    config_path = config_path.expanduser().resolve()
+    if not config_path.exists():
+        raise SystemExit(f"Configuration file not found: {config_path}")
+    try:
+        payload = load_config(config_path)
+        scenario = parse_scenario(payload, config_path=config_path)
+    except ScenarioError as exc:
+        raise SystemExit(str(exc)) from exc
+    return scenario
+
+
+def _render_plan_to_disk(scenario) -> None:
+    mermaid = render_mermaid(scenario.jobs)
+    ui_dir = Path(__file__).resolve().parent / "ui"
+    ui_dir.mkdir(parents=True, exist_ok=True)
+    (ui_dir / "mission-plan.mmd").write_text(mermaid, encoding="utf-8")
+
+
+def _print_plan_summary(scenario) -> None:
+    print(f"Mission: {scenario.config.mission_name}")
+    print(f"Operator account: {scenario.config.operator_account}")
+    print(
+        "Resources: energy_capacity={:.0f} compute_capacity={:.0f} base_tokens={:.0f}".format(
+            scenario.config.energy_capacity,
+            scenario.config.compute_capacity,
+            scenario.config.base_agent_tokens,
+        )
+    )
+    print("Validators:", ", ".join(scenario.config.validator_names))
+    print("Workers:", ", ".join(f"{name} (x{efficiency})" for name, efficiency in scenario.config.worker_specs.items()))
+    for node in scenario.jobs:
+        _print_node(node, indent=0)
+
+
+def _print_node(node, *, indent: int) -> None:
+    prefix = "  " * indent
+    spec = node.payload
+    print(
+        f"{prefix}- {spec['title']} | reward={spec['reward_tokens']:.0f} | stake={spec['stake_required']:.0f} |"
+        f" energy={spec['energy_budget']:.0f} | compute={spec['compute_budget']:.0f}"
+    )
+    for child in node.children:
+        _print_node(child, indent=indent + 1)
+
+
+async def _run_orchestrator(scenario, *, duration: Optional[float]) -> None:
+    orchestrator = Orchestrator(scenario.config)
+    await orchestrator.start()
+    try:
+        if duration is not None:
+            await asyncio.sleep(duration)
+            await orchestrator.shutdown()
+        else:
+            await orchestrator.wait_until_stopped()
+    except KeyboardInterrupt:  # pragma: no cover - manual intervention
+        print("\nOperator requested shutdown via keyboard interrupt.")
+        await orchestrator.shutdown()
+    finally:
+        await orchestrator.wait_until_stopped()
+        print(
+            "Mission completed at",
+            datetime.utcnow().isoformat(timespec="seconds"),
+        )

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/config/omega_mission.json
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/config/omega_mission.json
@@ -1,0 +1,186 @@
+{
+  "mission_name": "Kardashev-II Omega-Grade α-AGI Business 3 – Operator Empowerment",
+  "owner_account": "sovereign-operator",
+  "resources": {
+    "energy_capacity": 5000000,
+    "compute_capacity": 15000000,
+    "base_agent_tokens": 12000
+  },
+  "agents": {
+    "strategists": ["macro-strategist", "expansion-architect"],
+    "validators": ["validator-1", "validator-2", "validator-3", "validator-4"],
+    "workers": [
+      {"name": "dyson-foundry", "efficiency": 1.6},
+      {"name": "supply-chain", "efficiency": 1.3},
+      {"name": "terraforming", "efficiency": 1.15},
+      {"name": "a2a-ops", "efficiency": 1.05}
+    ]
+  },
+  "orchestrator": {
+    "checkpoint_path": "storage/checkpoint.json",
+    "status_output_path": "storage/status.jsonl",
+    "control_channel_file": "storage/control-channel.jsonl",
+    "audit_log_path": "storage/audit-log.jsonl",
+    "energy_oracle_path": "storage/energy-oracle.jsonl",
+    "checkpoint_interval_seconds": 30,
+    "insight_interval_seconds": 20,
+    "energy_oracle_interval_seconds": 180,
+    "heartbeat_interval_seconds": 5,
+    "heartbeat_timeout_seconds": 45,
+    "health_check_interval_seconds": 5,
+    "integrity_check_interval_seconds": 45,
+    "cycle_sleep_seconds": 0.5,
+    "max_cycles": 0,
+    "resume_from_checkpoint": true,
+    "enable_simulation": true,
+    "simulation": {
+      "tick_seconds": 1.0,
+      "hours_per_tick": 2.0,
+      "energy_scale": 3.0,
+      "compute_scale": 1.5
+    },
+    "governance": {
+      "worker_stake_ratio": 0.15,
+      "validator_stake": 1200,
+      "approvals_required": 3,
+      "slash_ratio": 0.35,
+      "pause_enabled": true,
+      "validator_commit_window_seconds": 900,
+      "validator_reveal_window_seconds": 600
+    }
+  },
+  "jobs": [
+    {
+      "job_id": "mission-core",
+      "title": "Launch Stellar Infrastructure Programme",
+      "description": "Mobilise AGI agents to orchestrate a Dyson-swarm expansion with full validator governance.",
+      "required_skills": ["macro-strategy", "energy-architecture"],
+      "reward_tokens": 16000,
+      "stake_required": 3200,
+      "energy_budget": 280000,
+      "compute_budget": 450000,
+      "deadline_hours": 36,
+      "validation_window_hours": 4,
+      "metadata": {"mission_phase": "alpha", "impact_score": 10},
+      "children": [
+        {
+          "job_id": "mission-energy",
+          "title": "Deploy Dyson Foundry Nodes",
+          "description": "Design, construct, and calibrate stellar collectors for immediate integration into the planetary energy ledger.",
+          "required_skills": ["energy", "manufacturing"],
+          "reward_tokens": 9000,
+          "stake_required": 1800,
+          "energy_budget": 180000,
+          "compute_budget": 240000,
+          "deadline_hours": 18,
+          "validation_window_hours": 2,
+          "metadata": {"mission_phase": "energy", "impact_score": 9},
+          "children": [
+            {
+              "job_id": "mission-energy-design",
+              "title": "Design Dyson Swarm Blueprint",
+              "required_skills": ["systems-design", "energy"],
+              "reward_tokens": 3500,
+              "stake_required": 700,
+              "energy_budget": 65000,
+              "compute_budget": 120000,
+              "deadline_hours": 6,
+              "validation_window_hours": 1.5,
+              "metadata": {"mission_phase": "design", "impact_score": 7}
+            },
+            {
+              "job_id": "mission-energy-fabrication",
+              "title": "Coordinate Fabrication Supply Web",
+              "required_skills": ["supply-chain", "automation"],
+              "reward_tokens": 3200,
+              "stake_required": 640,
+              "energy_budget": 48000,
+              "compute_budget": 80000,
+              "deadline_hours": 8,
+              "validation_window_hours": 1.5,
+              "metadata": {"mission_phase": "fabrication", "impact_score": 6}
+            }
+          ]
+        },
+        {
+          "job_id": "mission-governance",
+          "title": "Institutionalise Validator Syndicate",
+          "description": "On-board validator agents, distribute stakes, and prepare commit–reveal oversight for mission-critical jobs.",
+          "required_skills": ["governance", "compliance"],
+          "reward_tokens": 6000,
+          "stake_required": 900,
+          "energy_budget": 80000,
+          "compute_budget": 120000,
+          "deadline_hours": 12,
+          "validation_window_hours": 2,
+          "metadata": {"mission_phase": "governance", "impact_score": 8},
+          "children": [
+            {
+              "job_id": "mission-governance-stake",
+              "title": "Configure Staking Ledgers",
+              "required_skills": ["finance", "tokenomics"],
+              "reward_tokens": 2200,
+              "stake_required": 330,
+              "energy_budget": 20000,
+              "compute_budget": 40000,
+              "deadline_hours": 6,
+              "validation_window_hours": 1,
+              "metadata": {"mission_phase": "staking", "impact_score": 6}
+            },
+            {
+              "job_id": "mission-governance-observatory",
+              "title": "Activate Validator Observatory",
+              "required_skills": ["monitoring", "security"],
+              "reward_tokens": 2400,
+              "stake_required": 360,
+              "energy_budget": 22000,
+              "compute_budget": 42000,
+              "deadline_hours": 6,
+              "validation_window_hours": 1,
+              "metadata": {"mission_phase": "governance", "impact_score": 6}
+            }
+          ]
+        },
+        {
+          "job_id": "mission-supply",
+          "title": "Orchestrate Interplanetary Supply Corridors",
+          "description": "Deliver sustained logistics for energy units, compute substrates, and validator tooling across the Dyson network.",
+          "required_skills": ["logistics", "coordination"],
+          "reward_tokens": 7200,
+          "stake_required": 1200,
+          "energy_budget": 120000,
+          "compute_budget": 200000,
+          "deadline_hours": 20,
+          "validation_window_hours": 3,
+          "metadata": {"mission_phase": "logistics", "impact_score": 8},
+          "children": [
+            {
+              "job_id": "mission-supply-resourcing",
+              "title": "Secure Resource Offtake Contracts",
+              "required_skills": ["negotiation", "procurement"],
+              "reward_tokens": 2600,
+              "stake_required": 520,
+              "energy_budget": 42000,
+              "compute_budget": 60000,
+              "deadline_hours": 8,
+              "validation_window_hours": 1.5,
+              "metadata": {"mission_phase": "logistics", "impact_score": 6}
+            },
+            {
+              "job_id": "mission-supply-telemetry",
+              "title": "Deploy Telemetry Mesh",
+              "required_skills": ["telemetry", "automation"],
+              "reward_tokens": 2800,
+              "stake_required": 560,
+              "energy_budget": 38000,
+              "compute_budget": 58000,
+              "deadline_hours": 10,
+              "validation_window_hours": 1.5,
+              "metadata": {"mission_phase": "logistics", "impact_score": 6}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/scenario.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/scenario.py
@@ -1,0 +1,345 @@
+"""Scenario loader for the Omega-grade Kardashev-II α-AGI Business 3 demo."""
+
+from __future__ import annotations
+
+import json
+import math
+import textwrap
+from dataclasses import dataclass, field
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.governance import (
+    GovernanceParameters,
+)
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.jobs import JobSpec
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    OrchestratorConfig,
+)
+
+
+@dataclass(slots=True)
+class JobPlanNode:
+    """Declarative description of a job and its recursive children."""
+
+    job_id: str
+    payload: Dict[str, Any]
+    children: List["JobPlanNode"] = field(default_factory=list)
+
+    def flatten(self, parent_id: Optional[str] = None) -> Iterator[Dict[str, Any]]:
+        """Yield flattened job payloads understood by :class:`JobSpec`."""
+
+        spec = dict(self.payload)
+        spec.setdefault("metadata", {})
+        spec["metadata"] = dict(spec["metadata"])
+        spec["metadata"].setdefault("job_id", self.job_id)
+        if parent_id is not None:
+            spec["parent_id"] = parent_id
+        else:
+            spec.setdefault("parent_id", None)
+        yield spec
+        for child in self.children:
+            yield from child.flatten(self.job_id)
+
+
+@dataclass(slots=True)
+class Scenario:
+    """Fully parsed scenario, ready to initialise the orchestrator."""
+
+    config: OrchestratorConfig
+    jobs: List[JobPlanNode]
+    raw_payload: Dict[str, Any]
+
+    @property
+    def job_specs(self) -> List[Dict[str, Any]]:
+        flattened: List[Dict[str, Any]] = []
+        for node in self.jobs:
+            flattened.extend(list(node.flatten()))
+        return flattened
+
+
+class ScenarioError(ValueError):
+    """Raised when a configuration file is invalid."""
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - configuration guard
+        snippet = path.read_text(encoding="utf-8")[:200]
+        raise ScenarioError(
+            f"Failed to parse JSON configuration at {path}: {exc}\nSnippet: {snippet}"
+        ) from exc
+    if not isinstance(data, Mapping):  # pragma: no cover - configuration guard
+        raise ScenarioError("Top level of configuration must be a JSON object")
+    return dict(data)
+
+
+def parse_scenario(payload: Mapping[str, Any], *, config_path: Path) -> Scenario:
+    mission_name = str(payload.get("mission_name", "Kardashev-II Omega-Grade α-AGI Business 3"))
+    owner_account = str(payload.get("owner_account", "operator"))
+    resources_section = payload.get("resources", {})
+    if not isinstance(resources_section, Mapping):
+        raise ScenarioError("resources must be a JSON object")
+    agents_section = payload.get("agents", {})
+    if not isinstance(agents_section, Mapping):
+        raise ScenarioError("agents must be a JSON object")
+    orchestrator_section = payload.get("orchestrator", {})
+    if not isinstance(orchestrator_section, Mapping):
+        raise ScenarioError("orchestrator must be a JSON object")
+
+    governance_section = orchestrator_section.get("governance", payload.get("governance", {}))
+    governance = _build_governance(governance_section)
+
+    base_tokens = float(resources_section.get("base_agent_tokens", 10_000.0))
+    energy_capacity = float(resources_section.get("energy_capacity", 1_000_000.0))
+    compute_capacity = float(resources_section.get("compute_capacity", 5_000_000.0))
+
+    scenario_dir = config_path.parent
+
+    config = OrchestratorConfig(
+        mission_name=mission_name,
+        checkpoint_path=_resolve_path(
+            scenario_dir, orchestrator_section.get("checkpoint_path", "storage/checkpoint.json")
+        ),
+        checkpoint_interval_seconds=int(orchestrator_section.get("checkpoint_interval_seconds", 60)),
+        resume_from_checkpoint=bool(orchestrator_section.get("resume_from_checkpoint", True)),
+        enable_simulation=bool(orchestrator_section.get("enable_simulation", True)),
+        simulation_tick_seconds=float(
+            orchestrator_section.get("simulation", {}).get("tick_seconds", 1.0)
+        ),
+        simulation_hours_per_tick=float(
+            orchestrator_section.get("simulation", {}).get("hours_per_tick", 1.0)
+        ),
+        simulation_energy_scale=float(
+            orchestrator_section.get("simulation", {}).get("energy_scale", 2.0)
+        ),
+        simulation_compute_scale=float(
+            orchestrator_section.get("simulation", {}).get("compute_scale", 1.0)
+        ),
+        operator_account=owner_account,
+        base_agent_tokens=base_tokens,
+        energy_capacity=energy_capacity,
+        compute_capacity=compute_capacity,
+        governance=governance,
+        validator_names=_parse_validator_names(agents_section.get("validators")),
+        worker_specs=_parse_worker_specs(agents_section.get("workers")),
+        strategist_names=_parse_strategists(agents_section.get("strategists")),
+        cycle_sleep_seconds=float(orchestrator_section.get("cycle_sleep_seconds", 0.2)),
+        max_cycles=_parse_optional_int(orchestrator_section.get("max_cycles")),
+        insight_interval_seconds=int(orchestrator_section.get("insight_interval_seconds", 30)),
+        control_channel_file=_resolve_path(
+            scenario_dir, orchestrator_section.get("control_channel_file", "storage/control-channel.jsonl")
+        ),
+        audit_log_path=_resolve_optional_path(scenario_dir, orchestrator_section.get("audit_log_path")),
+        initial_jobs=[],
+        status_output_path=_resolve_optional_path(
+            scenario_dir, orchestrator_section.get("status_output_path", "storage/status.jsonl")
+        ),
+        energy_oracle_path=_resolve_optional_path(
+            scenario_dir, orchestrator_section.get("energy_oracle_path", "storage/energy-oracle.jsonl")
+        ),
+        energy_oracle_interval_seconds=float(
+            orchestrator_section.get("energy_oracle_interval_seconds", 120)
+        ),
+        heartbeat_interval_seconds=float(orchestrator_section.get("heartbeat_interval_seconds", 5)),
+        heartbeat_timeout_seconds=float(orchestrator_section.get("heartbeat_timeout_seconds", 30)),
+        health_check_interval_seconds=float(
+            orchestrator_section.get("health_check_interval_seconds", 5)
+        ),
+        integrity_check_interval_seconds=float(
+            orchestrator_section.get("integrity_check_interval_seconds", 30)
+        ),
+    )
+
+    jobs_section = payload.get("jobs", [])
+    if not isinstance(jobs_section, Sequence):
+        raise ScenarioError("jobs must be an array of job specifications")
+    job_nodes = [_parse_job_node(entry, employer=owner_account) for entry in jobs_section]
+
+    config.initial_jobs = [spec for node in job_nodes for spec in node.flatten()]
+
+    _validate_jobs(config.initial_jobs)
+
+    return Scenario(config=config, jobs=job_nodes, raw_payload=dict(payload))
+
+
+def _build_governance(payload: Any) -> GovernanceParameters:
+    if not isinstance(payload, Mapping):
+        payload = {}
+    worker_stake_ratio = float(payload.get("worker_stake_ratio", 0.1))
+    validator_stake = float(payload.get("validator_stake", 1_000.0))
+    approvals_required = int(payload.get("approvals_required", 2))
+    slash_ratio = float(payload.get("slash_ratio", 0.5))
+    pause_enabled = bool(payload.get("pause_enabled", True))
+    commit_window = float(payload.get("validator_commit_window_seconds", payload.get("validator_commit_window", 600)))
+    reveal_window = float(payload.get("validator_reveal_window_seconds", payload.get("validator_reveal_window", 600)))
+    return GovernanceParameters(
+        worker_stake_ratio=max(0.0, worker_stake_ratio),
+        validator_stake=max(0.0, validator_stake),
+        approvals_required=max(1, approvals_required),
+        slash_ratio=min(1.0, max(0.0, slash_ratio)),
+        pause_enabled=pause_enabled,
+        validator_commit_window=timedelta(seconds=max(1.0, commit_window)),
+        validator_reveal_window=timedelta(seconds=max(1.0, reveal_window)),
+    )
+
+
+def _parse_validator_names(value: Any) -> List[str]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        names = [str(item) for item in value if str(item)]
+        return names or ["validator-1", "validator-2", "validator-3"]
+    return ["validator-1", "validator-2", "validator-3"]
+
+
+def _parse_worker_specs(value: Any) -> Dict[str, float]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        result: Dict[str, float] = {}
+        for entry in value:
+            if isinstance(entry, Mapping):
+                name = str(entry.get("name", "")).strip()
+                if not name:
+                    continue
+                efficiency = float(entry.get("efficiency", 1.0))
+                result[name] = max(0.1, efficiency)
+            else:
+                name = str(entry)
+                if name:
+                    result[name] = 1.0
+        if result:
+            return result
+    return {"energy-architect": 1.5, "supply-chain": 1.2, "validator-ops": 1.0}
+
+
+def _parse_strategists(value: Any) -> List[str]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        strategists = [str(item) for item in value if str(item)]
+        return strategists or ["macro-strategist"]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return ["macro-strategist"]
+
+
+def _parse_optional_int(value: Any) -> Optional[int]:
+    try:
+        if value is None:
+            return None
+        numeric = int(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric if numeric > 0 else None
+
+
+def _resolve_path(base: Path, value: Any) -> Path:
+    path = Path(str(value))
+    if not path.is_absolute():
+        path = base / path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _resolve_optional_path(base: Path, value: Any) -> Optional[Path]:
+    if value in (None, "", False):
+        return None
+    path = Path(str(value))
+    if not path.is_absolute():
+        path = base / path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _parse_job_node(payload: Any, *, employer: str) -> JobPlanNode:
+    if not isinstance(payload, Mapping):
+        raise ScenarioError("Each job must be an object")
+    job_id = str(payload.get("job_id") or _slugify(payload.get("title", "job")))
+    required_skills = _ensure_skills(payload.get("required_skills"))
+    reward_tokens = float(payload.get("reward_tokens", 1_000.0))
+    if not math.isfinite(reward_tokens) or reward_tokens <= 0:
+        raise ScenarioError(f"Job {job_id} must have a positive reward")
+    validation_window_hours = payload.get("validation_window_hours")
+    validation_window_minutes = payload.get("validation_window_minutes")
+    validation_window_seconds = payload.get("validation_window_seconds")
+    validation_window = (
+        {"validation_window_hours": float(validation_window_hours)}
+        if validation_window_hours is not None
+        else (
+            {"validation_window_minutes": float(validation_window_minutes)}
+            if validation_window_minutes is not None
+            else {
+                "validation_window_seconds": float(validation_window_seconds)
+                if validation_window_seconds is not None
+                else 3600.0
+            }
+        )
+    )
+    deadline_spec = {}
+    for field in ("deadline_hours", "deadline_minutes", "deadline_seconds"):
+        if field in payload:
+            deadline_spec[field] = float(payload[field])
+            break
+    metadata = dict(payload.get("metadata", {}))
+    metadata.setdefault("employer", employer)
+    metadata.setdefault("impact_score", payload.get("impact_score", 1.0))
+    metadata.setdefault("mission_phase", payload.get("mission_phase", "core"))
+    metadata.setdefault("job_id", job_id)
+    node_payload: Dict[str, Any] = {
+        "job_id": job_id,
+        "title": str(payload.get("title", job_id.replace("-", " ").title())),
+        "description": str(
+            payload.get(
+                "description",
+                textwrap.dedent(
+                    f"""
+                    Mission-critical task automatically generated for {job_id}.
+                    """
+                ).strip(),
+            )
+        ),
+        "required_skills": required_skills,
+        "reward_tokens": reward_tokens,
+        "stake_required": float(payload.get("stake_required", reward_tokens * 0.1)),
+        "energy_budget": float(payload.get("energy_budget", 10_000.0)),
+        "compute_budget": float(payload.get("compute_budget", 50_000.0)),
+        "metadata": metadata,
+        **deadline_spec,
+        **validation_window,
+    }
+    parent_id = payload.get("parent_id")
+    if parent_id:
+        node_payload["parent_id"] = str(parent_id)
+    children_payload = payload.get("children", [])
+    if isinstance(children_payload, Sequence) and not isinstance(children_payload, (str, bytes)):
+        children = [_parse_job_node(child, employer=employer) for child in children_payload]
+    else:
+        children = []
+    return JobPlanNode(job_id=job_id, payload=node_payload, children=children)
+
+
+def _ensure_skills(value: Any) -> List[str]:
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        skills = [str(item).strip() for item in value if str(item).strip()]
+        if skills:
+            return skills
+    return ["macro-strategy"]
+
+
+def _validate_jobs(jobs: Iterable[Dict[str, Any]]) -> None:
+    seen_ids = set()
+    for spec in jobs:
+        job_id = str(spec.get("metadata", {}).get("job_id", spec.get("title", "")))
+        if job_id in seen_ids:
+            raise ScenarioError(f"Duplicate job identifier detected: {job_id}")
+        seen_ids.add(job_id)
+        JobSpec.from_dict(spec)  # validation for required fields
+
+
+def _slugify(value: Any) -> str:
+    text = str(value or "job").strip().lower()
+    slug = "".join(ch if ch.isalnum() else "-" for ch in text)
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    slug = slug.strip("-")
+    return slug or "job"

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/ui/mission-plan.mmd
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/ui/mission-plan.mmd
@@ -1,0 +1,20 @@
+flowchart TD
+    mission_core["Launch Stellar Infrastructure Programme\nReward: 16000 tokens\nEnergy: 280000 | Compute: 450000"]
+    mission_core --> mission_energy
+    mission_energy["Deploy Dyson Foundry Nodes\nReward: 9000 tokens\nEnergy: 180000 | Compute: 240000"]
+    mission_energy --> mission_energy_design
+    mission_energy_design["Design Dyson Swarm Blueprint\nReward: 3500 tokens\nEnergy: 65000 | Compute: 120000"]
+    mission_energy --> mission_energy_fabrication
+    mission_energy_fabrication["Coordinate Fabrication Supply Web\nReward: 3200 tokens\nEnergy: 48000 | Compute: 80000"]
+    mission_core --> mission_governance
+    mission_governance["Institutionalise Validator Syndicate\nReward: 6000 tokens\nEnergy: 80000 | Compute: 120000"]
+    mission_governance --> mission_governance_stake
+    mission_governance_stake["Configure Staking Ledgers\nReward: 2200 tokens\nEnergy: 20000 | Compute: 40000"]
+    mission_governance --> mission_governance_observatory
+    mission_governance_observatory["Activate Validator Observatory\nReward: 2400 tokens\nEnergy: 22000 | Compute: 42000"]
+    mission_core --> mission_supply
+    mission_supply["Orchestrate Interplanetary Supply Corridors\nReward: 7200 tokens\nEnergy: 120000 | Compute: 200000"]
+    mission_supply --> mission_supply_resourcing
+    mission_supply_resourcing["Secure Resource Offtake Contracts\nReward: 2600 tokens\nEnergy: 42000 | Compute: 60000"]
+    mission_supply --> mission_supply_telemetry
+    mission_supply_telemetry["Deploy Telemetry Mesh\nReward: 2800 tokens\nEnergy: 38000 | Compute: 58000"]

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/visuals.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/visuals.py
@@ -1,0 +1,37 @@
+"""Utilities for rendering mission plans and diagrams."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .scenario import JobPlanNode
+
+
+def render_mermaid(nodes: Iterable[JobPlanNode]) -> str:
+    """Render a Mermaid flowchart illustrating the job graph."""
+
+    lines: List[str] = ["flowchart TD"]
+    for node in nodes:
+        _render_node(node, lines)
+    return "\n".join(lines) + "\n"
+
+
+def _render_node(node: JobPlanNode, lines: List[str]) -> None:
+    node_id = _mermaid_id(node.job_id)
+    title = node.payload.get("title", node.job_id)
+    reward = node.payload.get("reward_tokens", 0)
+    energy = node.payload.get("energy_budget", 0)
+    compute = node.payload.get("compute_budget", 0)
+    lines.append(
+        f"    {node_id}[\"{title}\\nReward: {reward:.0f} tokens\\nEnergy: {energy:.0f} | Compute: {compute:.0f}\"]"
+    )
+    for child in node.children:
+        child_id = _mermaid_id(child.job_id)
+        lines.append(f"    {node_id} --> {child_id}")
+        _render_node(child, lines)
+
+
+def _mermaid_id(value: str) -> str:
+    safe = [ch if ch.isalnum() else "_" for ch in value]
+    candidate = "".join(safe)
+    return candidate or "job"

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__init__.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__init__.py
@@ -1,0 +1,1 @@
+"""Forwarder package for the Omega-grade alpha AGI business demo."""

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__main__.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__main__.py
@@ -1,0 +1,11 @@
+"""Forward execution to the canonical demo package."""
+
+from importlib import import_module
+
+_main_module = import_module(
+    "demo.Kardashev-II Omega-Grade-α-AGI Business-3.kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega.__main__"
+)
+main = _main_module.main
+
+if __name__ == "__main__":  # pragma: no cover - script execution entry
+    main()

--- a/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__init__.py
+++ b/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__init__.py
@@ -1,0 +1,10 @@
+"""Bridge for the Omega-grade α-AGI Business 3 operator demo."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_pkg_dir = Path(__file__).resolve().parent
+_nested = _pkg_dir.parent / "demo" / "Kardashev-II Omega-Grade-α-AGI Business-3" / "kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega"
+__path__ = [str(_nested)]
+__all__: list[str] = []

--- a/package.json
+++ b/package.json
@@ -212,6 +212,8 @@
     "demo:kardashev-ii-lattice:orchestrate": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/stellar-civilization-lattice/scripts/orchestrate.ts",
     "demo:kardashev-ii-omega-upgrade": "python -m kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo.cli launch --config demo/'Kardashev-II Omega-Grade-\u03b1-AGI Business-3'/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo/config/mission.json",
     "demo:kardashev-ii-omega-upgrade:ci": "python -m kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo.cli ci",
+    "demo:kardashev-ii-omega-operator": "python -m kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega --config demo/'Kardashev-II Omega-Grade-\u03b1-AGI Business-3'/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/config/omega_mission.json",
+    "demo:kardashev-ii-omega-operator:ci": "python -m kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega --config demo/'Kardashev-II Omega-Grade-\u03b1-AGI Business-3'/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/config/omega_mission.json ci",
     "demo:kardashev-ii-stellar:ci": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/scripts/ci-validate.ts",
     "demo:kardashev-ii-stellar:orchestrate": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/k2-stellar-demo/scripts/orchestrate.ts",
     "demo:kardashev-ii:ci": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/ci-validate.ts",


### PR DESCRIPTION
## Summary
- add an operator-focused Kardashev-II omega demo with CLI, scenario loader, and mission assets
- publish a reusable shell launcher and generated mission plan visualisations
- wire the demo into package scripts and provide a dedicated CI workflow for continuous validation

## Testing
- `npm run demo:kardashev-ii-omega-operator:ci`


------
https://chatgpt.com/codex/tasks/task_e_68fedefec2a0833390293d6607372e3f