### PR TITLE
Add agent registry service, router integration, and deployment tooling

### DIFF
--- a/deploy/docker/agent-node.Dockerfile
+++ b/deploy/docker/agent-node.Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    APP_HOME=/opt/agi-agent
+
+WORKDIR ${APP_HOME}
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+COPY requirements-agent.txt ${APP_HOME}/requirements-agent.txt
+RUN pip install --no-cache-dir -r requirements-agent.txt
+
+COPY tools/agent_registry_cli.py ${APP_HOME}/agent_registry_cli.py
+COPY orchestrator ${APP_HOME}/orchestrator
+
+COPY agent-gateway ${APP_HOME}/agent-gateway
+
+ENV AGENT_ID=agent-001 \
+    AGENT_REGION=us-east \
+    AGENT_CAPABILITIES=execution,validation \
+    AGENT_ROUTER=default \
+    AGENT_REGISTRY_URL=http://meta-api:8000/agents \
+    AGENT_REGISTRY_OWNER_TOKEN=changeme \
+    AGENT_HEARTBEAT_SECRET=please-change-me
+
+COPY deploy/docker/entrypoints/agent-node.sh /usr/local/bin/agent-node
+RUN chmod +x /usr/local/bin/agent-node
+
+ENTRYPOINT ["agent-node"]

--- a/deploy/docker/entrypoints/agent-node.sh
+++ b/deploy/docker/entrypoints/agent-node.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AGENT_ID="${AGENT_ID:-agent-001}"
+AGENT_REGION="${AGENT_REGION:-us-east}"
+AGENT_CAPABILITIES="${AGENT_CAPABILITIES:-execution}"
+AGENT_ROUTER="${AGENT_ROUTER:-default}"
+AGENT_REGISTRY_URL="${AGENT_REGISTRY_URL:-http://meta-api:8000/agents}"
+AGENT_HEARTBEAT_SECRET="${AGENT_HEARTBEAT_SECRET:-changeme}"
+
+echo "Starting AGI Jobs agent node"
+echo " -> id: ${AGENT_ID}"
+echo " -> region: ${AGENT_REGION}"
+echo " -> capabilities: ${AGENT_CAPABILITIES}"
+echo " -> router: ${AGENT_ROUTER}"
+
+until curl -sf "${AGENT_REGISTRY_URL}" >/dev/null; do
+  echo "Waiting for registry ${AGENT_REGISTRY_URL}"
+  sleep 5
+done
+
+python -m http.server 8081 --bind 0.0.0.0 &
+
+python agent_registry_cli.py register \
+  "${AGENT_ID}" \
+  "docker-operator" \
+  "${AGENT_REGION}" \
+  "${AGENT_CAPABILITIES}" \
+  "1000" \
+  "${AGENT_HEARTBEAT_SECRET}" \
+  --router "${AGENT_ROUTER}" \
+  --api-url "${AGENT_REGISTRY_URL}" \
+  --owner-token "${AGENT_REGISTRY_OWNER_TOKEN}" || true
+
+while true; do
+  python agent_registry_cli.py heartbeat "${AGENT_ID}" "${AGENT_HEARTBEAT_SECRET}" \
+    --router "${AGENT_ROUTER}" \
+    --api-url "${AGENT_REGISTRY_URL}" || true
+  sleep 30
+done

--- a/deployment-config/agent-node.compose.yaml
+++ b/deployment-config/agent-node.compose.yaml
@@ -1,0 +1,24 @@
+version: "3.9"
+
+services:
+  agent-node:
+    container_name: agi-agent-node
+    build:
+      context: ..
+      dockerfile: deploy/docker/agent-node.Dockerfile
+    environment:
+      AGENT_ID: agent-001
+      AGENT_REGION: us-east
+      AGENT_CAPABILITIES: execution,validation
+      AGENT_ROUTER: default
+      AGENT_REGISTRY_URL: http://meta-api:8000/agents
+      AGENT_REGISTRY_OWNER_TOKEN: super-secret-token
+      AGENT_HEARTBEAT_SECRET: replace-me
+    volumes:
+      - ./agent-data:/var/lib/agent
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081"]
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/orchestrator/agents.py
+++ b/orchestrator/agents.py
@@ -1,0 +1,411 @@
+"""Registry management for orchestrated agent nodes."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from pydantic import BaseModel, ValidationError
+
+from .models import (
+    AgentCapability,
+    AgentHeartbeatIn,
+    AgentListOut,
+    AgentRegistrationIn,
+    AgentSecurityControls,
+    AgentStake,
+    AgentStatus,
+    AgentUpdateIn,
+)
+
+def _default_registry_path() -> Path:
+    return Path(os.environ.get("AGENT_REGISTRY_PATH", "storage/orchestrator/agents/registry.json"))
+
+
+def _default_heartbeat_timeout() -> float:
+    return float(os.environ.get("AGENT_HEARTBEAT_TIMEOUT", "120"))
+
+
+class AgentRegistryError(RuntimeError):
+    """Base class for registry interaction failures."""
+
+
+class AgentNotFoundError(AgentRegistryError):
+    """Raised when an agent identifier cannot be resolved."""
+
+
+class AgentUnauthorizedError(AgentRegistryError):
+    """Raised when a provided secret does not match the stored hash."""
+
+
+class AgentAssignmentError(AgentRegistryError):
+    """Raised when no eligible replacement agent can be located."""
+
+
+class _RegistrySnapshot(BaseModel):
+    agents: List[AgentStatus]
+    secrets: Dict[str, str]
+
+    @classmethod
+    def empty(cls) -> "_RegistrySnapshot":
+        return cls(agents=[], secrets={})
+
+
+def _hash_secret(secret: str) -> str:
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class AgentAssignment:
+    agent: AgentStatus
+    replaced: bool
+    previous: Optional[str] = None
+    reason: Optional[str] = None
+
+
+class AgentRegistry:
+    """Authoritative store for registered agent metadata and runtime health."""
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        heartbeat_timeout: float | None = None,
+        watchdog_interval: float | None = None,
+    ) -> None:
+        self._path = (path or _default_registry_path()).resolve()
+        self._heartbeat_timeout = float(heartbeat_timeout or _default_heartbeat_timeout())
+        interval = watchdog_interval or max(5.0, self._heartbeat_timeout / 2.0)
+        self._watchdog_interval = max(0.5, float(interval))
+        self._lock = threading.RLock()
+        self._agents: Dict[str, AgentStatus] = {}
+        self._secrets: Dict[str, str] = {}
+        self._watchdog_started = False
+        self._load()
+        self._ensure_watchdog()
+
+    # ---------------------------------------------------------------------
+    # persistence helpers
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            snapshot = _RegistrySnapshot.model_validate(data)
+        except (OSError, json.JSONDecodeError, ValidationError) as exc:
+            raise AgentRegistryError(f"Failed to load agent registry: {exc}") from exc
+        for entry in snapshot.agents:
+            self._agents[entry.agent_id] = entry
+        self._secrets = dict(snapshot.secrets)
+
+    def _persist(self) -> None:
+        snapshot = _RegistrySnapshot(
+            agents=list(self._agents.values()),
+            secrets=dict(self._secrets),
+        )
+        payload = snapshot.model_dump(mode="json")
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True), encoding="utf-8")
+        tmp_path.replace(self._path)
+
+    # ------------------------------------------------------------------
+    # public API
+    # ------------------------------------------------------------------
+    def register(self, payload: AgentRegistrationIn) -> AgentStatus:
+        with self._lock:
+            if payload.agent_id in self._agents:
+                raise AgentRegistryError(f"Agent `{payload.agent_id}` is already registered")
+            timestamp = time.time()
+            status = AgentStatus(
+                agent_id=payload.agent_id,
+                owner=payload.owner,
+                region=payload.region,
+                capabilities=list(payload.capabilities),
+                stake=payload.stake,
+                security=payload.security,
+                router=payload.router,
+                status="active",
+                registered_at=timestamp,
+                updated_at=timestamp,
+                last_heartbeat=None,
+            )
+            self._agents[payload.agent_id] = status
+            self._secrets[payload.agent_id] = _hash_secret(payload.operator_secret)
+            self._persist()
+            return self._with_heartbeat_lag(status)
+
+    def update(self, agent_id: str, payload: AgentUpdateIn) -> AgentStatus:
+        with self._lock:
+            status = self._agents.get(agent_id)
+            if not status:
+                raise AgentNotFoundError(f"Agent `{agent_id}` is not registered")
+            updated = status.model_copy()
+            changed = False
+            if payload.region and payload.region != updated.region:
+                updated.region = payload.region
+                changed = True
+            if payload.capabilities is not None:
+                updated.capabilities = list(payload.capabilities)
+                changed = True
+            if payload.stake is not None:
+                updated.stake = payload.stake
+                changed = True
+            if payload.security is not None:
+                updated.security = payload.security
+                changed = True
+            if payload.router is not None:
+                updated.router = payload.router
+                changed = True
+            if payload.status is not None and payload.status != updated.status:
+                updated.status = payload.status
+                changed = True
+            if payload.operator_secret is not None:
+                self._secrets[agent_id] = _hash_secret(payload.operator_secret)
+                changed = True
+            if not changed:
+                return self._with_heartbeat_lag(status)
+            updated.updated_at = time.time()
+            self._agents[agent_id] = updated
+            self._persist()
+            return self._with_heartbeat_lag(updated)
+
+    def deregister(self, agent_id: str) -> AgentStatus:
+        with self._lock:
+            status = self._agents.pop(agent_id, None)
+            if not status:
+                raise AgentNotFoundError(f"Agent `{agent_id}` is not registered")
+            self._secrets.pop(agent_id, None)
+            self._persist()
+            return self._with_heartbeat_lag(status)
+
+    def record_heartbeat(self, agent_id: str, payload: AgentHeartbeatIn) -> AgentStatus:
+        with self._lock:
+            status = self._agents.get(agent_id)
+            if not status:
+                raise AgentNotFoundError(f"Agent `{agent_id}` is not registered")
+            secret_hash = self._secrets.get(agent_id)
+            if secret_hash:
+                if not payload.secret:
+                    raise AgentUnauthorizedError("Heartbeat secret missing")
+                if not hmac.compare_digest(secret_hash, _hash_secret(payload.secret)):
+                    raise AgentUnauthorizedError("Heartbeat secret mismatch")
+            timestamp = time.time()
+            updated = status.model_copy()
+            updated.last_heartbeat = timestamp
+            updated.updated_at = timestamp
+            if updated.status != "suspended":
+                updated.status = "active"
+            if payload.router is not None:
+                updated.router = payload.router
+            if payload.capabilities is not None:
+                updated.capabilities = list(payload.capabilities)
+            self._agents[agent_id] = updated
+            self._persist()
+            return self._with_heartbeat_lag(updated)
+
+    def get(self, agent_id: str) -> AgentStatus:
+        with self._lock:
+            status = self._agents.get(agent_id)
+            if not status:
+                raise AgentNotFoundError(f"Agent `{agent_id}` is not registered")
+            return self._with_heartbeat_lag(status)
+
+    def list(self, region: str | None = None, status: str | None = None) -> AgentListOut:
+        with self._lock:
+            agents = list(self._agents.values())
+        filtered: List[AgentStatus] = []
+        for entry in agents:
+            if region and entry.region != region:
+                continue
+            if status and entry.status != status:
+                continue
+            filtered.append(self._with_heartbeat_lag(entry))
+        return AgentListOut(agents=filtered, total=len(filtered))
+
+    # ------------------------------------------------------------------
+    # assignment helpers
+    # ------------------------------------------------------------------
+    def prepare_step(self, step: "Step", agent_ids: List[str]) -> Tuple[List[str], List[str]]:
+        """Ensure the provided agents are live; replace offline entries if required."""
+
+        from .models import Step  # local import to avoid circular dependency
+
+        if not isinstance(step, Step):  # defensive check for typing
+            raise AgentRegistryError("prepare_step received incompatible step instance")
+
+        logs: List[str] = []
+        resolved: List[str] = []
+        capability_hint = getattr(step, "tool", None) or None
+        region_hint: Optional[str] = None
+        if isinstance(step.params, dict):
+            region_hint = (
+                step.params.get("region")
+                or step.params.get("preferredRegion")
+                or step.params.get("location")
+            )
+
+        for agent_id in agent_ids:
+            assignment = self._ensure_assignment(agent_id, capability_hint, region_hint)
+            resolved.append(assignment.agent.agent_id)
+            if assignment.replaced and assignment.previous:
+                logs.append(
+                    f"Agent `{assignment.previous}` is {assignment.reason or 'unavailable'}; "
+                    f"reassigned to `{assignment.agent.agent_id}`."
+                )
+                self._rewrite_step_params(step, assignment.previous, assignment.agent.agent_id)
+        return resolved, logs
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_assignment(
+        self,
+        agent_id: str,
+        capability_hint: str | None,
+        region_hint: str | None,
+    ) -> AgentAssignment:
+        with self._lock:
+            status = self._agents.get(agent_id)
+            if status and self._is_available(status):
+                return AgentAssignment(agent=self._with_heartbeat_lag(status), replaced=False)
+            reason = "not registered" if not status else status.status
+            replacement = self._find_replacement(capability_hint, region_hint, exclude={agent_id})
+            if not replacement:
+                raise AgentAssignmentError(
+                    f"No available agent for `{capability_hint or 'generic'}` in region `{region_hint or 'any'}`"
+                )
+            return AgentAssignment(
+                agent=self._with_heartbeat_lag(replacement),
+                replaced=True,
+                previous=agent_id,
+                reason=reason,
+            )
+
+    def _find_replacement(
+        self,
+        capability_hint: str | None,
+        region_hint: str | None,
+        exclude: Iterable[str],
+    ) -> Optional[AgentStatus]:
+        with self._lock:
+            candidates = [entry for entry in self._agents.values() if entry.agent_id not in set(exclude)]
+        active_candidates = [entry for entry in candidates if self._is_available(entry)]
+        if not active_candidates:
+            return None
+
+        def _score(entry: AgentStatus) -> Tuple[int, int, Decimal]:
+            score_capability = 1 if capability_hint and self._matches_capability(entry, capability_hint) else 0
+            score_region = 1 if region_hint and entry.region == region_hint else 0
+            stake_amount = entry.stake.amount if isinstance(entry.stake.amount, Decimal) else Decimal(str(entry.stake.amount))
+            return (score_capability, score_region, stake_amount)
+
+        active_candidates.sort(key=_score, reverse=True)
+
+        if capability_hint:
+            for entry in active_candidates:
+                if self._matches_capability(entry, capability_hint):
+                    if region_hint and entry.region == region_hint:
+                        return entry
+            for entry in active_candidates:
+                if self._matches_capability(entry, capability_hint):
+                    return entry
+
+        if region_hint:
+            for entry in active_candidates:
+                if entry.region == region_hint:
+                    return entry
+        return active_candidates[0]
+
+    def _matches_capability(self, entry: AgentStatus, capability_hint: str) -> bool:
+        try:
+            capability = AgentCapability(capability_hint)
+            return capability in entry.capabilities
+        except ValueError:
+            return capability_hint in {capability.value for capability in entry.capabilities}
+
+    def _is_available(self, entry: AgentStatus) -> bool:
+        if entry.status in {"suspended", "offline"}:
+            return False
+        if not entry.last_heartbeat:
+            return entry.status == "active"
+        return (time.time() - entry.last_heartbeat) < self._heartbeat_timeout
+
+    def _rewrite_step_params(self, step: "Step", old: str, new: str) -> None:
+        if not isinstance(step.params, dict):
+            return
+        for key in (
+            "agent",
+            "agentId",
+            "agentAddress",
+            "validator",
+            "student",
+            "teacher",
+            "recipient",
+        ):
+            if step.params.get(key) == old:
+                step.params[key] = new
+
+    def _with_heartbeat_lag(self, entry: AgentStatus) -> AgentStatus:
+        copy = entry.model_copy()
+        if copy.last_heartbeat:
+            copy.heartbeat_lag_seconds = max(0.0, time.time() - copy.last_heartbeat)
+        else:
+            copy.heartbeat_lag_seconds = None
+        return copy
+
+    # ------------------------------------------------------------------
+    # watchdog
+    # ------------------------------------------------------------------
+    def _ensure_watchdog(self) -> None:
+        if self._watchdog_started:
+            return
+
+        def _watchdog() -> None:
+            interval = self._watchdog_interval
+            while True:
+                time.sleep(interval)
+                with self._lock:
+                    dirty = False
+                    now = time.time()
+                    for agent_id, entry in list(self._agents.items()):
+                        if entry.status == "suspended":
+                            continue
+                        if not entry.last_heartbeat:
+                            continue
+                        if now - entry.last_heartbeat <= self._heartbeat_timeout:
+                            continue
+                        updated = entry.model_copy()
+                        updated.status = "offline"
+                        updated.updated_at = now
+                        self._agents[agent_id] = updated
+                        dirty = True
+                    if dirty:
+                        self._persist()
+
+        thread = threading.Thread(target=_watchdog, daemon=True, name="agent-registry-watchdog")
+        thread.start()
+        self._watchdog_started = True
+
+
+_REGISTRY_SINGLETON: AgentRegistry | None = None
+
+
+def get_registry() -> AgentRegistry:
+    global _REGISTRY_SINGLETON
+    if _REGISTRY_SINGLETON is None:
+        _REGISTRY_SINGLETON = AgentRegistry()
+    return _REGISTRY_SINGLETON
+
+
+def reset_registry() -> None:
+    global _REGISTRY_SINGLETON
+    _REGISTRY_SINGLETON = None

--- a/requirements-agent.txt
+++ b/requirements-agent.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+httpx==0.27.0
+uvicorn==0.27.1

--- a/routes/agents.py
+++ b/routes/agents.py
@@ -1,0 +1,102 @@
+"""FastAPI router exposing agent registry management endpoints."""
+
+from __future__ import annotations
+
+import hmac
+import os
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
+
+from orchestrator.agents import (
+    AgentAssignmentError,
+    AgentNotFoundError,
+    AgentRegistryError,
+    AgentUnauthorizedError,
+    get_registry,
+)
+from orchestrator.models import AgentHeartbeatIn, AgentListOut, AgentRegistrationIn, AgentStatus, AgentUpdateIn
+
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+
+
+def _owner_token() -> Optional[str]:
+    return os.environ.get("AGENT_REGISTRY_OWNER_TOKEN")
+
+
+def require_owner(x_owner_token: str = Header(..., alias="X-Owner-Token")) -> None:
+    token = _owner_token()
+    if not token:
+        raise HTTPException(status_code=503, detail="OWNER_TOKEN_NOT_CONFIGURED")
+    if not hmac.compare_digest(token, x_owner_token):
+        raise HTTPException(status_code=403, detail="OWNER_TOKEN_INVALID")
+
+
+def _handle_error(exc: AgentRegistryError) -> None:
+    if isinstance(exc, AgentNotFoundError):
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    if isinstance(exc, AgentUnauthorizedError):
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+    if isinstance(exc, AgentAssignmentError):
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("", response_model=AgentStatus, dependencies=[Depends(require_owner)])
+def register_agent(payload: AgentRegistrationIn) -> AgentStatus:
+    try:
+        return get_registry().register(payload)
+    except AgentRegistryError as exc:  # pragma: no cover - defensive
+        _handle_error(exc)
+
+
+@router.put("/{agent_id}", response_model=AgentStatus, dependencies=[Depends(require_owner)])
+def update_agent(agent_id: str, payload: AgentUpdateIn) -> AgentStatus:
+    try:
+        return get_registry().update(agent_id, payload)
+    except AgentRegistryError as exc:
+        _handle_error(exc)
+
+
+@router.delete("/{agent_id}", response_model=AgentStatus, dependencies=[Depends(require_owner)])
+def deregister_agent(agent_id: str) -> AgentStatus:
+    try:
+        return get_registry().deregister(agent_id)
+    except AgentRegistryError as exc:
+        _handle_error(exc)
+
+
+@router.get("", response_model=AgentListOut)
+def list_agents(region: Optional[str] = Query(default=None), status: Optional[str] = Query(default=None)) -> AgentListOut:
+    try:
+        return get_registry().list(region=region, status=status)
+    except AgentRegistryError as exc:  # pragma: no cover - defensive
+        _handle_error(exc)
+
+
+@router.get("/{agent_id}", response_model=AgentStatus)
+def get_agent(agent_id: str) -> AgentStatus:
+    try:
+        return get_registry().get(agent_id)
+    except AgentRegistryError as exc:
+        _handle_error(exc)
+
+
+@router.post("/{agent_id}/heartbeat", response_model=AgentStatus)
+def agent_heartbeat(agent_id: str, payload: AgentHeartbeatIn) -> AgentStatus:
+    try:
+        return get_registry().record_heartbeat(agent_id, payload)
+    except AgentRegistryError as exc:
+        _handle_error(exc)
+
+
+__all__ = [
+    "router",
+    "register_agent",
+    "update_agent",
+    "deregister_agent",
+    "list_agents",
+    "get_agent",
+    "agent_heartbeat",
+]

--- a/services/meta_api/app/main.py
+++ b/services/meta_api/app/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 
 from orchestrator.analytics import AnalyticsScheduler, AnalyticsEngine, get_cache, run_once
 from routes.analytics import router as analytics_router
+from routes.agents import router as agents_router
 from routes.meta_orchestrator import router as meta_router
 from routes.onebox import health_router, router as onebox_router
 
@@ -32,6 +33,7 @@ def create_app() -> FastAPI:
     app.include_router(onebox_router)
     app.include_router(meta_router)
     app.include_router(analytics_router)
+    app.include_router(agents_router)
 
     scheduler = AnalyticsScheduler(AnalyticsEngine(), get_cache())
 

--- a/test/orchestrator/test_agents.py
+++ b/test/orchestrator/test_agents.py
@@ -1,0 +1,84 @@
+"""Unit tests for the agent registry helpers."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from orchestrator.agents import AgentRegistry, AgentUnauthorizedError
+from orchestrator.models import (
+    AgentCapability,
+    AgentHeartbeatIn,
+    AgentRegistrationIn,
+    AgentSecurityControls,
+    AgentStake,
+    AgentUpdateIn,
+    Step,
+)
+
+
+def _registry(tmp_path, timeout: float = 0.2) -> AgentRegistry:
+    path = tmp_path / "registry.json"
+    return AgentRegistry(path=path, heartbeat_timeout=timeout, watchdog_interval=timeout / 2.0)
+
+
+def _registration_payload(agent_id: str, secret: str = "secret123") -> AgentRegistrationIn:
+    return AgentRegistrationIn(
+        agent_id=agent_id,
+        owner="owner",
+        region="us-east",
+        capabilities=[AgentCapability.EXECUTION],
+        stake=AgentStake(amount="100"),
+        security=AgentSecurityControls(),
+        router="default",
+        operator_secret=secret,
+    )
+
+
+def test_register_and_list_agents(tmp_path) -> None:
+    registry = _registry(tmp_path)
+    created = registry.register(_registration_payload("agent-1"))
+    assert created.agent_id == "agent-1"
+    fetched = registry.get("agent-1")
+    assert fetched.region == "us-east"
+    listing = registry.list()
+    assert listing.total == 1
+    assert listing.agents[0].agent_id == "agent-1"
+
+
+def test_heartbeat_requires_secret(tmp_path) -> None:
+    registry = _registry(tmp_path)
+    registry.register(_registration_payload("agent-1", secret="correct1"))
+    with pytest.raises(AgentUnauthorizedError):
+        registry.record_heartbeat("agent-1", AgentHeartbeatIn(secret="wrong000"))
+    updated = registry.record_heartbeat("agent-1", AgentHeartbeatIn(secret="correct1"))
+    assert updated.last_heartbeat is not None
+
+
+def test_prepare_step_reassigns_offline_agent(tmp_path) -> None:
+    registry = _registry(tmp_path)
+    registry.register(_registration_payload("primary"))
+    registry.update("primary", AgentUpdateIn(status="offline"))
+    registry.register(_registration_payload("backup"))
+    step = Step(
+        id="step-1",
+        name="Execute",
+        kind="code",
+        tool="execution",
+        params={"agent": "primary"},
+        needs=[],
+    )
+    agents, logs = registry.prepare_step(step, ["primary"])
+    assert agents == ["backup"]
+    assert any("reassigned" in entry for entry in logs)
+    assert step.params["agent"] == "backup"
+
+
+def test_watchdog_marks_agent_offline(tmp_path) -> None:
+    registry = _registry(tmp_path, timeout=0.3)
+    registry.register(_registration_payload("agent-1", secret="beatgood"))
+    registry.record_heartbeat("agent-1", AgentHeartbeatIn(secret="beatgood"))
+    time.sleep(0.7)
+    status = registry.get("agent-1")
+    assert status.status == "offline"

--- a/test/routes/test_agents.py
+++ b/test/routes/test_agents.py
@@ -1,0 +1,86 @@
+"""Tests for the agent registry FastAPI router."""
+
+from __future__ import annotations
+
+import pytest
+
+try:  # pragma: no cover - optional dependency guard
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - FastAPI optional in CI
+    FastAPI = None  # type: ignore
+    TestClient = None  # type: ignore
+
+from orchestrator.agents import reset_registry
+from routes.agents import router
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    if FastAPI is None or TestClient is None:  # pragma: no cover - FastAPI optional
+        pytest.skip("FastAPI not available")
+    path = tmp_path / "registry.json"
+    if path.exists():
+        path.unlink()
+    monkeypatch.setenv("AGENT_REGISTRY_OWNER_TOKEN", "owner-token")
+    monkeypatch.setenv("AGENT_REGISTRY_PATH", str(path))
+    monkeypatch.setenv("AGENT_HEARTBEAT_TIMEOUT", "0.5")
+    reset_registry()
+    app = FastAPI()
+    app.include_router(router)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.mark.skipif(FastAPI is None, reason="FastAPI not available")
+def test_agent_lifecycle(client: TestClient) -> None:
+    registration = {
+        "agent_id": "agent-a",
+        "owner": "owner",
+        "region": "us-east",
+        "capabilities": ["execution"],
+        "stake": {"amount": "100", "token": "AGIALPHA"},
+        "security": {"requires_kyc": False, "multisig": False, "isolation_level": "process"},
+        "router": "default",
+        "operator_secret": "secret-token",
+    }
+    headers = {"X-Owner-Token": "owner-token"}
+    resp = client.post("/agents", json=registration, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["agent_id"] == "agent-a"
+
+    list_resp = client.get("/agents")
+    assert list_resp.status_code == 200
+    assert list_resp.json()["total"] == 1
+
+    hb_resp = client.post("/agents/agent-a/heartbeat", json={"secret": "secret-token"})
+    assert hb_resp.status_code == 200
+
+    update_resp = client.put("/agents/agent-a", json={"region": "eu-west"}, headers=headers)
+    assert update_resp.status_code == 200
+    assert update_resp.json()["region"] == "eu-west"
+
+    delete_resp = client.delete("/agents/agent-a", headers=headers)
+    assert delete_resp.status_code == 200
+
+    missing = client.get("/agents/agent-a")
+    assert missing.status_code == 404
+
+
+@pytest.mark.skipif(FastAPI is None, reason="FastAPI not available")
+def test_heartbeat_secret_validation(client: TestClient) -> None:
+    headers = {"X-Owner-Token": "owner-token"}
+    registration = {
+        "agent_id": "agent-sec",
+        "owner": "owner",
+        "region": "us-east",
+        "capabilities": ["execution"],
+        "stake": {"amount": "100", "token": "AGIALPHA"},
+        "security": {"requires_kyc": False, "multisig": False, "isolation_level": "process"},
+        "router": "default",
+        "operator_secret": "secret-token",
+    }
+    client.post("/agents", json=registration, headers=headers)
+    resp = client.post("/agents/agent-sec/heartbeat", json={"secret": "badsecret"})
+    assert resp.status_code == 401

--- a/tools/agent_registry_cli.py
+++ b/tools/agent_registry_cli.py
@@ -1,0 +1,326 @@
+"""Operator friendly CLI for managing the agent registry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+import httpx
+
+from orchestrator.agents import AgentRegistry, AgentRegistryError, get_registry, reset_registry
+from orchestrator.models import (
+    AgentCapability,
+    AgentHeartbeatIn,
+    AgentRegistrationIn,
+    AgentSecurityControls,
+    AgentStake,
+    AgentUpdateIn,
+)
+
+TEMPLATE_COMPOSE = """\
+version: "3.9"
+services:
+  agent-node:
+    build:
+      context: ..
+      dockerfile: deploy/docker/agent-node.Dockerfile
+    environment:
+      AGENT_ID: {agent_id}
+      AGENT_REGION: {region}
+      AGENT_CAPABILITIES: {capabilities}
+      AGENT_ROUTER: {router}
+      AGENT_REGISTRY_URL: {registry_url}
+      AGENT_REGISTRY_OWNER_TOKEN: ${AGENT_REGISTRY_OWNER_TOKEN}
+      AGENT_HEARTBEAT_SECRET: {secret}
+    volumes:
+      - ./agent-data:/var/lib/agent
+    restart: unless-stopped
+"""
+
+
+def _ensure_registry(path: Path | None) -> AgentRegistry:
+    if path:
+        reset_registry()
+        return AgentRegistry(path=path)
+    return get_registry()
+
+
+def _use_remote(args: argparse.Namespace) -> bool:
+    return bool(args.api_url)
+
+
+def _endpoint(args: argparse.Namespace, suffix: str = "") -> str:
+    if not args.api_url:
+        raise RuntimeError("API URL not configured")
+    base = args.api_url.rstrip("/")
+    return f"{base}{suffix}"
+
+
+def _owner_headers(args: argparse.Namespace) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if args.owner_token:
+        headers["X-Owner-Token"] = args.owner_token
+    return headers
+
+
+def _perform_request(
+    args: argparse.Namespace,
+    method: str,
+    suffix: str,
+    json_payload: dict | None = None,
+    params: dict | None = None,
+) -> dict:
+    url = _endpoint(args, suffix)
+    headers = _owner_headers(args)
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            response = client.request(method, url, json=json_payload, params=params, headers=headers)
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        detail = exc.response.text if exc.response else str(exc)
+        raise SystemExit(f"API {method} {url} failed: {exc.response.status_code if exc.response else ''} {detail}") from exc
+    except httpx.HTTPError as exc:
+        raise SystemExit(f"API request failed: {exc}") from exc
+    return response.json()
+
+
+def _parse_capabilities(raw: Iterable[str]) -> List[AgentCapability]:
+    capabilities: List[AgentCapability] = []
+    for value in raw:
+        value = value.strip()
+        if not value:
+            continue
+        try:
+            capabilities.append(AgentCapability(value))
+        except ValueError:
+            raise SystemExit(f"Unknown capability `{value}`")
+    if not capabilities:
+        raise SystemExit("At least one capability is required")
+    return capabilities
+
+
+def command_register(args: argparse.Namespace) -> None:
+    payload = AgentRegistrationIn(
+        agent_id=args.agent_id,
+        owner=args.owner,
+        region=args.region,
+        capabilities=_parse_capabilities(args.capabilities.split(",")),
+        stake=AgentStake(amount=args.stake, token=args.stake_token, slashable=not args.nonslashable),
+        security=AgentSecurityControls(
+            requires_kyc=args.requires_kyc,
+            multisig=args.multisig,
+            isolation_level=args.isolation_level,
+            hardware_root_of_trust=args.hardware_root,
+            notes=args.security_notes,
+        ),
+        router=args.router,
+        operator_secret=args.secret,
+    )
+    if _use_remote(args):
+        if not args.owner_token:
+            raise SystemExit("--owner-token is required when using --api-url for registration")
+        data = payload.model_dump(mode="json")
+        result = _perform_request(args, "POST", "", data)
+        print(json.dumps(result, indent=2))
+        return
+    registry = _ensure_registry(args.registry_path)
+    try:
+        result = registry.register(payload)
+    except AgentRegistryError as exc:
+        raise SystemExit(f"Registration failed: {exc}") from exc
+    print(json.dumps(result.model_dump(mode="json"), indent=2))
+
+
+def command_update(args: argparse.Namespace) -> None:
+    capabilities = (
+        _parse_capabilities(args.capabilities.split(",")) if args.capabilities else None
+    )
+    stake = (
+        AgentStake(amount=args.stake, token=args.stake_token, slashable=not args.nonslashable)
+        if args.stake is not None
+        else None
+    )
+    security = None
+    if (
+        args.requires_kyc is not None
+        or args.multisig is not None
+        or args.isolation_level is not None
+        or args.hardware_root is not None
+        or args.security_notes is not None
+    ):
+        security = AgentSecurityControls(
+            requires_kyc=args.requires_kyc if args.requires_kyc is not None else False,
+            multisig=args.multisig if args.multisig is not None else False,
+            isolation_level=args.isolation_level or "process",
+            hardware_root_of_trust=args.hardware_root if args.hardware_root is not None else False,
+            notes=args.security_notes,
+        )
+    payload = AgentUpdateIn(
+        region=args.region,
+        capabilities=capabilities,
+        stake=stake,
+        security=security,
+        router=args.router,
+        status=args.status,
+        operator_secret=args.secret,
+    )
+    if _use_remote(args):
+        if not args.owner_token:
+            raise SystemExit("--owner-token is required when using --api-url for updates")
+        data = payload.model_dump(mode="json", exclude_none=True)
+        result = _perform_request(args, "PUT", f"/{args.agent_id}", data)
+        print(json.dumps(result, indent=2))
+        return
+    registry = _ensure_registry(args.registry_path)
+    try:
+        result = registry.update(args.agent_id, payload)
+    except AgentRegistryError as exc:
+        raise SystemExit(f"Update failed: {exc}") from exc
+    print(json.dumps(result.model_dump(mode="json"), indent=2))
+
+
+def command_list(args: argparse.Namespace) -> None:
+    if _use_remote(args):
+        params = {}
+        if args.region:
+            params["region"] = args.region
+        if args.status:
+            params["status"] = args.status
+        result = _perform_request(args, "GET", "", params=params)
+        print(json.dumps(result, indent=2))
+        return
+    registry = _ensure_registry(args.registry_path)
+    try:
+        result = registry.list(region=args.region, status=args.status)
+    except AgentRegistryError as exc:
+        raise SystemExit(f"Listing failed: {exc}") from exc
+    print(json.dumps(result.model_dump(mode="json"), indent=2))
+
+
+def command_remove(args: argparse.Namespace) -> None:
+    if _use_remote(args):
+        if not args.owner_token:
+            raise SystemExit("--owner-token is required when using --api-url for deregistration")
+        result = _perform_request(args, "DELETE", f"/{args.agent_id}")
+        print(json.dumps(result, indent=2))
+        return
+    registry = _ensure_registry(args.registry_path)
+    try:
+        result = registry.deregister(args.agent_id)
+    except AgentRegistryError as exc:
+        raise SystemExit(f"Deregistration failed: {exc}") from exc
+    print(json.dumps(result.model_dump(mode="json"), indent=2))
+
+
+def command_heartbeat(args: argparse.Namespace) -> None:
+    payload = AgentHeartbeatIn(router=args.router, secret=args.secret)
+    if _use_remote(args):
+        data = payload.model_dump(mode="json", exclude_none=True)
+        result = _perform_request(args, "POST", f"/{args.agent_id}/heartbeat", data)
+        print(json.dumps(result, indent=2))
+        return
+    registry = _ensure_registry(args.registry_path)
+    try:
+        result = registry.record_heartbeat(args.agent_id, payload)
+    except AgentRegistryError as exc:
+        raise SystemExit(f"Heartbeat failed: {exc}") from exc
+    print(json.dumps(result.model_dump(mode="json"), indent=2))
+
+
+def command_template(args: argparse.Namespace) -> None:
+    compose = TEMPLATE_COMPOSE.format(
+        agent_id=args.agent_id,
+        region=args.region,
+        capabilities=args.capabilities,
+        router=args.router,
+        registry_url=args.registry_url,
+        secret=args.secret,
+    )
+    Path(args.output).write_text(compose, encoding="utf-8")
+    print(f"Wrote docker compose template to {args.output}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage agent registry entries from the command line.")
+    parser.add_argument("--registry-path", type=Path, default=None, help="Override registry persistence path (local mode).")
+    parser.add_argument("--api-url", default=None, help="Remote agent registry API base (e.g. http://localhost:8000/agents)")
+    parser.add_argument("--owner-token", default=None, help="Owner governance token for remote mutations.")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    register = subparsers.add_parser("register", help="Register a new agent")
+    register.add_argument("agent_id")
+    register.add_argument("owner")
+    register.add_argument("region")
+    register.add_argument("capabilities", help="Comma separated capability list (router,execution,validation,analysis,support)")
+    register.add_argument("stake", help="Stake amount", type=str)
+    register.add_argument("secret", help="Shared heartbeat secret")
+    register.add_argument("--stake-token", default="AGIALPHA")
+    register.add_argument("--router", default=None)
+    register.add_argument("--requires-kyc", action="store_true")
+    register.add_argument("--multisig", action="store_true")
+    register.add_argument("--isolation-level", default="process")
+    register.add_argument("--hardware-root", action="store_true")
+    register.add_argument("--security-notes", default=None)
+    register.add_argument("--nonslashable", action="store_true")
+    register.set_defaults(func=command_register)
+
+    update = subparsers.add_parser("update", help="Update an existing agent")
+    update.add_argument("agent_id")
+    update.add_argument("--region")
+    update.add_argument("--capabilities")
+    update.add_argument("--stake")
+    update.add_argument("--stake-token", default="AGIALPHA")
+    update.add_argument("--router")
+    update.add_argument("--status")
+    update.add_argument("--secret")
+    update.add_argument("--requires-kyc", dest="requires_kyc", action="store_const", const=True, default=None)
+    update.add_argument("--no-requires-kyc", dest="requires_kyc", action="store_const", const=False)
+    update.add_argument("--multisig", dest="multisig", action="store_const", const=True, default=None)
+    update.add_argument("--no-multisig", dest="multisig", action="store_const", const=False)
+    update.add_argument("--isolation-level", default=None)
+    update.add_argument("--hardware-root", dest="hardware_root", action="store_const", const=True, default=None)
+    update.add_argument("--no-hardware-root", dest="hardware_root", action="store_const", const=False)
+    update.add_argument("--security-notes", default=None)
+    update.add_argument("--nonslashable", action="store_true")
+    update.set_defaults(func=command_update)
+
+    list_parser = subparsers.add_parser("list", help="List registered agents")
+    list_parser.add_argument("--region")
+    list_parser.add_argument("--status")
+    list_parser.set_defaults(func=command_list)
+
+    remove = subparsers.add_parser("remove", help="Remove an agent")
+    remove.add_argument("agent_id")
+    remove.set_defaults(func=command_remove)
+
+    heartbeat = subparsers.add_parser("heartbeat", help="Send a heartbeat for an agent")
+    heartbeat.add_argument("agent_id")
+    heartbeat.add_argument("secret")
+    heartbeat.add_argument("--router")
+    heartbeat.set_defaults(func=command_heartbeat)
+
+    template = subparsers.add_parser("template", help="Generate a docker-compose template")
+    template.add_argument("agent_id")
+    template.add_argument("region")
+    template.add_argument("capabilities")
+    template.add_argument("router")
+    template.add_argument("registry_url")
+    template.add_argument("secret")
+    template.add_argument("--output", default="agent-node.compose.yaml")
+    template.set_defaults(func=command_template)
+
+    return parser
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- introduce agent registry models and state management with automated heartbeats and reassignment helpers
- expose owner-governed FastAPI endpoints and wire the agent router into the meta API
- add an operator CLI plus Docker/compose templates for agent nodes and cover behaviour with unit tests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/orchestrator/test_agents.py test/routes/test_agents.py

------
https://chatgpt.com/codex/tasks/task_e_68ff7f7106b4833391a9447cf9401046