### PR TITLE
Add owner guardrails to Validator Constellation demo

### DIFF
--- a/demo/Validator-Constellation-v0/README.md
+++ b/demo/Validator-Constellation-v0/README.md
@@ -76,6 +76,11 @@ import { ValidatorConstellationDemo } from './src/core/constellation';
 
 const demo = new ValidatorConstellationDemo(setup);
 demo.updateGovernanceParameter('slashPenaltyBps', 2_500);
+demo.updateSentinelConfig({ budgetGraceRatio: 0.12 });
+demo.updateDomainSafety('deep-space-lab', { unsafeOpcodes: ['STATICCALL', 'DELEGATECALL'] });
+demo.pauseDomain('deep-space-lab', 'scheduled upgrade');
+demo.resumeDomain('deep-space-lab');
+demo.setAgentBudget('nova.agent.agi.eth', 2_000_000n);
 ```
 
 All modules respond instantly (new committee sizes, quorum thresholds, penalty weights, etc.).

--- a/demo/Validator-Constellation-v0/src/core/fixtures.ts
+++ b/demo/Validator-Constellation-v0/src/core/fixtures.ts
@@ -60,13 +60,19 @@ export function demoJobBatch(domainId: string, count: number): JobResult[] {
   return jobs;
 }
 
-export function budgetOverrunAction(agentEns: string, agentAddress: `0x${string}`, domainId: string, overspend: bigint): AgentAction {
+export function budgetOverrunAction(
+  agentEns: string,
+  agentAddress: `0x${string}`,
+  domainId: string,
+  overspend: bigint,
+  budget = 1_000_000n,
+): AgentAction {
   return {
     agent: {
       ensName: agentEns,
       address: agentAddress,
       domainId,
-      budget: 1_000_000n,
+      budget,
     },
     domainId,
     type: 'TRANSFER',

--- a/demo/Validator-Constellation-v0/src/core/sentinel.ts
+++ b/demo/Validator-Constellation-v0/src/core/sentinel.ts
@@ -61,4 +61,28 @@ export class SentinelMonitor {
 
     return undefined;
   }
+
+  updateBudgetGraceRatio(ratio: number): void {
+    if (!Number.isFinite(ratio) || ratio < 0) {
+      throw new Error('invalid budget grace ratio');
+    }
+    this.config.budgetGraceRatio = ratio;
+  }
+
+  getBudgetGraceRatio(): number {
+    return this.config.budgetGraceRatio;
+  }
+
+  updateUnsafeOpcodes(domainId: string, opcodes: Iterable<string>): void {
+    const normalized = Array.from(opcodes);
+    this.config.unsafeOpcodes.set(domainId, new Set(normalized));
+  }
+
+  getUnsafeOpcodes(domainId: string): Set<string> {
+    const fromConfig = this.config.unsafeOpcodes.get(domainId);
+    if (fromConfig) {
+      return new Set(fromConfig);
+    }
+    return new Set(this.getDomainConfig(domainId).unsafeOpcodes);
+  }
 }

--- a/demo/Validator-Constellation-v0/src/core/types.ts
+++ b/demo/Validator-Constellation-v0/src/core/types.ts
@@ -139,6 +139,12 @@ export interface DomainState {
   pauseReason?: PauseRecord;
 }
 
+export interface DomainSafetyUpdate {
+  humanName?: string;
+  budgetLimit?: bigint;
+  unsafeOpcodes?: Iterable<string>;
+}
+
 export interface ValidatorEventBus extends EventEmitter {
   on(event: 'StakeSlashed', listener: (event: SlashingEvent) => void): this;
   on(event: 'SentinelAlert', listener: (alert: SentinelAlert) => void): this;


### PR DESCRIPTION
## Summary
- add governance APIs to the validator constellation orchestrator so owners can pause domains, retune sentinels, update unsafe opcode catalogs, and retarget agent budgets
- enrich the demo launcher output with governance telemetry and ENS-driven maintenance controls to highlight operator empowerment
- cover the new controls with deterministic tests that prove sentinel reconfiguration and pausing work for non-technical operators

## Testing
- npm run lint:validator-constellation
- npm run test:validator-constellation
- npm run demo:validator-constellation

------
https://chatgpt.com/codex/tasks/task_e_68ff8474a0008333a5286d1406977ec2