### PR TITLE
Add Validator Constellation demo with sentinel guardrails

### DIFF
--- a/demo/Validator-Constellation-v0/src/commitReveal/CommitReveal.ts
+++ b/demo/Validator-Constellation-v0/src/commitReveal/CommitReveal.ts
@@ -1,0 +1,122 @@
+import { keccak256, toUtf8Bytes } from "ethers";
+import { StakeManager } from "../staking/StakeManager";
+import { EventBus } from "../subgraph/EventBus";
+
+export type VoteValue = "approve" | "reject";
+
+export interface CommitEntry {
+  commitHash: string;
+  committedAt: number;
+}
+
+export interface RevealEntry {
+  vote: VoteValue;
+  salt: string;
+  revealedAt: number;
+}
+
+export interface RoundConfig {
+  roundId: string;
+  validators: string[];
+  commitDeadline: number;
+  revealDeadline: number;
+  quorum: number;
+  penaltyPercentage: number;
+}
+
+export interface RoundResult {
+  roundId: string;
+  consensus: VoteValue;
+  totalReveals: number;
+  slashed: string[];
+}
+
+function computeCommit(vote: VoteValue, salt: string): string {
+  return keccak256(toUtf8Bytes(`${vote}:${salt}`));
+}
+
+export class CommitRevealRound {
+  private readonly commits = new Map<string, CommitEntry>();
+  private readonly reveals = new Map<string, RevealEntry>();
+  private phase: "commit" | "reveal" | "finalized" = "commit";
+
+  constructor(
+    private readonly config: RoundConfig,
+    private readonly stakeManager: StakeManager,
+    private readonly bus: EventBus,
+  ) {}
+
+  commit(address: string, vote: VoteValue, salt: string, now: number): void {
+    if (this.phase !== "commit") {
+      throw new Error(`Round ${this.config.roundId} not in commit phase`);
+    }
+    if (!this.config.validators.includes(address)) {
+      throw new Error(`Validator ${address} not assigned to round ${this.config.roundId}`);
+    }
+    if (now > this.config.commitDeadline) {
+      throw new Error(`Commit deadline exceeded for round ${this.config.roundId}`);
+    }
+    const hash = computeCommit(vote, salt);
+    this.commits.set(address, { commitHash: hash, committedAt: now });
+    this.bus.emit("ValidatorCommitted", { roundId: this.config.roundId, validator: address, commitHash: hash });
+  }
+
+  advancePhase(now: number): void {
+    if (this.phase === "commit" && now >= this.config.commitDeadline) {
+      this.phase = "reveal";
+    }
+    if (this.phase === "reveal" && now >= this.config.revealDeadline) {
+      this.phase = "finalized";
+    }
+  }
+
+  reveal(address: string, vote: VoteValue, salt: string, now: number): void {
+    if (this.phase === "commit") {
+      throw new Error(`Round ${this.config.roundId} not yet in reveal phase`);
+    }
+    if (this.phase === "finalized") {
+      throw new Error(`Round ${this.config.roundId} already finalized`);
+    }
+    const commit = this.commits.get(address);
+    if (!commit) {
+      throw new Error(`Validator ${address} has no commit for round ${this.config.roundId}`);
+    }
+    const expected = computeCommit(vote, salt);
+    if (expected !== commit.commitHash) {
+      throw new Error(`Reveal mismatch for validator ${address}`);
+    }
+    if (now > this.config.revealDeadline) {
+      throw new Error(`Reveal deadline exceeded for round ${this.config.roundId}`);
+    }
+    this.reveals.set(address, { vote, salt, revealedAt: now });
+    this.bus.emit("ValidatorRevealed", { roundId: this.config.roundId, validator: address, vote });
+  }
+
+  finalize(truth: VoteValue): RoundResult {
+    if (this.phase !== "finalized") {
+      throw new Error(`Round ${this.config.roundId} cannot be finalised during ${this.phase}`);
+    }
+    const reveals = Array.from(this.reveals.entries());
+    if (reveals.length < this.config.quorum) {
+      throw new Error(`Round ${this.config.roundId} did not reach quorum`);
+    }
+    const slashed: string[] = [];
+    for (const validator of this.config.validators) {
+      if (!this.reveals.has(validator)) {
+        this.stakeManager.slash(validator, this.config.penaltyPercentage, "NonReveal");
+        slashed.push(validator);
+      }
+    }
+    for (const [validator, reveal] of reveals) {
+      if (reveal.vote !== truth) {
+        this.stakeManager.slash(validator, this.config.penaltyPercentage, "DishonestVote");
+        slashed.push(validator);
+      }
+    }
+    return { roundId: this.config.roundId, consensus: truth, totalReveals: reveals.length, slashed };
+  }
+}
+
+export function deriveCommit(vote: VoteValue, salt: string): string {
+  return computeCommit(vote, salt);
+}

--- a/demo/Validator-Constellation-v0/src/identity/EnsRegistry.ts
+++ b/demo/Validator-Constellation-v0/src/identity/EnsRegistry.ts
@@ -1,0 +1,103 @@
+import { keccak256, toUtf8Bytes } from "ethers";
+
+export type EnsRole = "validator" | "agent" | "node";
+
+export interface EnsRecord {
+  name: string;
+  owner: string;
+  role: EnsRole;
+  merkleProof?: string[];
+}
+
+const VALIDATOR_ROOTS = ["club.agi.eth", "alpha.club.agi.eth"];
+const AGENT_ROOTS = ["agent.agi.eth", "alpha.agent.agi.eth"];
+const NODE_ROOTS = ["node.agi.eth", "alpha.node.agi.eth"];
+
+function normaliseAddress(address: string): string {
+  if (!/^0x[a-fA-F0-9]{40}$/.test(address)) {
+    throw new Error(`Invalid address ${address}`);
+  }
+  return address.toLowerCase();
+}
+
+function ensureSubdomain(name: string, root: string): boolean {
+  if (!name.toLowerCase().endsWith(root)) {
+    return false;
+  }
+  const prefix = name.slice(0, name.length - root.length);
+  return prefix.length > 1 && prefix.endsWith(".");
+}
+
+function buildLeaf(name: string, owner: string): string {
+  return keccak256(toUtf8Bytes(`${name.toLowerCase()}::${normaliseAddress(owner)}`));
+}
+
+export class EnsRegistry {
+  private readonly records = new Map<string, EnsRecord>();
+  private readonly blacklist = new Set<string>();
+
+  constructor(initialRecords: EnsRecord[] = []) {
+    initialRecords.forEach((record) => this.register(record));
+  }
+
+  register(record: EnsRecord): void {
+    const nameKey = record.name.toLowerCase();
+    if (!this.isValidForRole(record.name, record.role)) {
+      throw new Error(`ENS name ${record.name} does not satisfy naming policy for role ${record.role}`);
+    }
+    const owner = normaliseAddress(record.owner);
+    this.records.set(nameKey, { ...record, owner });
+  }
+
+  blacklistAddress(address: string): void {
+    this.blacklist.add(normaliseAddress(address));
+  }
+
+  isAuthorised(address: string, name: string, role: EnsRole, merkleRoot?: string): boolean {
+    if (this.blacklist.has(normaliseAddress(address))) {
+      return false;
+    }
+    const nameKey = name.toLowerCase();
+    const record = this.records.get(nameKey);
+    if (!record || record.role !== role) {
+      return false;
+    }
+    if (record.owner !== normaliseAddress(address)) {
+      return false;
+    }
+    if (record.merkleProof && merkleRoot) {
+      return this.verifyMerkleProof(name, record.owner, record.merkleProof, merkleRoot);
+    }
+    return true;
+  }
+
+  assertAuthorised(address: string, name: string, role: EnsRole, merkleRoot?: string): void {
+    if (!this.isAuthorised(address, name, role, merkleRoot)) {
+      throw new Error(`Address ${address} is not authorised to operate as ${role} using ${name}`);
+    }
+  }
+
+  verifyMerkleProof(name: string, owner: string, proof: string[], root: string): boolean {
+    let computed = buildLeaf(name, owner);
+    for (const sibling of proof) {
+      const [lower, upper] = [computed, sibling].sort();
+      computed = keccak256(toUtf8Bytes(`${lower}:${upper}`));
+    }
+    return computed === root;
+  }
+
+  isValidForRole(name: string, role: EnsRole): boolean {
+    const roots = role === "validator" ? VALIDATOR_ROOTS : role === "agent" ? AGENT_ROOTS : NODE_ROOTS;
+    return roots.some((root) => ensureSubdomain(name, root));
+  }
+
+  list(role?: EnsRole): EnsRecord[] {
+    return Array.from(this.records.values()).filter((record) => !role || record.role === role);
+  }
+}
+
+export const ensPolicies = {
+  validatorRoots: VALIDATOR_ROOTS,
+  agentRoots: AGENT_ROOTS,
+  nodeRoots: NODE_ROOTS,
+};

--- a/demo/Validator-Constellation-v0/src/index.ts
+++ b/demo/Validator-Constellation-v0/src/index.ts
@@ -1,0 +1,167 @@
+import { CommitRevealRound, RoundConfig, VoteValue, deriveCommit } from "./commitReveal/CommitReveal";
+import { EnsRegistry, EnsRecord } from "./identity/EnsRegistry";
+import { DomainPauseController } from "./pause/DomainPauseController";
+import { budgetMonitor, forbiddenCallMonitor, Sentinel, AgentAction } from "./sentinel/Sentinel";
+import { StakeManager } from "./staking/StakeManager";
+import { EventBus } from "./subgraph/EventBus";
+import { SubgraphIndexer } from "./subgraph/SubgraphIndexer";
+import { ValidatorCandidate, VrfCommitteeSelector } from "./vrf/VrfCommittee";
+import { BatchProof, JobResult, ZkBatchAttestor } from "./zk/ZkBatcher";
+
+export interface ValidatorProfile {
+  address: string;
+  ensName: string;
+  stake: bigint;
+  domain: string;
+}
+
+export interface AgentProfile {
+  address: string;
+  ensName: string;
+  domain: string;
+  budget: number;
+}
+
+export interface NodeProfile {
+  address: string;
+  ensName: string;
+  domain: string;
+}
+
+export interface DemoConfig {
+  committeeSize: number;
+  commitPhaseMs: number;
+  revealPhaseMs: number;
+  quorum: number;
+  penaltyPercentage: number;
+  sentinelSlaMs: number;
+  spendingLimit: number;
+}
+
+export interface RoundExecutionOptions {
+  malicious?: Record<string, "nonReveal" | "dishonest">;
+  secretSalt?: Record<string, string>;
+}
+
+export interface RoundOutcome {
+  proof: BatchProof;
+  roundId: string;
+  validators: ValidatorCandidate[];
+  consensus: VoteValue;
+  slashed: string[];
+}
+
+export class ValidatorConstellationDemo {
+  readonly bus = new EventBus();
+  readonly indexer = new SubgraphIndexer(this.bus);
+  readonly ensRegistry: EnsRegistry;
+  readonly pauseController = new DomainPauseController(this.bus);
+  readonly sentinel: Sentinel;
+  readonly stakeManager: StakeManager;
+  readonly vrfSelector: VrfCommitteeSelector;
+  readonly zkBatcher: ZkBatchAttestor;
+
+  private readonly validators = new Map<string, ValidatorProfile>();
+  private readonly agents = new Map<string, AgentProfile>();
+  private readonly nodes = new Map<string, NodeProfile>();
+
+  constructor(private readonly config: DemoConfig, ensRecords: EnsRecord[]) {
+    this.ensRegistry = new EnsRegistry(ensRecords);
+    this.stakeManager = new StakeManager(this.bus);
+    this.sentinel = new Sentinel(this.bus, this.pauseController, config.sentinelSlaMs);
+    this.sentinel.registerMonitor("budget", budgetMonitor(config.spendingLimit));
+    this.sentinel.registerMonitor("forbidden", forbiddenCallMonitor());
+    this.vrfSelector = new VrfCommitteeSelector(config.committeeSize);
+    this.zkBatcher = new ZkBatchAttestor(this.bus);
+  }
+
+  registerValidator(profile: ValidatorProfile): void {
+    this.ensRegistry.assertAuthorised(profile.address, profile.ensName, "validator");
+    this.validators.set(profile.address, profile);
+    this.stakeManager.deposit(profile.address, profile.stake);
+    this.bus.emit("ValidatorRegistered", { address: profile.address, ens: profile.ensName, stake: profile.stake.toString() });
+  }
+
+  registerAgent(profile: AgentProfile): void {
+    this.ensRegistry.assertAuthorised(profile.address, profile.ensName, "agent");
+    this.agents.set(profile.address, profile);
+  }
+
+  registerNode(profile: NodeProfile): void {
+    this.ensRegistry.assertAuthorised(profile.address, profile.ensName, "node");
+    this.nodes.set(profile.address, profile);
+  }
+
+  dispatchAgentAction(action: AgentAction): void {
+    const agent = this.agents.get(action.agent);
+    if (!agent) {
+      throw new Error(`Unknown agent ${action.agent}`);
+    }
+    if (agent.domain !== action.domain) {
+      throw new Error(`Agent ${agent.ensName} cannot operate in domain ${action.domain}`);
+    }
+    const node = this.nodes.get(action.node);
+    if (!node) {
+      throw new Error(`Unknown node ${action.node}`);
+    }
+    if (node.domain !== action.domain) {
+      throw new Error(`Node ${node.ensName} cannot operate in domain ${action.domain}`);
+    }
+    this.sentinel.evaluate(action);
+  }
+
+  runValidationRound(
+    roundId: string,
+    seed: string,
+    jobResults: JobResult[],
+    truth: VoteValue,
+    options: RoundExecutionOptions = {},
+  ): RoundOutcome {
+    const committee = this.formCommittee(seed);
+    const now = Date.now();
+    const roundConfig: RoundConfig = {
+      roundId,
+      validators: committee.map((member) => member.address),
+      commitDeadline: now + this.config.commitPhaseMs,
+      revealDeadline: now + this.config.commitPhaseMs + this.config.revealPhaseMs,
+      quorum: this.config.quorum,
+      penaltyPercentage: this.config.penaltyPercentage,
+    };
+    const round = new CommitRevealRound(roundConfig, this.stakeManager, this.bus);
+    for (const member of committee) {
+      const behaviour = options.malicious?.[member.address];
+      const salt = options.secretSalt?.[member.address] ?? `${roundId}:${member.address}`;
+      const vote = behaviour === "dishonest" ? (truth === "approve" ? "reject" : "approve") : truth;
+      round.commit(member.address, vote, salt, now + 1);
+    }
+    round.advancePhase(roundConfig.commitDeadline + 1);
+    for (const member of committee) {
+      const behaviour = options.malicious?.[member.address];
+      if (behaviour === "nonReveal") {
+        continue;
+      }
+      const salt = options.secretSalt?.[member.address] ?? `${roundId}:${member.address}`;
+      const vote = behaviour === "dishonest" ? (truth === "approve" ? "reject" : "approve") : truth;
+      round.reveal(member.address, vote, salt, now + this.config.commitPhaseMs + 1);
+    }
+    round.advancePhase(roundConfig.revealDeadline + 1);
+    const result = round.finalize(truth);
+    const proof = this.zkBatcher.buildProof(jobResults, `${roundId}-proof-secret`);
+    return { proof, roundId, validators: committee, consensus: truth, slashed: result.slashed };
+  }
+
+  private formCommittee(seed: string): ValidatorCandidate[] {
+    const candidates = Array.from(this.validators.values()).map(
+      (validator) =>
+        ({
+          address: validator.address,
+          ensName: validator.ensName,
+          stake: this.stakeManager.balanceOf(validator.address),
+        }) satisfies ValidatorCandidate,
+    );
+    return this.vrfSelector.select(seed, candidates).selected;
+  }
+}
+
+export { deriveCommit };
+export type { BatchProof, JobResult };

--- a/demo/Validator-Constellation-v0/src/pause/DomainPauseController.ts
+++ b/demo/Validator-Constellation-v0/src/pause/DomainPauseController.ts
@@ -1,0 +1,47 @@
+import { EventBus } from "../subgraph/EventBus";
+
+export interface DomainState {
+  domain: string;
+  paused: boolean;
+  reason?: string;
+  triggeredAt?: number;
+}
+
+export class DomainPauseController {
+  private readonly states = new Map<string, DomainState>();
+
+  constructor(private readonly bus: EventBus) {}
+
+  ensure(domain: string): DomainState {
+    if (!this.states.has(domain)) {
+      this.states.set(domain, { domain, paused: false });
+    }
+    return this.states.get(domain)!;
+  }
+
+  isPaused(domain: string): boolean {
+    return this.states.get(domain)?.paused ?? false;
+  }
+
+  pause(domain: string, reason: string): DomainState {
+    const state = this.ensure(domain);
+    state.paused = true;
+    state.reason = reason;
+    state.triggeredAt = Date.now();
+    this.bus.emit("DomainPaused", { domain, reason });
+    return state;
+  }
+
+  resume(domain: string): DomainState {
+    const state = this.ensure(domain);
+    state.paused = false;
+    state.reason = undefined;
+    state.triggeredAt = undefined;
+    this.bus.emit("DomainResumed", { domain });
+    return state;
+  }
+
+  all(): DomainState[] {
+    return Array.from(this.states.values());
+  }
+}

--- a/demo/Validator-Constellation-v0/src/sentinel/Sentinel.ts
+++ b/demo/Validator-Constellation-v0/src/sentinel/Sentinel.ts
@@ -1,0 +1,81 @@
+import { DomainPauseController } from "../pause/DomainPauseController";
+import { EventBus } from "../subgraph/EventBus";
+
+export interface AgentAction {
+  domain: string;
+  agent: string;
+  node: string;
+  cost: number;
+  call: string;
+  metadata?: Record<string, unknown>;
+  timestamp: number;
+}
+
+export interface SentinelFinding {
+  monitor: string;
+  reason: string;
+  severity: "critical" | "high" | "medium";
+}
+
+export type SentinelMonitor = (action: AgentAction) => SentinelFinding | undefined;
+
+export class Sentinel {
+  private readonly monitors = new Map<string, SentinelMonitor>();
+
+  constructor(
+    private readonly bus: EventBus,
+    private readonly pauseController: DomainPauseController,
+    private readonly slaMilliseconds: number,
+  ) {}
+
+  registerMonitor(name: string, monitor: SentinelMonitor): void {
+    this.monitors.set(name, monitor);
+  }
+
+  evaluate(action: AgentAction): SentinelFinding | undefined {
+    if (this.pauseController.isPaused(action.domain)) {
+      return undefined;
+    }
+    for (const [name, monitor] of this.monitors) {
+      const finding = monitor(action);
+      if (finding) {
+        const elapsed = Date.now() - action.timestamp;
+        if (elapsed > this.slaMilliseconds) {
+          throw new Error(`Sentinel SLA breached for monitor ${name}`);
+        }
+        this.pauseController.pause(action.domain, finding.reason);
+        this.bus.emit("SentinelAlert", { ...finding, domain: action.domain, agent: action.agent, elapsed });
+        return finding;
+      }
+    }
+    return undefined;
+  }
+}
+
+export function budgetMonitor(maxBudget: number): SentinelMonitor {
+  return (action) => {
+    if (action.cost > maxBudget) {
+      return {
+        monitor: "budget-overrun",
+        reason: `Action exceeded budget: ${action.cost} > ${maxBudget}`,
+        severity: "critical",
+      } satisfies SentinelFinding;
+    }
+    return undefined;
+  };
+}
+
+const FORBIDDEN_CALLS = new Set(["fs.writeFile", "process.exec", "selfDestruct"]);
+
+export function forbiddenCallMonitor(): SentinelMonitor {
+  return (action) => {
+    if (FORBIDDEN_CALLS.has(action.call)) {
+      return {
+        monitor: "forbidden-call",
+        reason: `Action attempted forbidden call ${action.call}`,
+        severity: "high",
+      } satisfies SentinelFinding;
+    }
+    return undefined;
+  };
+}

--- a/demo/Validator-Constellation-v0/src/staking/StakeManager.ts
+++ b/demo/Validator-Constellation-v0/src/staking/StakeManager.ts
@@ -1,0 +1,75 @@
+import { EventBus } from "../subgraph/EventBus";
+
+export interface StakePosition {
+  address: string;
+  stake: bigint;
+  frozenUntil?: number;
+}
+
+export interface SlashResult {
+  slashed: bigint;
+  remaining: bigint;
+}
+
+export class StakeManager {
+  private readonly stakes = new Map<string, StakePosition>();
+
+  constructor(private readonly bus: EventBus, initialStakes: StakePosition[] = []) {
+    initialStakes.forEach((position) => this.deposit(position.address, position.stake));
+  }
+
+  deposit(address: string, amount: bigint): StakePosition {
+    if (amount <= 0n) {
+      throw new Error("Stake amount must be positive");
+    }
+    const key = address.toLowerCase();
+    const current = this.stakes.get(key) ?? { address: key, stake: 0n };
+    const updated = { ...current, stake: current.stake + amount } satisfies StakePosition;
+    this.stakes.set(key, updated);
+    return updated;
+  }
+
+  balanceOf(address: string): bigint {
+    return this.stakes.get(address.toLowerCase())?.stake ?? 0n;
+  }
+
+  slash(address: string, percentage: number, reason: string): SlashResult {
+    if (percentage <= 0 || percentage > 100) {
+      throw new Error("Slashing percentage must be within (0,100]");
+    }
+    const key = address.toLowerCase();
+    const record = this.stakes.get(key);
+    if (!record) {
+      throw new Error(`Validator ${address} has no stake to slash`);
+    }
+    const slashed = (record.stake * BigInt(Math.round(percentage * 100))) / 10000n;
+    const remaining = record.stake - slashed;
+    record.stake = remaining;
+    this.bus.emit("ValidatorSlashed", {
+      address: key,
+      percentage,
+      slashed: slashed.toString(),
+      remaining: remaining.toString(),
+      reason,
+    });
+    return { slashed, remaining };
+  }
+
+  freeze(address: string, until: number): void {
+    const key = address.toLowerCase();
+    const record = this.stakes.get(key);
+    if (!record) {
+      throw new Error(`Validator ${address} has no stake to freeze`);
+    }
+    record.frozenUntil = until;
+  }
+
+  isFrozen(address: string, at: number): boolean {
+    const record = this.stakes.get(address.toLowerCase());
+    return record?.frozenUntil !== undefined && (record.frozenUntil ?? 0) > at;
+  }
+
+  list(): StakePosition[] {
+    return Array.from(this.stakes.values());
+  }
+}

--- a/demo/Validator-Constellation-v0/src/subgraph/EventBus.ts
+++ b/demo/Validator-Constellation-v0/src/subgraph/EventBus.ts
@@ -1,0 +1,40 @@
+export type EventTopic =
+  | "ValidatorRegistered"
+  | "ValidatorCommitted"
+  | "ValidatorRevealed"
+  | "ValidatorSlashed"
+  | "BatchProofSubmitted"
+  | "DomainPaused"
+  | "DomainResumed"
+  | "SentinelAlert";
+
+export interface EventPayload {
+  readonly topic: EventTopic;
+  readonly timestamp: number;
+  readonly data: Record<string, unknown>;
+}
+
+export type EventListener = (event: EventPayload) => void;
+
+export class EventBus {
+  private readonly listeners = new Set<EventListener>();
+  private readonly events: EventPayload[] = [];
+
+  emit(topic: EventTopic, data: Record<string, unknown>): EventPayload {
+    const event = { topic, data, timestamp: Date.now() } satisfies EventPayload;
+    this.events.push(event);
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+    return event;
+  }
+
+  subscribe(listener: EventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  all(topic?: EventTopic): EventPayload[] {
+    return topic ? this.events.filter((event) => event.topic === topic) : [...this.events];
+  }
+}

--- a/demo/Validator-Constellation-v0/src/subgraph/SubgraphIndexer.ts
+++ b/demo/Validator-Constellation-v0/src/subgraph/SubgraphIndexer.ts
@@ -1,0 +1,27 @@
+import { EventBus, EventPayload, EventTopic } from "./EventBus";
+
+export interface IndexedEvent extends EventPayload {
+  blockNumber: number;
+}
+
+export class SubgraphIndexer {
+  private readonly timeline: IndexedEvent[] = [];
+  private blockNumber = 0;
+
+  constructor(private readonly bus: EventBus) {
+    this.bus.subscribe((event) => this.capture(event));
+  }
+
+  private capture(event: EventPayload): void {
+    const indexed: IndexedEvent = { ...event, blockNumber: ++this.blockNumber };
+    this.timeline.push(indexed);
+  }
+
+  query(topic: EventTopic): IndexedEvent[] {
+    return this.timeline.filter((event) => event.topic === topic);
+  }
+
+  latest(): IndexedEvent | undefined {
+    return this.timeline.at(-1);
+  }
+}

--- a/demo/Validator-Constellation-v0/src/vrf/VrfCommittee.ts
+++ b/demo/Validator-Constellation-v0/src/vrf/VrfCommittee.ts
@@ -1,0 +1,42 @@
+import { keccak256, solidityPacked, toBigInt, toBeHex } from "ethers";
+
+export interface ValidatorCandidate {
+  address: string;
+  stake: bigint;
+  ensName: string;
+}
+
+export interface CommitteeSelectionResult {
+  randomness: string;
+  selected: ValidatorCandidate[];
+}
+
+export class VrfCommitteeSelector {
+  constructor(private readonly committeeSize: number) {
+    if (committeeSize <= 0) {
+      throw new Error("Committee size must be positive");
+    }
+  }
+
+  select(seed: string, validators: ValidatorCandidate[]): CommitteeSelectionResult {
+    if (!/^0x[0-9a-fA-F]{64}$/.test(seed)) {
+      throw new Error("Seed must be 32-byte hex string");
+    }
+    if (validators.length < this.committeeSize) {
+      throw new Error("Insufficient validators for committee");
+    }
+    const entropy = keccak256(solidityPacked(["bytes32", "uint256"], [seed, validators.length]));
+    const scored = validators.map((candidate, index) => {
+      const personalEntropy = keccak256(
+        solidityPacked(["bytes32", "address", "uint256"], [entropy, candidate.address, index]),
+      );
+      const combined = toBigInt(personalEntropy) ^ (candidate.stake << 32n);
+      return { candidate, personalEntropy, combined };
+    });
+    scored.sort((a, b) => (a.combined < b.combined ? -1 : a.combined > b.combined ? 1 : 0));
+    return {
+      randomness: toBeHex(toBigInt(entropy)),
+      selected: scored.slice(0, this.committeeSize).map((entry) => entry.candidate),
+    };
+  }
+}

--- a/demo/Validator-Constellation-v0/src/zk/ZkBatcher.ts
+++ b/demo/Validator-Constellation-v0/src/zk/ZkBatcher.ts
@@ -1,0 +1,61 @@
+import { keccak256, solidityPacked } from "ethers";
+import { EventBus } from "../subgraph/EventBus";
+import { VoteValue } from "../commitReveal/CommitReveal";
+
+export interface JobResult {
+  jobId: string;
+  domain: string;
+  vote: VoteValue;
+  witness: string;
+}
+
+export interface BatchProof {
+  readonly batchId: string;
+  readonly jobs: number;
+  readonly aggregateHash: string;
+  readonly commitment: string;
+}
+
+export class ZkBatchAttestor {
+  constructor(private readonly bus: EventBus, private readonly capacity = 1000) {}
+
+  buildProof(results: JobResult[], secret: string): BatchProof {
+    if (results.length === 0) {
+      throw new Error("Batch must contain at least one job result");
+    }
+    if (results.length > this.capacity) {
+      throw new Error(`Batch exceeds capacity of ${this.capacity} jobs`);
+    }
+    const aggregateHash = this.aggregate(results);
+    const commitment = keccak256(solidityPacked(["bytes32", "string"], [aggregateHash, secret]));
+    const proof: BatchProof = {
+      batchId: keccak256(solidityPacked(["bytes32", "uint256"], [aggregateHash, results.length])),
+      jobs: results.length,
+      aggregateHash,
+      commitment,
+    };
+    this.bus.emit("BatchProofSubmitted", { batchId: proof.batchId, jobs: proof.jobs });
+    return proof;
+  }
+
+  verify(results: JobResult[], proof: BatchProof, secret: string): boolean {
+    if (results.length !== proof.jobs) {
+      return false;
+    }
+    const aggregateHash = this.aggregate(results);
+    if (aggregateHash !== proof.aggregateHash) {
+      return false;
+    }
+    const expectedCommitment = keccak256(solidityPacked(["bytes32", "string"], [aggregateHash, secret]));
+    return expectedCommitment === proof.commitment;
+  }
+
+  private aggregate(results: JobResult[]): string {
+    let accumulator = "0x" + "00".repeat(32);
+    for (const result of results) {
+      const jobHash = keccak256(solidityPacked(["string", "string", "string"], [result.jobId, result.domain, result.vote]));
+      accumulator = keccak256(solidityPacked(["bytes32", "bytes32", "string"], [accumulator, jobHash, result.witness]));
+    }
+    return accumulator;
+  }
+}

--- a/demo/Validator-Constellation-v0/tsconfig.json
+++ b/demo/Validator-Constellation-v0/tsconfig.json
@@ -1,21 +1,21 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "module": "commonjs",
+    "target": "ES2022",
     "rootDir": "./",
     "outDir": "./dist",
-    "composite": false,
-    "module": "CommonJS",
-    "moduleResolution": "node",
-    "target": "ES2022",
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
     "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "declaration": false,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["src/**/*", "scripts/**/*", "tests/**/*"],
+  "include": ["src", "scripts", "tests"],
   "ts-node": {
-    "swc": false
+    "compilerOptions": {
+      "module": "commonjs"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add the Validator-Constellation-v0 demo showcasing VRF committee selection, commit–reveal validation, sentinel brakes, ENS-gated identities, and ZK batch attestations
- deliver a turnkey runDemo script and rich README documentation with architecture and safety flow mermaid diagrams
- introduce comprehensive TypeScript specs covering ENS compliance, slashing, ZK batching throughput, sentinel pauses, and subgraph event capture

## Testing
- npm run lint:validator-constellation
- npm run test:validator-constellation
- npm run demo:validator-constellation

------
https://chatgpt.com/codex/tasks/task_e_68ff969ad3508333b093ead1a6fd05ab