### PR TITLE
Add Kardashev-II Omega-Grade Upgrade v7 demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/README.md
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/README.md
@@ -1,0 +1,113 @@
+# Kardashev-II Omega-Grade Upgrade for α-AGI Business 3 · V7
+
+> **Purpose.** Exhibit how a non-technical operator can wield **AGI Jobs v0 (v2)** to command a Kardashev-II, Omega-grade enterprise with day-long autonomy, recursive labour markets, planetary tokenomics, and sovereign validator governance from a single, human-friendly console.
+
+## 🌌 Mission Overview
+
+V7 rebuilds the mission core around a **Long-Run Orchestrator** capable of operating for days without intervention. Every cycle checkpoints planetary state, job graphs, validator stakes, and energy reserves so the mission can be paused, migrated, or resumed instantly. Recursive agents publish sub-jobs onto a structured A2A bus, validators guard outcomes with commit–reveal, and the operator retains total control through pause, resume, and emergency stop channels.
+
+```mermaid
+flowchart TD
+    operator[(Operator Treasury)] --> wizard[MissionWizard Ω7 Presets]
+    wizard --> manifest[(Mission Manifest JSON)]
+    operator --> controls["Owner Control Stream"]
+    controls --> guardian{{"Autonomy Guardian Ω7"}}
+    guardian --> orchestrator{{"Long-Run Ω-Orchestrator"}}
+    orchestrator --> ledger[("Planetary Ledger & Vaults")]
+    orchestrator --> jobgraph[["Recursive Job Graph"]]
+    orchestrator --> council["Validator Council"]
+    orchestrator --> resources["Resource Governor"]
+    orchestrator --> bus["A2A Pub/Sub"]
+    orchestrator --> sim["Planetary Simulation Bridge"]
+    council --> staking[("Stake Pools & Commit/Reveal")]
+    jobgraph --> agents{{"Autonomous Agent Swarms"}}
+    bus --> agents
+    sim --> telemetry["Simulation Telemetry"]
+    ledger --> ui[["Mission Control UI"]]
+```
+
+## ✨ Key Capabilities
+
+- **Long-run autonomy.** Resilient loops, async scheduling, and rotating vault checkpoints keep the mission running for hours or days without manual babysitting.
+- **Recursive job graph.** Agents spawn child jobs with explicit parent tracking; results propagate upwards automatically and surface in a Mermaid DAG.
+- **Tokenised resource economics.** Every task consumes energy/compute credits priced dynamically against global supply. Stakes, rewards, and burns execute through the Resource Governor.
+- **A2A mesh.** Agents subscribe to skill/topic channels and barter work via signed messages on an in-process pub/sub bus or optional gRPC transport.
+- **Validator council.** Commit–reveal audits, quorum tracking, and slashing policies ensure only honest work is finalised – with operator-tunable parameters.
+- **Planetary simulation bridge.** Plug in planetary-scale simulations (synthetic economy, power grids) whose state feeds resource ceilings, dashboards, and job strategies.
+- **Owner supremacy.** Human operators retain explicit pause/resume/emergency stop verbs plus declarative governance controls over all mission parameters.
+
+## 🚀 Quickstart
+
+```bash
+# Install agent dependencies (virtualenv recommended)
+pip install -r requirements-agent.txt
+
+# Launch the Omega-grade demo with the default mission
+yarn demo:kardashev-ii-omega-upgrade-v7 -- launch
+
+# Stream telemetry, job graph Mermaid, and guardian insights
+yarn demo:kardashev-ii-omega-upgrade-v7 -- status
+
+# Generate a tailored mission preset without editing JSON
+yarn demo:kardashev-ii-omega-upgrade-v7 -- wizard --preset sovereign-grid --output mission.sovereign-grid.json
+
+# Operate the owner channel (pause/resume/emergency-stop)
+yarn demo:kardashev-ii-omega-upgrade-v7 -- owner pause
+yarn demo:kardashev-ii-omega-upgrade-v7 -- owner resume
+yarn demo:kardashev-ii-omega-upgrade-v7 -- owner emergency-stop
+```
+
+## 🧭 Owner Command Reference
+
+| Command | Effect |
+| --- | --- |
+| `owner governance --worker-stake-ratio 0.25` | Tune worker staking ratio |
+| `owner governance --validator-quorum 0.67` | Adjust validator quorum threshold |
+| `owner resources --energy-capacity 3e6 --compute-capacity 8e6` | Expand planetary ceilings |
+| `owner mission --checkpoint-interval 60 --state-history 4096` | Tune long-run checkpoint cadence |
+| `owner mission --background-limit 128 --delegation-retry 30` | Resize background pools and delegation cadence |
+| `owner mission --simulation-tick 15 --simulation-hours 6` | Configure simulation bridge cadence |
+| `owner mission --validator-commit 900 --validator-reveal 1500` | Redefine council timing windows |
+| `owner mission --continuity-interval 120 --continuity-history 8192` | Tune vault replication cadence |
+| `owner autonomy --guardian-interval 5 --resource-target 0.82` | Adjust guardian vigilance |
+| `owner account operator --tokens 3e6` | Top up operator treasury |
+| `owner cancel JOB_ID --reason "Operator veto"` | Cancel any job with slash-safe audit |
+
+Commands append JSONL entries to the control stream for audit, replay, and CI verification.
+
+## 🛡️ Resilience & Auditability
+
+- **Triple vaults.** `continuity-primary.json`, `continuity-secondary.json`, and `continuity-tertiary.json` replicate state with integrity hashes.
+- **State checkpoints.** `state-checkpoint.json` and `state-history.jsonl` ensure resumability after any outage.
+- **Long-run ledger.** JSONL feeds capture resource posture, validator posture, and guardian notices for dashboards.
+- **Job graph exports.** `job-graph.mmd` and `job-graph.json` document recursive job relationships at every cycle.
+- **Structured logging.** `structured-log.jsonl` delivers JSON logs ready for SIEM pipelines.
+- **CI mode.** `yarn demo:kardashev-ii-omega-upgrade-v7 -- ci` executes a deterministic, quick mission for automated verification.
+
+## 🖥️ Mission Artifacts
+
+Artifacts default to `demo/.../artifacts/`:
+
+- `status/omega-upgrade-v7/telemetry.json` – full mission snapshot
+- `status/omega-upgrade-v7/telemetry-ui.json` – UI-friendly payload
+- `status/omega-upgrade-v7/job-graph.mmd` – Mermaid job DAG
+- `status/omega-upgrade-v7/job-graph.json` – Structured job DAG export
+- `status/omega-upgrade-v7/autonomy-plan.json` – guardian plan of record
+- `status/omega-upgrade-v7/autonomy-history.jsonl` – guardian history stream
+- `status/omega-upgrade-v7/storyboard.json` – latest human-readable narrative
+- `status/omega-upgrade-v7/storyboard-history.jsonl` – storyboard ledger
+- `status/omega-upgrade-v7/insights.jsonl` – recommended action journal
+- `status/omega-upgrade-v7/long-run-ledger.jsonl` – rotating long-run ledger
+- `status/omega-upgrade-v7/state-checkpoint.json` – latest planetary checkpoint
+- `status/omega-upgrade-v7/state-history.jsonl` – rolling state history stream
+- `status/omega-upgrade-v7/continuity-primary.json` – primary vault snapshot (with `secondary` & `tertiary` siblings)
+- `status/omega-upgrade-v7/structured-log.jsonl` – JSONL mission log stream
+
+## ✅ Designed for Non-Technical Operators
+
+- **MissionWizard** delivers point-and-click presets for complex orchestration without editing YAML/JSON by hand.
+- **Mission Control UI** renders confidence, validation, energy posture, and delegation health with zero manual wiring.
+- **Owner supremacy** keeps pause/resume/stop/emergency-stop, governance tweaks, resource scaling, autonomy tuning, account management, and job cancellation at your fingertips.
+- **Production ready.** Aligns with AGI Jobs v0 (v2) primitives and mainnet-ready infrastructure: staking, slashing, audits, resource tokenomics, and day-long autonomy.
+
+Harness the V7 upgrade to prove that AGI Jobs v0 (v2) empowers any operator to command planetary-scale AGI businesses with unprecedented clarity, sovereignty, and economic integrity.

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/__init__.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/__init__.py
@@ -1,0 +1,7 @@
+"""Kardashev-II Omega-Grade Upgrade v7 demo package."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.7.0"

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/__main__.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/__main__.py
@@ -1,0 +1,9 @@
+"""Module entrypoint for ``python -m`` execution."""
+
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/bin/launch.sh
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/bin/launch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+python -m kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7.cli launch --config "${DEMO_ROOT}/config/mission.json" "$@"

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/cli.py
@@ -1,0 +1,458 @@
+"""Command-line entry point for the Ω-grade upgrade v7 demonstration."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo.owner import (
+    OwnerCommandStream,
+)
+
+from .config import OmegaOrchestratorV7Config, load_config
+from .orchestrator import OmegaUpgradeV7Orchestrator
+from .wizard import MissionWizard
+
+PACKAGE_ROOT = Path(__file__).resolve().parent
+DEFAULT_CONFIG = PACKAGE_ROOT / "config" / "mission.json"
+CI_CONFIG = PACKAGE_ROOT / "config" / "ci.json"
+WIZARD_OUTPUT = PACKAGE_ROOT / "config" / "mission.generated.json"
+
+try:
+    _DEFAULT_PRESETS = tuple(sorted(MissionWizard.from_path(DEFAULT_CONFIG).presets()))
+except FileNotFoundError:  # pragma: no cover - fallback for packaging environments
+    _DEFAULT_PRESETS = ("sovereign", "consortium", "galactic")
+
+
+async def _run_orchestrator(config: OmegaOrchestratorV7Config) -> None:
+    orchestrator = OmegaUpgradeV7Orchestrator(config)
+    await orchestrator.start()
+    try:
+        await orchestrator.wait_until_stopped()
+    except KeyboardInterrupt:  # pragma: no cover - interactive guard
+        await orchestrator.shutdown()
+
+
+def _load_config(
+    path: Optional[Path], overrides: Optional[Dict[str, Any]] = None
+) -> OmegaOrchestratorV7Config:
+    config_path = path or DEFAULT_CONFIG
+    return load_config(config_path, overrides)
+
+
+def _owner_stream(config: OmegaOrchestratorV7Config) -> OwnerCommandStream:
+    return OwnerCommandStream(
+        config.control_channel_file,
+        config.owner_command_ack_path,
+    )
+
+
+def _command_launch(args: argparse.Namespace) -> None:
+    overrides: Dict[str, Any] = {}
+    if args.cycles is not None:
+        overrides["max_cycles"] = int(args.cycles)
+    if args.no_resume:
+        overrides["resume_from_checkpoint"] = False
+    if args.mission_hours is not None:
+        overrides["mission_target_hours"] = float(args.mission_hours)
+    if args.integrity_interval is not None:
+        overrides["integrity_check_interval_seconds"] = float(args.integrity_interval)
+    if args.status_path is not None:
+        overrides["status_output_path"] = str(args.status_path)
+    if args.energy_oracle is not None:
+        overrides["energy_oracle_path"] = str(args.energy_oracle)
+    if args.energy_oracle_interval is not None:
+        overrides["energy_oracle_interval_seconds"] = float(args.energy_oracle_interval)
+    if args.telemetry_interval is not None:
+        overrides["telemetry_interval_seconds"] = float(args.telemetry_interval)
+    if args.resilience_interval is not None:
+        overrides["resilience_interval_seconds"] = float(args.resilience_interval)
+    if args.resilience_retention is not None:
+        overrides["resilience_retention_lines"] = int(args.resilience_retention)
+    if args.mermaid_nodes is not None:
+        overrides["mermaid_max_nodes"] = int(args.mermaid_nodes)
+    if args.forecast_hours is not None:
+        overrides["forecast_horizon_hours"] = float(args.forecast_hours)
+    if args.guardian_interval is not None:
+        overrides["guardian_interval_seconds"] = float(args.guardian_interval)
+    if args.guardian_threshold is not None:
+        overrides["guardian_deadline_threshold_minutes"] = float(args.guardian_threshold)
+    if args.resource_feedback is not None:
+        overrides["resource_feedback_interval_seconds"] = float(args.resource_feedback)
+    if args.resource_target is not None:
+        overrides["resource_target_utilization"] = float(args.resource_target)
+    if args.resource_floor is not None:
+        overrides["resource_price_floor"] = float(args.resource_floor)
+    if args.resource_ceiling is not None:
+        overrides["resource_price_ceiling"] = float(args.resource_ceiling)
+    if args.resource_smoothing is not None:
+        overrides["autonomy_price_smoothing"] = float(args.resource_smoothing)
+    if args.storyboard_history is not None:
+        overrides["storyboard_history_lines"] = int(args.storyboard_history)
+    if args.insight_history is not None:
+        overrides["insight_history_lines"] = int(args.insight_history)
+    if args.checkpoint_interval is not None:
+        overrides["checkpoint_interval_seconds"] = float(args.checkpoint_interval)
+    if args.state_history is not None:
+        overrides["state_history_lines"] = int(args.state_history)
+    if args.background_limit is not None:
+        overrides["background_task_limit"] = int(args.background_limit)
+    if args.delegation_depth is not None:
+        overrides["delegation_max_depth"] = int(args.delegation_depth)
+    if args.delegation_retry is not None:
+        overrides["delegation_retry_seconds"] = float(args.delegation_retry)
+    if args.validator_timeout is not None:
+        overrides["validator_vote_timeout_seconds"] = float(args.validator_timeout)
+    if args.validator_commit is not None:
+        overrides["validator_commit_window_seconds"] = float(args.validator_commit)
+    if args.validator_reveal is not None:
+        overrides["validator_reveal_window_seconds"] = float(args.validator_reveal)
+    if args.simulation_tick is not None:
+        overrides["simulation_tick_seconds"] = float(args.simulation_tick)
+    if args.simulation_hours is not None:
+        overrides["simulation_hours_per_tick"] = float(args.simulation_hours)
+    if args.continuity_interval is not None:
+        overrides["continuity_interval_seconds"] = float(args.continuity_interval)
+    if args.continuity_history is not None:
+        overrides["continuity_history_lines"] = int(args.continuity_history)
+    config = _load_config(args.config, overrides)
+    asyncio.run(_run_orchestrator(config))
+
+
+def _command_owner(args: argparse.Namespace) -> None:
+    config = _load_config(args.config)
+    stream = _owner_stream(config)
+    if args.subcommand == "pause":
+        stream.send({"action": "pause"})
+    elif args.subcommand == "resume":
+        stream.send({"action": "resume"})
+    elif args.subcommand == "stop":
+        stream.send({"action": "stop"})
+    elif args.subcommand == "emergency-stop":
+        stream.send({"action": "emergency_stop"})
+    elif args.subcommand == "governance":
+        payload: Dict[str, Any] = {"action": "update_parameters", "governance": {}}
+        if args.worker_stake_ratio is not None:
+            payload["governance"]["worker_stake_ratio"] = float(args.worker_stake_ratio)
+        if args.validator_stake is not None:
+            payload["governance"]["validator_stake"] = float(args.validator_stake)
+        if args.approvals_required is not None:
+            payload["governance"]["approvals_required"] = int(args.approvals_required)
+        if args.slash_ratio is not None:
+            payload["governance"]["slash_ratio"] = float(args.slash_ratio)
+        if args.pause_enabled is not None:
+            payload["governance"]["pause_enabled"] = bool(args.pause_enabled)
+        if args.commit_window is not None:
+            payload["governance"]["validator_commit_window"] = float(args.commit_window)
+        if args.reveal_window is not None:
+            payload["governance"]["validator_reveal_window"] = float(args.reveal_window)
+        stream.send(payload)
+    elif args.subcommand == "resources":
+        payload = {"action": "update_parameters", "resources": {}}
+        for key in ("energy_capacity", "compute_capacity", "energy_available", "compute_available"):
+            value = getattr(args, key)
+            if value is not None:
+                payload["resources"][key] = float(value)
+        stream.send(payload)
+    elif args.subcommand == "mission":
+        mission_updates: Dict[str, Any] = {}
+        if args.telemetry_interval is not None:
+            mission_updates["telemetry_interval_seconds"] = float(args.telemetry_interval)
+        if args.resilience_interval is not None:
+            mission_updates["resilience_interval_seconds"] = float(args.resilience_interval)
+        if args.resilience_retention is not None:
+            mission_updates["resilience_retention_lines"] = int(args.resilience_retention)
+        if args.mermaid_nodes is not None:
+            mission_updates["mermaid_max_nodes"] = int(args.mermaid_nodes)
+        if args.forecast_hours is not None:
+            mission_updates["forecast_horizon_hours"] = float(args.forecast_hours)
+        if args.storyboard_history is not None:
+            mission_updates["storyboard_history_lines"] = int(args.storyboard_history)
+        if args.insight_history is not None:
+            mission_updates["insight_history_lines"] = int(args.insight_history)
+        if args.checkpoint_interval is not None:
+            mission_updates["checkpoint_interval_seconds"] = float(args.checkpoint_interval)
+        if args.state_history is not None:
+            mission_updates["state_history_lines"] = int(args.state_history)
+        if args.background_limit is not None:
+            mission_updates["background_task_limit"] = int(args.background_limit)
+        if args.delegation_depth is not None:
+            mission_updates["delegation_max_depth"] = int(args.delegation_depth)
+        if args.delegation_retry is not None:
+            mission_updates["delegation_retry_seconds"] = float(args.delegation_retry)
+        if args.validator_timeout is not None:
+            mission_updates["validator_vote_timeout_seconds"] = float(args.validator_timeout)
+        if args.simulation_tick is not None:
+            mission_updates["simulation_tick_seconds"] = float(args.simulation_tick)
+        if args.simulation_hours is not None:
+            mission_updates["simulation_hours_per_tick"] = float(args.simulation_hours)
+        if args.validator_commit is not None:
+            mission_updates["validator_commit_window_seconds"] = float(args.validator_commit)
+        if args.validator_reveal is not None:
+            mission_updates["validator_reveal_window_seconds"] = float(args.validator_reveal)
+        if args.continuity_interval is not None:
+            mission_updates["continuity_interval_seconds"] = float(args.continuity_interval)
+        if args.continuity_history is not None:
+            mission_updates["continuity_history_lines"] = int(args.continuity_history)
+        payload = {"action": "update_parameters", "mission": mission_updates}
+        stream.send(payload)
+    elif args.subcommand == "autonomy":
+        mission_updates = {}
+        if args.guardian_interval is not None:
+            mission_updates["guardian_interval_seconds"] = float(args.guardian_interval)
+        if args.guardian_threshold is not None:
+            mission_updates["guardian_deadline_threshold_minutes"] = float(args.guardian_threshold)
+        if args.guardian_history is not None:
+            mission_updates["guardian_history_lines"] = int(args.guardian_history)
+        if args.resource_feedback is not None:
+            mission_updates["resource_feedback_interval_seconds"] = float(args.resource_feedback)
+        if args.resource_target is not None:
+            mission_updates["resource_target_utilization"] = float(args.resource_target)
+        if args.resource_floor is not None:
+            mission_updates["resource_price_floor"] = float(args.resource_floor)
+        if args.resource_ceiling is not None:
+            mission_updates["resource_price_ceiling"] = float(args.resource_ceiling)
+        if args.resource_smoothing is not None:
+            mission_updates["autonomy_price_smoothing"] = float(args.resource_smoothing)
+        payload = {"action": "update_parameters", "mission": mission_updates}
+        stream.send(payload)
+    elif args.subcommand == "account":
+        payload = {"action": "set_account", "account": args.account}
+        for field in ("tokens", "locked", "energy_quota", "compute_quota"):
+            value = getattr(args, field)
+            if value is not None:
+                payload[field] = float(value)
+        stream.send(payload)
+    elif args.subcommand == "cancel":
+        payload = {"action": "cancel_job", "job_id": args.job_id, "reason": args.reason}
+        stream.send(payload)
+    else:
+        raise SystemExit(f"Unknown owner subcommand: {args.subcommand}")
+    print(f"Command queued -> {config.control_channel_file}")
+    print(f"Await acknowledgement -> {config.owner_command_ack_path}")
+
+
+def _command_status(args: argparse.Namespace) -> None:
+    config = _load_config(args.config)
+    telemetry_path = config.telemetry_ui_payload_path
+    mermaid_path = config.mermaid_output_path
+    long_run_path = config.long_run_ledger_path
+    guardian_plan_path = config.guardian_plan_path
+    state_history_path = getattr(config, "state_history_path", None)
+    checkpoint_path = getattr(config, "state_checkpoint_path", None)
+    if telemetry_path.exists():
+        telemetry = json.loads(telemetry_path.read_text(encoding="utf-8"))
+    else:
+        telemetry = {"message": "Telemetry stream not initialised"}
+    print("=== Ω Mission Telemetry ===")
+    print(json.dumps(telemetry, indent=2))
+    if guardian_plan_path.exists():
+        print("\n=== Autonomy Guardian Plan ===")
+        print(guardian_plan_path.read_text(encoding="utf-8"))
+    if mermaid_path.exists():
+        print("\n=== Job Graph (Mermaid) ===")
+        print(mermaid_path.read_text(encoding="utf-8"))
+    if long_run_path.exists():
+        lines = long_run_path.read_text(encoding="utf-8").strip().splitlines()
+        tail = lines[-3:]
+        print("\n=== Long-Run Ledger (latest 3 entries) ===")
+        for line in tail:
+            print(line)
+    if state_history_path and Path(state_history_path).exists():
+        entries = Path(state_history_path).read_text(encoding="utf-8").strip().splitlines()
+        tail = entries[-3:]
+        print("\n=== State History (latest 3 entries) ===")
+        for line in tail:
+            print(line)
+    if checkpoint_path and Path(checkpoint_path).exists():
+        print("\n=== Last Checkpoint Snapshot ===")
+        print(Path(checkpoint_path).read_text(encoding="utf-8"))
+
+
+def _command_diagram(args: argparse.Namespace) -> None:
+    config = _load_config(args.config)
+    mermaid_path = config.mermaid_output_path
+    if not mermaid_path.exists():
+        raise SystemExit("Mermaid diagram not generated yet. Run launch command first.")
+    print(mermaid_path.read_text(encoding="utf-8"))
+
+
+def _command_ci(_: argparse.Namespace) -> None:
+    base_path = CI_CONFIG if CI_CONFIG.exists() else DEFAULT_CONFIG
+    overrides = {
+        "max_cycles": 6,
+        "resume_from_checkpoint": False,
+        "telemetry_interval_seconds": 2.0,
+        "resilience_interval_seconds": 2.0,
+        "guardian_interval_seconds": 2.0,
+        "resource_feedback_interval_seconds": 3.0,
+        "storyboard_history_lines": 32,
+        "insight_history_lines": 64,
+        "checkpoint_interval_seconds": 2.0,
+        "state_history_lines": 32,
+        "background_task_limit": 8,
+        "delegation_max_depth": 4,
+        "delegation_retry_seconds": 5.0,
+        "validator_vote_timeout_seconds": 30.0,
+        "simulation_tick_seconds": 1.5,
+        "simulation_hours_per_tick": 0.5,
+    }
+    config = _load_config(base_path, overrides)
+    asyncio.run(_run_orchestrator(config))
+
+
+def _command_wizard(args: argparse.Namespace) -> None:
+    template = args.template or DEFAULT_CONFIG
+    wizard = MissionWizard.from_path(template)
+    payload = wizard.generate(
+        args.preset,
+        mission_name=args.mission_name,
+        mission_hours=args.mission_hours,
+        energy_capacity=args.energy,
+        compute_capacity=args.compute,
+        max_cycles=args.cycles,
+        reward_multiplier=args.reward_multiplier,
+    )
+    output = args.output or WIZARD_OUTPUT
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    summary = wizard.summarise(payload)
+    print(f"Preset '{args.preset}' mission configuration written to {output}")
+    print(json.dumps(summary, indent=2))
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Operate the Kardashev-II Ω Upgrade v7 planetary orchestration demo",
+    )
+    parser.set_defaults(func=lambda _: parser.print_help())
+    subparsers = parser.add_subparsers(dest="command")
+
+    launch_parser = subparsers.add_parser("launch", help="Start the Ω Upgrade v7 orchestrator loop")
+    launch_parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    launch_parser.add_argument("--cycles", type=int, default=None, help="Maximum cycles before graceful shutdown")
+    launch_parser.add_argument("--mission-hours", type=float, default=None, help="Target mission duration in hours")
+    launch_parser.add_argument("--integrity-interval", type=float, default=None, help="Integrity check interval override")
+    launch_parser.add_argument("--no-resume", action="store_true", help="Ignore previous checkpoints")
+    launch_parser.add_argument("--status-path", type=Path, default=None, help="Custom status stream path")
+    launch_parser.add_argument("--energy-oracle", type=Path, default=None, help="Override energy oracle JSONL path")
+    launch_parser.add_argument("--energy-oracle-interval", type=float, default=None, help="Override energy oracle cadence in seconds")
+    launch_parser.add_argument("--telemetry-interval", type=float, default=None, help="Override telemetry emission cadence")
+    launch_parser.add_argument("--resilience-interval", type=float, default=None, help="Override long-run ledger cadence")
+    launch_parser.add_argument("--resilience-retention", type=int, default=None, help="Number of ledger lines to retain")
+    launch_parser.add_argument("--mermaid-nodes", type=int, default=None, help="Maximum nodes rendered in Mermaid diagrams")
+    launch_parser.add_argument("--forecast-hours", type=float, default=None, help="Forecast horizon for long-run planning")
+    launch_parser.add_argument("--guardian-interval", type=float, default=None, help="Guardian evaluation cadence in seconds")
+    launch_parser.add_argument("--guardian-threshold", type=float, default=None, help="Guardian deadline threshold in minutes")
+    launch_parser.add_argument("--resource-feedback", type=float, default=None, help="Resource pricing feedback cadence in seconds")
+    launch_parser.add_argument("--resource-target", type=float, default=None, help="Target utilisation for resource pricing")
+    launch_parser.add_argument("--resource-floor", type=float, default=None, help="Minimum dynamic price multiplier")
+    launch_parser.add_argument("--resource-ceiling", type=float, default=None, help="Maximum dynamic price multiplier")
+    launch_parser.add_argument("--resource-smoothing", type=float, default=None, help="Smoothing factor for price adaptation")
+    launch_parser.add_argument("--storyboard-history", type=int, default=None, help="Storyboard history retention lines")
+    launch_parser.add_argument("--insight-history", type=int, default=None, help="Insight journal retention lines")
+    launch_parser.add_argument("--checkpoint-interval", type=float, default=None, help="Seconds between state checkpoints")
+    launch_parser.add_argument("--state-history", type=int, default=None, help="Retained checkpoint history lines")
+    launch_parser.add_argument("--background-limit", type=int, default=None, help="Max concurrent background work items")
+    launch_parser.add_argument("--delegation-depth", type=int, default=None, help="Maximum recursive delegation depth")
+    launch_parser.add_argument("--delegation-retry", type=float, default=None, help="Seconds before resubmitting stalled delegations")
+    launch_parser.add_argument("--validator-timeout", type=float, default=None, help="Seconds validators have to reveal votes")
+    launch_parser.add_argument("--validator-commit", type=float, default=None, help="Seconds allocated for validator commit phase")
+    launch_parser.add_argument("--validator-reveal", type=float, default=None, help="Seconds allocated for validator reveal phase")
+    launch_parser.add_argument("--simulation-tick", type=float, default=None, help="Simulation bridge tick cadence in seconds")
+    launch_parser.add_argument("--simulation-hours", type=float, default=None, help="Simulated hours progressed per tick")
+    launch_parser.add_argument("--continuity-interval", type=float, default=None, help="Seconds between continuity vault replications")
+    launch_parser.add_argument("--continuity-history", type=int, default=None, help="Continuity history ledger line retention")
+    launch_parser.set_defaults(func=_command_launch)
+
+    owner_parser = subparsers.add_parser("owner", help="Operate owner control channel")
+    owner_parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    owner_sub = owner_parser.add_subparsers(dest="subcommand")
+    owner_sub.add_parser("pause")
+    owner_sub.add_parser("resume")
+    owner_sub.add_parser("stop")
+    owner_sub.add_parser("emergency-stop")
+    governance = owner_sub.add_parser("governance")
+    governance.add_argument("--worker-stake-ratio", type=float, default=None)
+    governance.add_argument("--validator-stake", type=float, default=None)
+    governance.add_argument("--approvals-required", type=int, default=None)
+    governance.add_argument("--slash-ratio", type=float, default=None)
+    governance.add_argument("--pause-enabled", type=int, choices=[0, 1], default=None)
+    governance.add_argument("--commit-window", type=float, default=None)
+    governance.add_argument("--reveal-window", type=float, default=None)
+    resources = owner_sub.add_parser("resources")
+    resources.add_argument("--energy-capacity", type=float, default=None)
+    resources.add_argument("--compute-capacity", type=float, default=None)
+    resources.add_argument("--energy-available", type=float, default=None)
+    resources.add_argument("--compute-available", type=float, default=None)
+    mission = owner_sub.add_parser("mission")
+    mission.add_argument("--telemetry-interval", type=float, default=None)
+    mission.add_argument("--resilience-interval", type=float, default=None)
+    mission.add_argument("--resilience-retention", type=int, default=None)
+    mission.add_argument("--mermaid-nodes", type=int, default=None)
+    mission.add_argument("--forecast-hours", type=float, default=None)
+    mission.add_argument("--storyboard-history", type=int, default=None)
+    mission.add_argument("--insight-history", type=int, default=None)
+    mission.add_argument("--checkpoint-interval", type=float, default=None)
+    mission.add_argument("--state-history", type=int, default=None)
+    mission.add_argument("--background-limit", type=int, default=None)
+    mission.add_argument("--delegation-depth", type=int, default=None)
+    mission.add_argument("--delegation-retry", type=float, default=None)
+    mission.add_argument("--validator-timeout", type=float, default=None)
+    mission.add_argument("--simulation-tick", type=float, default=None)
+    mission.add_argument("--simulation-hours", type=float, default=None)
+    mission.add_argument("--validator-commit", type=float, default=None)
+    mission.add_argument("--validator-reveal", type=float, default=None)
+    mission.add_argument("--continuity-interval", type=float, default=None)
+    mission.add_argument("--continuity-history", type=int, default=None)
+    autonomy = owner_sub.add_parser("autonomy")
+    autonomy.add_argument("--guardian-interval", type=float, default=None)
+    autonomy.add_argument("--guardian-threshold", type=float, default=None)
+    autonomy.add_argument("--guardian-history", type=int, default=None)
+    autonomy.add_argument("--resource-feedback", type=float, default=None)
+    autonomy.add_argument("--resource-target", type=float, default=None)
+    autonomy.add_argument("--resource-floor", type=float, default=None)
+    autonomy.add_argument("--resource-ceiling", type=float, default=None)
+    autonomy.add_argument("--resource-smoothing", type=float, default=None)
+    account = owner_sub.add_parser("account")
+    account.add_argument("account", type=str)
+    account.add_argument("--tokens", type=float, default=None)
+    account.add_argument("--locked", type=float, default=None)
+    account.add_argument("--energy-quota", type=float, default=None)
+    account.add_argument("--compute-quota", type=float, default=None)
+    cancel = owner_sub.add_parser("cancel")
+    cancel.add_argument("job_id", type=str)
+    cancel.add_argument("--reason", type=str, default="Operator cancel")
+
+    status_parser = subparsers.add_parser("status", help="Print telemetry status")
+    status_parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    status_parser.set_defaults(func=_command_status)
+
+    diagram_parser = subparsers.add_parser("diagram", help="Print latest Mermaid job graph")
+    diagram_parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    diagram_parser.set_defaults(func=_command_diagram)
+
+    wizard_parser = subparsers.add_parser("wizard", help="Craft mission configs without technical steps")
+    wizard_parser.add_argument("--preset", choices=_DEFAULT_PRESETS, default=_DEFAULT_PRESETS[0])
+    wizard_parser.add_argument("--mission-name", type=str, default=None)
+    wizard_parser.add_argument("--mission-hours", type=float, default=None)
+    wizard_parser.add_argument("--energy", type=float, default=None, help="Override energy capacity")
+    wizard_parser.add_argument("--compute", type=float, default=None, help="Override compute capacity")
+    wizard_parser.add_argument("--cycles", type=int, default=None, help="Preconfigure maximum mission cycles")
+    wizard_parser.add_argument("--reward-multiplier", type=float, default=None, help="Scale initial job rewards and budgets")
+    wizard_parser.add_argument("--template", type=Path, default=None, help="Template mission JSON to adapt")
+    wizard_parser.add_argument("--output", type=Path, default=None, help="Destination for generated mission JSON")
+    wizard_parser.set_defaults(func=_command_wizard)
+
+    ci_parser = subparsers.add_parser("ci", help="Run fast configuration for CI pipelines")
+    ci_parser.set_defaults(func=_command_ci)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/config.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/config.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from kardashev_ii_omega_grade_alpha_agi_business_3_demo.governance import (
+    GovernanceParameters,
+)
+from kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    OrchestratorConfig,
+)
+
+
+class ConfigError(RuntimeError):
+    """Raised when configuration payloads are invalid."""
+
+
+class UpgradeV7Paths:
+    """Filesystem artefact layout for the Kardashev-II Ω Upgrade v7 demo."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.control_channel = root / "control" / "command-stream.jsonl"
+        self.control_ack = root / "control" / "acknowledged-commands.jsonl"
+        self.status_stream = root / "status" / "mission-feed.jsonl"
+        self.dashboard = root / "status" / "dashboard.json"
+        self.metrics_history = root / "status" / "history.jsonl"
+        self.energy_oracle = root / "status" / "energy-oracle.jsonl"
+        self.supervisor_summary = root / "status" / "supervisor.json"
+        self.telemetry = root / "status" / "omega-upgrade-v7" / "telemetry.json"
+        self.telemetry_ui = root / "status" / "omega-upgrade-v7" / "telemetry-ui.json"
+        self.mermaid = root / "status" / "omega-upgrade-v7" / "job-graph.mmd"
+        self.job_graph_json = root / "status" / "omega-upgrade-v7" / "job-graph.json"
+        self.long_run_ledger = root / "status" / "omega-upgrade-v7" / "long-run-ledger.jsonl"
+        self.guardian_plan = root / "status" / "omega-upgrade-v7" / "autonomy-plan.json"
+        self.guardian_history = root / "status" / "omega-upgrade-v7" / "autonomy-history.jsonl"
+        self.autonomy_checkpoint = root / "status" / "omega-upgrade-v7" / "autonomy-checkpoint.json"
+        self.storyboard = root / "status" / "omega-upgrade-v7" / "storyboard.json"
+        self.storyboard_history = root / "status" / "omega-upgrade-v7" / "storyboard-history.jsonl"
+        self.insight_journal = root / "status" / "omega-upgrade-v7" / "insights.jsonl"
+        self.mission_manifest = root / "status" / "omega-upgrade-v7" / "mission-manifest.json"
+        self.state_history = root / "status" / "omega-upgrade-v7" / "state-history.jsonl"
+        self.state_checkpoint = root / "status" / "omega-upgrade-v7" / "state-checkpoint.json"
+        self.structured_log = root / "status" / "omega-upgrade-v7" / "structured-log.jsonl"
+        for path in (
+            self.control_channel,
+            self.control_ack,
+            self.status_stream,
+            self.dashboard,
+            self.metrics_history,
+            self.energy_oracle,
+            self.supervisor_summary,
+            self.telemetry,
+            self.telemetry_ui,
+            self.mermaid,
+            self.job_graph_json,
+            self.long_run_ledger,
+            self.guardian_plan,
+            self.guardian_history,
+            self.autonomy_checkpoint,
+            self.storyboard,
+            self.storyboard_history,
+            self.insight_journal,
+            self.mission_manifest,
+            self.state_history,
+            self.state_checkpoint,
+            self.structured_log,
+        ):
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+
+class OmegaOrchestratorV7Config(OrchestratorConfig):
+    """Configuration envelope extended with v7 upgrade artefacts."""
+
+
+_PATH_FIELDS = {
+    "checkpoint_path",
+    "control_channel_file",
+    "audit_log_path",
+    "status_output_path",
+    "status_dashboard_path",
+    "metrics_history_path",
+    "owner_command_ack_path",
+    "supervisor_summary_path",
+    "energy_oracle_path",
+    "telemetry_output_path",
+    "telemetry_ui_payload_path",
+    "mermaid_output_path",
+    "job_graph_json_path",
+    "long_run_ledger_path",
+    "guardian_plan_path",
+    "guardian_history_path",
+    "autonomy_checkpoint_path",
+    "storyboard_path",
+    "storyboard_history_path",
+    "insight_journal_path",
+    "mission_manifest_path",
+    "state_history_path",
+    "state_checkpoint_path",
+    "structured_log_path",
+    "continuity_history_path",
+}
+
+
+def build_config(overrides: Optional[Dict[str, Any]] = None) -> OmegaOrchestratorV7Config:
+    """Build an :class:`OmegaOrchestratorV7Config` from overrides."""
+
+    config = OmegaOrchestratorV7Config()
+    defaults: Dict[str, Any] = {
+        "checkpoint_path": Path("artifacts/state/checkpoint.json"),
+        "audit_log_path": Path("artifacts/status/audit.jsonl"),
+        "status_output_path": Path("artifacts/status/mission-feed.jsonl"),
+        "status_dashboard_path": Path("artifacts/status/dashboard.json"),
+        "metrics_history_path": Path("artifacts/status/history.jsonl"),
+        "energy_oracle_path": Path("artifacts/status/energy-oracle.jsonl"),
+        "owner_command_ack_path": Path("artifacts/control/acknowledged-commands.jsonl"),
+        "supervisor_summary_path": Path("artifacts/status/supervisor.json"),
+        "control_channel_file": Path("artifacts/control/command-stream.jsonl"),
+        "telemetry_output_path": Path("artifacts/status/omega-upgrade-v7/telemetry.json"),
+        "telemetry_ui_payload_path": Path("artifacts/status/omega-upgrade-v7/telemetry-ui.json"),
+        "mermaid_output_path": Path("artifacts/status/omega-upgrade-v7/job-graph.mmd"),
+        "job_graph_json_path": Path("artifacts/status/omega-upgrade-v7/job-graph.json"),
+        "long_run_ledger_path": Path("artifacts/status/omega-upgrade-v7/long-run-ledger.jsonl"),
+        "guardian_plan_path": Path("artifacts/status/omega-upgrade-v7/autonomy-plan.json"),
+        "guardian_history_path": Path("artifacts/status/omega-upgrade-v7/autonomy-history.jsonl"),
+        "autonomy_checkpoint_path": Path("artifacts/status/omega-upgrade-v7/autonomy-checkpoint.json"),
+        "storyboard_path": Path("artifacts/status/omega-upgrade-v7/storyboard.json"),
+        "storyboard_history_path": Path("artifacts/status/omega-upgrade-v7/storyboard-history.jsonl"),
+        "insight_journal_path": Path("artifacts/status/omega-upgrade-v7/insights.jsonl"),
+        "mission_manifest_path": Path("artifacts/status/omega-upgrade-v7/mission-manifest.json"),
+        "state_history_path": Path("artifacts/status/omega-upgrade-v7/state-history.jsonl"),
+        "state_checkpoint_path": Path("artifacts/status/omega-upgrade-v7/state-checkpoint.json"),
+        "structured_log_path": Path("artifacts/status/omega-upgrade-v7/structured-log.jsonl"),
+        "storyboard_history_lines": 4096,
+        "insight_history_lines": 6144,
+        "supervisor_interval_seconds": 10.0,
+        "owner_poll_interval_seconds": 3.0,
+        "mission_target_hours": 72.0,
+        "energy_oracle_interval_seconds": 30.0,
+        "telemetry_interval_seconds": 12.0,
+        "resilience_interval_seconds": 15.0,
+        "resilience_retention_lines": 4096,
+        "mermaid_max_nodes": 96,
+        "forecast_horizon_hours": 36.0,
+        "guardian_interval_seconds": 8.0,
+        "guardian_deadline_threshold_minutes": 45.0,
+        "guardian_history_lines": 6144,
+        "resource_feedback_interval_seconds": 20.0,
+        "resource_target_utilization": 0.78,
+        "resource_price_floor": 0.15,
+        "resource_price_ceiling": 16.0,
+        "autonomy_price_smoothing": 0.3,
+        "checkpoint_interval_seconds": 90.0,
+        "state_history_lines": 6144,
+        "background_task_limit": 96,
+        "delegation_max_depth": 10,
+        "delegation_retry_seconds": 60.0,
+        "validator_vote_timeout_seconds": 900.0,
+        "validator_commit_window_seconds": 480.0,
+        "validator_reveal_window_seconds": 960.0,
+        "simulation_tick_seconds": 30.0,
+        "simulation_hours_per_tick": 6.0,
+        "continuity_history_path": Path("artifacts/status/omega-upgrade-v7/continuity-history.jsonl"),
+        "continuity_history_lines": 8192,
+        "continuity_interval_seconds": 150.0,
+        "continuity_replicas": [
+            {"name": "primary", "path": Path("artifacts/status/omega-upgrade-v7/continuity-primary.json")},
+            {"name": "secondary", "path": Path("artifacts/status/omega-upgrade-v7/continuity-secondary.json")},
+            {"name": "tertiary", "path": Path("artifacts/status/omega-upgrade-v7/continuity-tertiary.json")},
+        ],
+    }
+    for key, value in defaults.items():
+        if not overrides or key not in overrides:
+            setattr(config, key, value)
+
+    if overrides:
+        dataclass_fields = {field_info.name for field_info in fields(OmegaOrchestratorV7Config)}
+        for name, value in overrides.items():
+            target_value = value
+            if name in _PATH_FIELDS and value is not None:
+                target_value = Path(value)
+            elif name == "governance" and not isinstance(value, GovernanceParameters):
+                if not isinstance(value, dict):
+                    raise ConfigError("governance configuration must be a mapping")
+                target_value = _coerce_governance(value)
+            elif name in {
+                "telemetry_interval_seconds",
+                "resilience_interval_seconds",
+                "mission_target_hours",
+                "resilience_retention_lines",
+                "mermaid_max_nodes",
+                "forecast_horizon_hours",
+                "guardian_interval_seconds",
+                "guardian_deadline_threshold_minutes",
+                "guardian_history_lines",
+                "resource_feedback_interval_seconds",
+                "resource_target_utilization",
+                "resource_price_floor",
+                "resource_price_ceiling",
+                "autonomy_price_smoothing",
+                "storyboard_history_lines",
+                "insight_history_lines",
+                "continuity_history_lines",
+                "continuity_interval_seconds",
+                "validator_commit_window_seconds",
+                "validator_reveal_window_seconds",
+                "checkpoint_interval_seconds",
+                "state_history_lines",
+                "background_task_limit",
+                "delegation_max_depth",
+                "delegation_retry_seconds",
+                "validator_vote_timeout_seconds",
+                "simulation_tick_seconds",
+                "simulation_hours_per_tick",
+            }:
+                if name in {
+                    "resilience_retention_lines",
+                    "mermaid_max_nodes",
+                    "guardian_history_lines",
+                    "storyboard_history_lines",
+                    "insight_history_lines",
+                    "continuity_history_lines",
+                    "state_history_lines",
+                    "background_task_limit",
+                    "delegation_max_depth",
+                }:
+                    target_value = int(value)
+                else:
+                    target_value = float(value)
+            elif name == "continuity_replicas":
+                target_value = _coerce_replicas(value)
+            if name in dataclass_fields or hasattr(config, name) or name in defaults:
+                setattr(config, name, target_value)
+            else:
+                setattr(config, name, target_value)
+    return config
+
+
+def load_config_payload(path: Path) -> Dict[str, Any]:
+    """Load raw configuration payload from JSON or YAML."""
+
+    if not path.exists():
+        raise ConfigError(f"Configuration file not found: {path}")
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix in {".yaml", ".yml"}:
+        try:
+            import yaml  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise ConfigError("PyYAML is required to parse YAML configuration files") from exc
+        data: Any = yaml.safe_load(text)
+    else:
+        data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ConfigError("Configuration payload must be a mapping")
+    return data
+
+
+def load_config(path: Path, overrides: Optional[Dict[str, Any]] = None) -> OmegaOrchestratorV7Config:
+    """Load configuration from *path* and apply CLI overrides."""
+
+    payload = load_config_payload(path)
+    data = dict(payload)
+    cli_overrides = dict(overrides or {})
+    if "paths" in data:
+        root = Path(data.pop("paths"))
+        artefacts = UpgradeV7Paths(root)
+        cli_overrides.setdefault("control_channel_file", artefacts.control_channel)
+        cli_overrides.setdefault("owner_command_ack_path", artefacts.control_ack)
+        cli_overrides.setdefault("status_output_path", artefacts.status_stream)
+        cli_overrides.setdefault("status_dashboard_path", artefacts.dashboard)
+        cli_overrides.setdefault("metrics_history_path", artefacts.metrics_history)
+        cli_overrides.setdefault("energy_oracle_path", artefacts.energy_oracle)
+        cli_overrides.setdefault("supervisor_summary_path", artefacts.supervisor_summary)
+        cli_overrides.setdefault("telemetry_output_path", artefacts.telemetry)
+        cli_overrides.setdefault("telemetry_ui_payload_path", artefacts.telemetry_ui)
+        cli_overrides.setdefault("mermaid_output_path", artefacts.mermaid)
+        cli_overrides.setdefault("job_graph_json_path", artefacts.job_graph_json)
+        cli_overrides.setdefault("long_run_ledger_path", artefacts.long_run_ledger)
+        cli_overrides.setdefault("guardian_plan_path", artefacts.guardian_plan)
+        cli_overrides.setdefault("guardian_history_path", artefacts.guardian_history)
+        cli_overrides.setdefault("autonomy_checkpoint_path", artefacts.autonomy_checkpoint)
+        cli_overrides.setdefault("storyboard_path", artefacts.storyboard)
+        cli_overrides.setdefault("storyboard_history_path", artefacts.storyboard_history)
+        cli_overrides.setdefault("insight_journal_path", artefacts.insight_journal)
+        cli_overrides.setdefault("mission_manifest_path", artefacts.mission_manifest)
+        cli_overrides.setdefault("state_history_path", artefacts.state_history)
+        cli_overrides.setdefault("state_checkpoint_path", artefacts.state_checkpoint)
+        cli_overrides.setdefault("structured_log_path", artefacts.structured_log)
+        continuity_dir = artefacts.state_checkpoint.parent
+        cli_overrides.setdefault("continuity_history_path", continuity_dir / "continuity-history.jsonl")
+        cli_overrides.setdefault(
+            "continuity_replicas",
+            [
+                {"name": "primary", "path": artefacts.state_checkpoint},
+                {"name": "secondary", "path": continuity_dir / "continuity-secondary.json"},
+                {"name": "tertiary", "path": continuity_dir / "continuity-tertiary.json"},
+            ],
+        )
+    data.update(cli_overrides)
+    return build_config(data)
+
+
+def _coerce_governance(payload: Dict[str, Any]) -> GovernanceParameters:
+    data = dict(payload)
+    for field in ("validator_commit_window", "validator_reveal_window"):
+        value = data.get(field)
+        if value is None:
+            continue
+        if isinstance(value, timedelta):
+            continue
+        data[field] = timedelta(seconds=float(value))
+    return GovernanceParameters(**data)
+
+
+def _coerce_replicas(payload: Any) -> Any:
+    if payload is None:
+        return []
+    if not isinstance(payload, (list, tuple)):
+        raise ConfigError("continuity_replicas must be a sequence of mappings")
+    replicas = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            raise ConfigError("continuity replica entries must be mappings")
+        name = entry.get("name")
+        path_value = entry.get("path")
+        if name is None or path_value is None:
+            raise ConfigError("continuity replica entries require 'name' and 'path'")
+        path = Path(path_value) if not isinstance(path_value, Path) else path_value
+        replicas.append({"name": str(name), "path": path})
+    return replicas
+
+
+__all__ = [
+    "ConfigError",
+    "UpgradeV7Paths",
+    "OmegaOrchestratorV7Config",
+    "build_config",
+    "load_config",
+    "load_config_payload",
+]

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/config/ci.json
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/config/ci.json
@@ -1,0 +1,74 @@
+{
+  "mission_name": "Kardashev-II Omega-Grade Upgrade v7 CI",
+  "checkpoint_interval_seconds": 5,
+  "integrity_check_interval_seconds": 10,
+  "insight_interval_seconds": 5,
+  "cycle_sleep_seconds": 0.05,
+  "resume_from_checkpoint": false,
+  "energy_capacity": 120000.0,
+  "compute_capacity": 220000.0,
+  "telemetry_interval_seconds": 2.0,
+  "resilience_interval_seconds": 2.0,
+  "resilience_retention_lines": 64,
+  "mermaid_max_nodes": 16,
+  "forecast_horizon_hours": 4.0,
+  "guardian_interval_seconds": 2.0,
+  "guardian_deadline_threshold_minutes": 20.0,
+  "guardian_history_lines": 256,
+  "resource_feedback_interval_seconds": 3.0,
+  "resource_target_utilization": 0.7,
+  "resource_price_floor": 0.25,
+  "resource_price_ceiling": 6.0,
+  "autonomy_price_smoothing": 0.3,
+  "storyboard_history_lines": 128,
+  "insight_history_lines": 256,
+  "state_history_lines": 256,
+  "background_task_limit": 16,
+  "delegation_max_depth": 4,
+  "delegation_retry_seconds": 12.0,
+  "validator_vote_timeout_seconds": 120.0,
+  "validator_commit_window_seconds": 60.0,
+  "validator_reveal_window_seconds": 90.0,
+  "simulation_tick_seconds": 1.5,
+  "simulation_hours_per_tick": 0.5,
+  "continuity_interval_seconds": 12.0,
+  "continuity_history_lines": 128,
+  "worker_specs": {
+    "energy-architect": 0.5,
+    "supply-chain": 0.5
+  },
+  "strategist_names": [
+    "macro-strategist"
+  ],
+  "validator_names": [
+    "validator-1",
+    "validator-2"
+  ],
+  "governance": {
+    "worker_stake_ratio": 0.1,
+    "validator_stake": 50.0,
+    "approvals_required": 2,
+    "slash_ratio": 0.2,
+    "pause_enabled": true,
+    "validator_commit_window": 120.0,
+    "validator_reveal_window": 180.0
+  },
+  "initial_jobs": [
+    {
+      "title": "CI Dyson Spike",
+      "description": "Short CI mission for automated verification.",
+      "required_skills": [
+        "energy-architect"
+      ],
+      "reward_tokens": 800.0,
+      "deadline_minutes": 30,
+      "validation_window_minutes": 5,
+      "energy_budget": 5000.0,
+      "compute_budget": 9000.0,
+      "metadata": {
+        "employer": "operator",
+        "category": "ci"
+      }
+    }
+  ]
+}

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/config/mission.json
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/config/mission.json
@@ -1,0 +1,123 @@
+{
+  "mission_name": "Kardashev-II Omega-Grade Upgrade v7 for α-AGI Business 3",
+  "checkpoint_interval_seconds": 40,
+  "integrity_check_interval_seconds": 45,
+  "insight_interval_seconds": 18,
+  "cycle_sleep_seconds": 0.2,
+  "max_cycles": null,
+  "resume_from_checkpoint": true,
+  "energy_capacity": 1800000.0,
+  "compute_capacity": 8200000.0,
+  "telemetry_interval_seconds": 15.0,
+  "resilience_interval_seconds": 20.0,
+  "resilience_retention_lines": 4096,
+  "mermaid_max_nodes": 72,
+  "forecast_horizon_hours": 24.0,
+  "guardian_interval_seconds": 10.0,
+  "guardian_deadline_threshold_minutes": 75.0,
+  "guardian_history_lines": 4096,
+  "resource_feedback_interval_seconds": 18.0,
+  "resource_target_utilization": 0.8,
+  "resource_price_floor": 0.35,
+  "resource_price_ceiling": 14.0,
+  "autonomy_price_smoothing": 0.28,
+  "storyboard_history_lines": 4096,
+  "insight_history_lines": 8192,
+  "state_history_lines": 8192,
+  "background_task_limit": 128,
+  "delegation_max_depth": 9,
+  "delegation_retry_seconds": 120.0,
+  "validator_vote_timeout_seconds": 1800.0,
+  "validator_commit_window_seconds": 900.0,
+  "validator_reveal_window_seconds": 1500.0,
+  "simulation_tick_seconds": 30.0,
+  "simulation_hours_per_tick": 6.0,
+  "continuity_interval_seconds": 150.0,
+  "continuity_history_lines": 8192,
+  "continuity_replicas": [
+    {"name": "primary", "path": "artifacts/status/omega-upgrade-v7/continuity-primary.json"},
+    {"name": "secondary", "path": "artifacts/status/omega-upgrade-v7/continuity-secondary.json"},
+    {"name": "tertiary", "path": "artifacts/status/omega-upgrade-v7/continuity-tertiary.json"}
+  ],
+  "worker_specs": {
+    "energy-architect": 1.4,
+    "supply-chain": 1.2,
+    "validator-ops": 1.0,
+    "planetary-logistics": 1.6,
+    "macro-research": 1.3,
+    "validator-guardian": 1.1
+  },
+  "strategist_names": [
+    "macro-strategist",
+    "cosmic-planner",
+    "risk-governor"
+  ],
+  "validator_names": [
+    "validator-1",
+    "validator-2",
+    "validator-3",
+    "validator-4",
+    "validator-5"
+  ],
+  "governance": {
+    "worker_stake_ratio": 0.2,
+    "validator_stake": 250.0,
+    "approvals_required": 3,
+    "slash_ratio": 0.35,
+    "pause_enabled": true,
+    "validator_commit_window": 900.0,
+    "validator_reveal_window": 1200.0
+  },
+  "initial_jobs": [
+    {
+      "title": "Dyson Swarm Omega Reinforcement",
+      "description": "Expand the Dyson swarm spiral with autonomous construction cells.",
+      "required_skills": [
+        "energy-architect",
+        "planetary-logistics"
+      ],
+      "reward_tokens": 9500.0,
+      "deadline_hours": 24,
+      "validation_window_hours": 4,
+      "energy_budget": 120000.0,
+      "compute_budget": 260000.0,
+      "metadata": {
+        "employer": "operator",
+        "priority": "omega",
+        "category": "infrastructure"
+      }
+    },
+    {
+      "title": "Planetary Logistics Equilibrium",
+      "description": "Balance orbital, lunar, and asteroid nodes for just-in-time supply.",
+      "required_skills": [
+        "supply-chain"
+      ],
+      "reward_tokens": 5200.0,
+      "deadline_hours": 18,
+      "validation_window_hours": 3,
+      "energy_budget": 52000.0,
+      "compute_budget": 90000.0,
+      "metadata": {
+        "employer": "macro-strategist",
+        "category": "logistics"
+      }
+    },
+    {
+      "title": "Macro Risk Forecast Grid",
+      "description": "Spin up recursive agents to monitor macro volatility and validator health.",
+      "required_skills": [
+        "macro-research"
+      ],
+      "reward_tokens": 4800.0,
+      "deadline_hours": 12,
+      "validation_window_hours": 2,
+      "energy_budget": 32000.0,
+      "compute_budget": 64000.0,
+      "metadata": {
+        "employer": "risk-governor",
+        "category": "governance"
+      }
+    }
+  ]
+}

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/continuity.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/continuity.py
@@ -1,0 +1,98 @@
+"""Continuity vault utilities for Ω-grade v7 missions."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass(slots=True, frozen=True)
+class ContinuityReplica:
+    """Single redundant snapshot target."""
+
+    name: str
+    path: Path
+
+
+class ContinuityVault:
+    """Persist redundant mission checkpoints for instant resumption."""
+
+    def __init__(
+        self,
+        replicas: Iterable[ContinuityReplica],
+        *,
+        history_path: Optional[Path] = None,
+        history_limit: int = 8192,
+        logger,
+    ) -> None:
+        replica_list = [replica for replica in replicas]
+        if not replica_list:
+            raise ValueError("at least one continuity replica must be configured")
+        self._replicas: List[ContinuityReplica] = replica_list
+        self._history_path = history_path
+        self._history_limit = max(1, int(history_limit))
+        self._lock = asyncio.Lock()
+        self._logger = logger
+        for replica in self._replicas:
+            replica.path.parent.mkdir(parents=True, exist_ok=True)
+        if self._history_path is not None:
+            self._history_path.parent.mkdir(parents=True, exist_ok=True)
+
+    async def persist(self, payload: Dict[str, object]) -> None:
+        """Persist *payload* to all replicas and record success/failure."""
+
+        async with self._lock:
+            await asyncio.to_thread(self._write_all, payload)
+
+    def configure(
+        self,
+        *,
+        replicas: Optional[Iterable[ContinuityReplica]] = None,
+        history_limit: Optional[int] = None,
+    ) -> None:
+        if replicas is not None:
+            replica_list = [replica for replica in replicas]
+            if not replica_list:
+                raise ValueError("continuity vault requires at least one replica")
+            for replica in replica_list:
+                replica.path.parent.mkdir(parents=True, exist_ok=True)
+            self._replicas = replica_list
+        if history_limit is not None:
+            self._history_limit = max(1, int(history_limit))
+
+    @property
+    def replicas(self) -> List[ContinuityReplica]:
+        return list(self._replicas)
+
+    @property
+    def history_limit(self) -> int:
+        return int(self._history_limit)
+
+    # ---------------------------------------------------------------------
+    # internal helpers
+    # ---------------------------------------------------------------------
+    def _write_all(self, payload: Dict[str, object]) -> None:
+        failures: Dict[str, str] = {}
+        for replica in self._replicas:
+            try:
+                replica.path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            except OSError as exc:  # pragma: no cover - filesystem failure simulation
+                failures[replica.name] = str(exc)
+        record = {
+            "timestamp": payload.get("timestamp"),
+            "replicas": [replica.name for replica in self._replicas],
+            "failures": failures,
+        }
+        self._logger.debug(
+            "continuity_vault_persist",
+            extra={"event": "continuity_vault_persist", **record},
+        )
+        if self._history_path is not None:
+            history = self._history_path.read_text(encoding="utf-8").splitlines() if self._history_path.exists() else []
+            history.append(json.dumps(record, separators=(",", ":")))
+            trimmed = history[-self._history_limit :]
+            self._history_path.write_text("\n".join(trimmed) + "\n", encoding="utf-8")
+

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/council.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/council.py
@@ -1,0 +1,110 @@
+"""Validator council orchestration for Ω-grade v7 missions."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List, Sequence
+
+
+@dataclass(slots=True)
+class CouncilCommit:
+    job_id: str
+    validator: str
+    commit_hash: str
+    committed_at: datetime
+    reveal_due: datetime
+
+
+@dataclass(slots=True)
+class CouncilReveal:
+    job_id: str
+    validator: str
+    verdict: str
+    revealed_at: datetime
+
+
+class ValidatorCouncil:
+    """Simulate commit–reveal voting with operator observability."""
+
+    def __init__(
+        self,
+        *,
+        commit_window: timedelta,
+        reveal_window: timedelta,
+        logger,
+    ) -> None:
+        self._commit_window = commit_window
+        self._reveal_window = reveal_window
+        self._logger = logger
+        self._commits: Dict[str, List[CouncilCommit]] = {}
+        self._reveals: Dict[str, List[CouncilReveal]] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # lifecycle hooks invoked by the orchestrator
+    # ------------------------------------------------------------------
+    async def stage_commits(self, job_id: str, validators: Sequence[str]) -> None:
+        now = datetime.now(timezone.utc)
+        commits = [
+            CouncilCommit(
+                job_id=job_id,
+                validator=validator,
+                commit_hash=self._make_commit(job_id, validator, now),
+                committed_at=now,
+                reveal_due=now + self._commit_window + self._reveal_window,
+            )
+            for validator in validators
+        ]
+        async with self._lock:
+            self._commits.setdefault(job_id, []).extend(commits)
+        self._logger.info(
+            "validator_commits_staged",
+            extra={
+                "event": "validator_commits_staged",
+                "job_id": job_id,
+                "validators": list(validators),
+            },
+        )
+
+    async def record_reveal(self, job_id: str, validator: str, verdict: str) -> None:
+        now = datetime.now(timezone.utc)
+        reveal = CouncilReveal(job_id=job_id, validator=validator, verdict=verdict, revealed_at=now)
+        async with self._lock:
+            self._reveals.setdefault(job_id, []).append(reveal)
+        self._logger.info(
+            "validator_reveal_recorded",
+            extra={
+                "event": "validator_reveal_recorded",
+                "job_id": job_id,
+                "validator": validator,
+                "verdict": verdict,
+            },
+        )
+
+    async def audit_job(self, job_id: str) -> Dict[str, object]:
+        async with self._lock:
+            commits = list(self._commits.get(job_id, []))
+            reveals = list(self._reveals.get(job_id, []))
+        payload = {
+            "job_id": job_id,
+            "commits": [commit.__dict__ for commit in commits],
+            "reveals": [reveal.__dict__ for reveal in reveals],
+        }
+        return payload
+
+    async def prune(self, active_jobs: Iterable[str]) -> None:
+        active = set(active_jobs)
+        async with self._lock:
+            self._commits = {job_id: commits for job_id, commits in self._commits.items() if job_id in active}
+            self._reveals = {job_id: reveals for job_id, reveals in self._reveals.items() if job_id in active}
+
+    # ------------------------------------------------------------------
+    # utility helpers
+    # ------------------------------------------------------------------
+    def _make_commit(self, job_id: str, validator: str, timestamp: datetime) -> str:
+        payload = f"{job_id}:{validator}:{timestamp.isoformat()}".encode("utf-8")
+        return hashlib.sha3_256(payload).hexdigest()
+

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/orchestrator.py
@@ -1,0 +1,1218 @@
+"""Omega-grade upgrade orchestrator with narrative UX, autonomy guardian, and resource governor."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, List, Optional, Sequence, Coroutine
+
+from kardashev_ii_omega_grade_alpha_agi_business_3_demo.jobs import JobRecord, JobStatus, JobSpec
+from kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo.orchestrator import (
+    OmegaUpgradeOrchestrator,
+)
+
+from .config import OmegaOrchestratorV7Config
+from .continuity import ContinuityReplica, ContinuityVault
+from .council import ValidatorCouncil
+from .resilience import AsyncTaskRegistry, LongRunResilience
+from .telemetry import MissionTelemetry
+from .storyboard import MissionStoryBoard
+
+
+@dataclass(slots=True)
+class StateSnapshot:
+    """Serializable checkpoint of the orchestrator's planetary state."""
+
+    timestamp: str
+    cycle: int
+    running: bool
+    paused: bool
+    outstanding_jobs: int
+    in_progress_jobs: int
+    root_jobs: int
+    resources: Dict[str, float]
+    guardian: Optional[Dict[str, Any]] = None
+    council: Optional[Dict[str, Any]] = None
+    continuity: Optional[Dict[str, Any]] = None
+
+
+class LongRunStateManager:
+    """Persist orchestrator state for multi-hour/day continuity."""
+
+    def __init__(
+        self,
+        checkpoint_path: Path,
+        history_path: Path,
+        *,
+        history_limit: int,
+        logger,
+    ) -> None:
+        self.checkpoint_path = checkpoint_path
+        self.history_path = history_path
+        self.history_limit = max(1, int(history_limit))
+        self.log = logger
+        self.checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        self.history_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
+
+    async def persist(self, snapshot: StateSnapshot | Dict[str, Any]) -> None:
+        payload = snapshot if isinstance(snapshot, dict) else asdict(snapshot)
+        async with self._lock:
+            await asyncio.to_thread(self._persist_sync, payload)
+
+    def _persist_sync(self, payload: Dict[str, Any]) -> None:
+        self.checkpoint_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        line = json.dumps(payload, separators=(",", ":"))
+        if self.history_path.exists():
+            history = self.history_path.read_text(encoding="utf-8").splitlines()
+        else:
+            history = []
+        history.append(line)
+        trimmed = history[-self.history_limit :]
+        self.history_path.write_text("\n".join(trimmed) + "\n", encoding="utf-8")
+        self.log.debug(
+            "state_checkpoint_persisted",
+            extra={"event": "state_checkpoint", "path": str(self.checkpoint_path)},
+        )
+
+
+
+class StructuredLogWriter:
+    """Append structured JSONL events for long-running missions."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = Lock()
+
+    def write(self, event: str, **fields: Any) -> None:
+        payload = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "event": event,
+            **fields,
+        }
+        line = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+        with self._lock:
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+
+
+class BackgroundWorkPool:
+    """Bounded background task manager for long-running async jobs."""
+
+    def __init__(self, limit: int, logger) -> None:
+        self._limit = max(1, int(limit))
+        self._logger = logger
+        self._semaphore = asyncio.Semaphore(self._limit)
+        self._tasks: Dict[str, asyncio.Task[Any]] = {}
+        self._lock = asyncio.Lock()
+
+    async def start(self, label: str, coroutine: Coroutine[Any, Any, Any]) -> None:
+        await self._semaphore.acquire()
+        async with self._lock:
+            if label in self._tasks:
+                self._semaphore.release()
+                raise ValueError(f"Background task {label} already running")
+            task = asyncio.create_task(self._wrap(label, coroutine), name=f"omega-bg:{label}")
+            self._tasks[label] = task
+
+    async def cancel(self, label: str) -> None:
+        async with self._lock:
+            task = self._tasks.pop(label, None)
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    async def shutdown(self) -> None:
+        async with self._lock:
+            tasks = list(self._tasks.values())
+            self._tasks.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _wrap(self, label: str, coroutine: Coroutine[Any, Any, Any]) -> None:
+        try:
+            await coroutine
+        except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
+            raise
+        except Exception as exc:  # pragma: no cover - defensive guard
+            self._logger.error(
+                "background_task_failed",
+                extra={"event": "background_task_failed", "label": label, "error": str(exc)},
+            )
+        finally:
+            async with self._lock:
+                self._tasks.pop(label, None)
+            self._semaphore.release()
+
+
+class DelegationEngine:
+    """Coordinate recursive delegation reminders and dependency tracking."""
+
+    def __init__(
+        self,
+        *,
+        retry_seconds: float,
+        background_pool: BackgroundWorkPool,
+        bus,
+        logger,
+    ) -> None:
+        self.retry_seconds = max(5.0, float(retry_seconds))
+        self._pool = background_pool
+        self._bus = bus
+        self._logger = logger
+        self._graph: Dict[str, List[str]] = {}
+
+    def register(self, orchestrator: "OmegaUpgradeV7Orchestrator", job: JobRecord) -> None:
+        parent = job.spec.parent_id
+        if parent:
+            self._graph.setdefault(parent, []).append(job.job_id)
+        asyncio.create_task(
+            self._pool.start(
+                f"delegation:{job.job_id}",
+                self._monitor(orchestrator, job.job_id),
+            ),
+            name=f"delegation-register:{job.job_id}",
+        )
+
+    def complete(self, job_id: str) -> None:
+        asyncio.create_task(self._pool.cancel(f"delegation:{job_id}"))
+        for children in self._graph.values():
+            if job_id in children:
+                children.remove(job_id)
+
+    async def _monitor(self, orchestrator: "OmegaUpgradeV7Orchestrator", job_id: str) -> None:
+        await asyncio.sleep(self.retry_seconds)
+        while orchestrator._running:
+            await orchestrator._paused.wait()
+            job = orchestrator.job_registry.get_job(job_id)
+            if job.status in {JobStatus.COMPLETED, JobStatus.CANCELLED, JobStatus.FAILED, JobStatus.FINALIZED}:
+                break
+            if job.status == JobStatus.POSTED and not job.assigned_agent:
+                await self._bus.publish(
+                    f"jobs:reminder:{job_id}",
+                    {"job_id": job_id, "title": job.spec.title},
+                    "delegation-engine",
+                )
+                self._logger.info(
+                    "delegation_reminder",
+                    extra={"event": "delegation_reminder", "job_id": job_id},
+                )
+            await asyncio.sleep(self.retry_seconds)
+
+
+@dataclass(slots=True)
+class GuardianEntry:
+    job_id: str
+    title: str
+    status: str
+    deadline: str
+    assigned_agent: Optional[str]
+    depth: int
+
+
+class AutonomyGuardian:
+    """Analyse the job graph and orchestrate long-run autonomy safeguards."""
+
+    def __init__(
+        self,
+        plan_path: Path,
+        history_path: Path,
+        *,
+        history_limit: int,
+        deadline_threshold: timedelta,
+        bus,
+        logger,
+    ) -> None:
+        self.plan_path = plan_path
+        self.history_path = history_path
+        self.history_limit = max(1, int(history_limit))
+        self.deadline_threshold = deadline_threshold
+        self.bus = bus
+        self.log = logger
+        self.plan_path.parent.mkdir(parents=True, exist_ok=True)
+        self.history_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = asyncio.Lock()
+
+    async def evaluate(self, orchestrator: "OmegaUpgradeV7Orchestrator") -> Dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        jobs = list(orchestrator.job_registry.iter_jobs())
+        outstanding = [
+            job for job in jobs if job.status in {JobStatus.POSTED, JobStatus.IN_PROGRESS}
+        ]
+        root_jobs = [job for job in outstanding if not job.spec.parent_id]
+        max_depth = 0
+        entries: List[GuardianEntry] = []
+        expedite: List[str] = []
+        depth_memo: Dict[str, int] = {}
+        for job in outstanding:
+            depth = self._calculate_depth(orchestrator.job_registry, job, memo=depth_memo)
+            max_depth = max(max_depth, depth)
+            deadline = job.spec.deadline
+            if deadline.tzinfo is None:
+                deadline = deadline.replace(tzinfo=timezone.utc)
+            if job.status == JobStatus.POSTED:
+                posted_jobs += 1
+            elif job.status == JobStatus.IN_PROGRESS:
+                in_progress_jobs += 1
+            entry = GuardianEntry(
+                job_id=job.job_id,
+                title=job.spec.title,
+                status=job.status.value,
+                deadline=deadline.isoformat(),
+                assigned_agent=job.assigned_agent,
+                depth=depth,
+            )
+            if deadline <= now + self.deadline_threshold and job.status == JobStatus.POSTED:
+                entries.append(entry)
+                if job.assigned_agent is None:
+                    expedite.append(job.job_id)
+        entries.sort(key=lambda item: item.deadline)
+        resource_pressure = self._resource_pressure(orchestrator)
+        report = {
+            "timestamp": now.isoformat(),
+            "outstanding_jobs": len(outstanding),
+            "root_jobs": len(root_jobs),
+            "near_deadline_jobs": [entry.__dict__ for entry in entries],
+            "max_depth": max_depth,
+            "resource_pressure": resource_pressure,
+            "expedite_jobs": expedite,
+            "paused": not orchestrator._paused.is_set(),
+            "running": orchestrator._running,
+        }
+        if expedite:
+            await self._broadcast_expedite(expedite, orchestrator)
+        async with self._lock:
+            await asyncio.to_thread(self._persist_report, report)
+        return report
+
+    async def _broadcast_expedite(
+        self, job_ids: Sequence[str], orchestrator: "OmegaUpgradeV7Orchestrator"
+    ) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        for job_id in job_ids:
+            await self.bus.publish(
+                f"jobs:control:{job_id}",
+                {
+                    "job_id": job_id,
+                    "action": "expedite",
+                    "timestamp": now,
+                },
+                "autonomy-guardian",
+            )
+        if job_ids:
+            await self.bus.publish(
+                "jobs:expedite",
+                {"jobs": list(job_ids), "timestamp": now},
+                "autonomy-guardian",
+            )
+            self.log.info(
+                "guardian_expedite",
+                extra={"event": "guardian_expedite", "jobs": list(job_ids)},
+            )
+
+    def _resource_pressure(self, orchestrator: "OmegaUpgradeV7Orchestrator") -> Dict[str, float]:
+        resources = orchestrator.resources
+        energy_capacity = max(resources.energy_capacity, 1.0)
+        compute_capacity = max(resources.compute_capacity, 1.0)
+        energy_pressure = max(
+            0.0, 1.0 - float(resources.energy_available) / float(energy_capacity)
+        )
+        compute_pressure = max(
+            0.0, 1.0 - float(resources.compute_available) / float(compute_capacity)
+        )
+        locked_supply = float(getattr(resources, "locked_supply", 0.0))
+        token_supply = float(getattr(resources, "token_supply", 0.0))
+        token_pressure = (
+            locked_supply / max(token_supply + locked_supply, 1.0)
+        )
+        return {
+            "energy": round(energy_pressure, 6),
+            "compute": round(compute_pressure, 6),
+            "token": round(token_pressure, 6),
+        }
+
+    def _persist_report(self, report: Dict[str, Any]) -> None:
+        self.plan_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        line = json.dumps(report, separators=(",", ":"))
+        if self.history_path.exists():
+            text = self.history_path.read_text(encoding="utf-8").splitlines()
+        else:
+            text = []
+        text.append(line)
+        trimmed = text[-self.history_limit :]
+        self.history_path.write_text("\n".join(trimmed) + "\n", encoding="utf-8")
+
+    def _calculate_depth(
+        self,
+        registry,
+        job: JobRecord,
+        memo: Optional[Dict[str, int]] = None,
+    ) -> int:
+        memo = memo or {}
+        if job.job_id in memo:
+            return memo[job.job_id]
+        children = registry.children_of(job.job_id)
+        if not children:
+            memo[job.job_id] = 1
+            return 1
+        depth = 1 + max(self._calculate_depth(registry, child, memo) for child in children)
+        memo[job.job_id] = depth
+        return depth
+
+
+class ResourceGovernor:
+    """Dynamic resource pricing controller for planetary-scale utilisation."""
+
+    def __init__(
+        self,
+        resources,
+        *,
+        target: float,
+        smoothing: float,
+        floor: float,
+        ceiling: float,
+    ) -> None:
+        self.resources = resources
+        self.target = max(0.0, min(0.99, float(target)))
+        self.smoothing = max(0.01, float(smoothing))
+        self.floor = max(0.01, float(floor))
+        self.ceiling = max(self.floor, float(ceiling))
+        self._last_state: Dict[str, Any] = {}
+
+    def configure(
+        self,
+        *,
+        target: Optional[float] = None,
+        smoothing: Optional[float] = None,
+        floor: Optional[float] = None,
+        ceiling: Optional[float] = None,
+    ) -> None:
+        if target is not None:
+            self.target = max(0.0, min(0.99, float(target)))
+        if smoothing is not None:
+            self.smoothing = max(0.01, float(smoothing))
+        if floor is not None:
+            self.floor = max(0.01, float(floor))
+        if ceiling is not None:
+            self.ceiling = max(self.floor, float(ceiling))
+
+    def adjust(self) -> Dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        resources = self.resources
+        energy_capacity = max(resources.energy_capacity, 1.0)
+        compute_capacity = max(resources.compute_capacity, 1.0)
+        energy_utilisation = 1.0 - float(resources.energy_available) / float(energy_capacity)
+        compute_utilisation = 1.0 - float(resources.compute_available) / float(compute_capacity)
+
+        def _adjust(current: float, utilisation: float) -> float:
+            target_delta = utilisation - self.target
+            candidate = current * (1.0 + self.smoothing * target_delta)
+            return float(min(self.ceiling, max(self.floor, candidate)))
+
+        current_energy_price = float(getattr(resources, "energy_price", 1.0) or 1.0)
+        current_compute_price = float(getattr(resources, "compute_price", 1.0) or 1.0)
+        energy_price = _adjust(current_energy_price, energy_utilisation)
+        compute_price = _adjust(current_compute_price, compute_utilisation)
+        resources.energy_price = energy_price
+        resources.compute_price = compute_price
+        state = {
+            "timestamp": now.isoformat(),
+            "energy_utilisation": round(energy_utilisation, 6),
+            "compute_utilisation": round(compute_utilisation, 6),
+            "target": self.target,
+            "energy_price": energy_price,
+            "compute_price": compute_price,
+        }
+        self._last_state = state
+        return state
+
+    @property
+    def last_state(self) -> Dict[str, Any]:
+        return dict(self._last_state)
+
+
+def _coerce_continuity_payload(payload: Sequence[Dict[str, Any]]) -> List[Dict[str, Path]]:
+    replicas: List[Dict[str, Path]] = []
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        path_value = entry.get("path")
+        if name is None or path_value is None:
+            continue
+        path = Path(path_value) if not isinstance(path_value, Path) else path_value
+        replicas.append({"name": str(name), "path": path})
+    if not replicas:
+        replicas = [{"name": "primary", "path": Path("continuity-primary.json")}]  # pragma: no cover - defensive default
+    return replicas
+
+
+class OmegaUpgradeV7Orchestrator(OmegaUpgradeOrchestrator):
+    """Augmented orchestrator that adds v7 continuity, council, and audit loops."""
+
+    config: OmegaOrchestratorV7Config
+
+    def __init__(self, config: OmegaOrchestratorV7Config) -> None:
+        super().__init__(config)
+        self.config = config
+        self._task_registry = AsyncTaskRegistry(self.log)
+        self._telemetry_interval = max(1.0, float(getattr(config, "telemetry_interval_seconds", 15.0)))
+        self._forecast_horizon_hours = float(getattr(config, "forecast_horizon_hours", 24.0))
+        self._guardian_interval = max(1.0, float(getattr(config, "guardian_interval_seconds", 12.0)))
+        deadline_threshold_minutes = float(
+            getattr(config, "guardian_deadline_threshold_minutes", 60.0)
+        )
+        self._guardian = AutonomyGuardian(
+            Path(getattr(config, "guardian_plan_path", Path("guardian-plan.json"))),
+            Path(getattr(config, "guardian_history_path", Path("guardian-history.jsonl"))),
+            history_limit=int(getattr(config, "guardian_history_lines", 4096)),
+            deadline_threshold=timedelta(minutes=deadline_threshold_minutes),
+            bus=self.bus,
+            logger=self.log,
+        )
+        self._guardian_report: Optional[Dict[str, Any]] = None
+        self._resource_governor = ResourceGovernor(
+            self.resources,
+            target=float(getattr(config, "resource_target_utilization", 0.75)),
+            smoothing=float(getattr(config, "autonomy_price_smoothing", 0.35)),
+            floor=float(getattr(config, "resource_price_floor", 0.25)),
+            ceiling=float(getattr(config, "resource_price_ceiling", 12.0)),
+        )
+        self._governor_state: Dict[str, Any] = {}
+        self._resource_feedback_interval = max(
+            1.0, float(getattr(config, "resource_feedback_interval_seconds", 25.0))
+        )
+        self._resilience = LongRunResilience(
+            Path(getattr(config, "long_run_ledger_path", Path("long-run-ledger.jsonl"))),
+            interval_seconds=float(getattr(config, "resilience_interval_seconds", 20.0)),
+            retention_lines=int(getattr(config, "resilience_retention_lines", 2048)),
+        )
+        self._telemetry = MissionTelemetry(
+            telemetry_path=Path(getattr(config, "telemetry_output_path", Path("telemetry.json"))),
+            ui_payload_path=Path(getattr(config, "telemetry_ui_payload_path", Path("telemetry-ui.json"))),
+            mermaid_path=Path(getattr(config, "mermaid_output_path", Path("job-graph.mmd"))),
+            max_nodes=int(getattr(config, "mermaid_max_nodes", 72)),
+            job_graph_path=Path(getattr(config, "job_graph_json_path", Path("job-graph.json"))),
+        )
+        self._autonomy_checkpoint_path = Path(
+            getattr(config, "autonomy_checkpoint_path", Path("autonomy-checkpoint.json"))
+        )
+        self._autonomy_checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        self._storyboard = MissionStoryBoard(
+            storyboard_path=Path(getattr(config, "storyboard_path", Path("storyboard.json"))),
+            history_path=Path(getattr(config, "storyboard_history_path", Path("storyboard-history.jsonl"))),
+            history_limit=int(getattr(config, "storyboard_history_lines", 2048)),
+            insight_path=Path(getattr(config, "insight_journal_path", Path("insights.jsonl"))),
+            insight_limit=int(getattr(config, "insight_history_lines", 4096)),
+            mission_manifest_path=Path(
+                getattr(config, "mission_manifest_path", Path("mission-manifest.json"))
+            ),
+            mission_name=config.mission_name,
+        )
+        self._structured_log = StructuredLogWriter(
+            Path(getattr(config, "structured_log_path", Path("structured-log.jsonl")))
+        )
+        self._state_manager = LongRunStateManager(
+            checkpoint_path=Path(
+                getattr(config, "state_checkpoint_path", Path("state-checkpoint.json"))
+            ),
+            history_path=Path(
+                getattr(config, "state_history_path", Path("state-history.jsonl"))
+            ),
+            history_limit=int(getattr(config, "state_history_lines", 4096)),
+            logger=self.log,
+        )
+        self._background_pool = BackgroundWorkPool(
+            limit=int(getattr(config, "background_task_limit", 64)),
+            logger=self.log,
+        )
+        self._delegation_engine = DelegationEngine(
+            retry_seconds=float(getattr(config, "delegation_retry_seconds", 90.0)),
+            background_pool=self._background_pool,
+            bus=self.bus,
+            logger=self.log,
+        )
+        self._tracked_delegations: set[str] = set()
+        self._checkpoint_interval = max(
+            30.0, float(getattr(config, "checkpoint_interval_seconds", 120.0))
+        )
+        self._validator_timeout_seconds = max(
+            60.0, float(getattr(config, "validator_vote_timeout_seconds", 600.0))
+        )
+        commit_window_seconds = float(
+            getattr(config, "validator_commit_window_seconds", 300.0)
+        )
+        reveal_window_seconds = float(
+            getattr(config, "validator_reveal_window_seconds", 600.0)
+        )
+        self._validator_commit_window_seconds = commit_window_seconds
+        self._validator_reveal_window_seconds = reveal_window_seconds
+        self._validator_council = ValidatorCouncil(
+            commit_window=timedelta(seconds=self._validator_commit_window_seconds),
+            reveal_window=timedelta(seconds=self._validator_reveal_window_seconds),
+            logger=self.log,
+        )
+        self._simulation_tick_seconds = max(
+            1.0, float(getattr(config, "simulation_tick_seconds", 45.0))
+        )
+        self._simulation_hours_per_tick = max(
+            0.1, float(getattr(config, "simulation_hours_per_tick", 4.0))
+        )
+        replicas_payload = _coerce_continuity_payload(getattr(config, "continuity_replicas", []))
+        replicas = [
+            ContinuityReplica(name=entry["name"], path=entry["path"]) for entry in replicas_payload
+        ]
+        continuity_history_path = Path(
+            getattr(
+                config,
+                "continuity_history_path",
+                Path("artifacts/status/omega-upgrade-v7/continuity-history.jsonl"),
+            )
+        )
+        self._continuity_vault = ContinuityVault(
+            replicas,
+            history_path=continuity_history_path,
+            history_limit=int(getattr(config, "continuity_history_lines", 4096)),
+            logger=self.log,
+        )
+        self._continuity_interval = max(
+            30.0, float(getattr(config, "continuity_interval_seconds", 180.0))
+        )
+        self._autonomy_lock = asyncio.Lock()
+        self._started_at: Optional[datetime] = None
+        self.bus.register_listener(self._control_hook)
+
+    async def start(self) -> None:
+        self._started_at = datetime.now(timezone.utc)
+        await super().start()
+        telemetry_task = asyncio.create_task(self._telemetry_loop(), name="omega-telemetry")
+        resilience_task = asyncio.create_task(self._resilience_loop(), name="omega-resilience-ledger")
+        guardian_task = asyncio.create_task(self._guardian_loop(), name="omega-guardian")
+        governor_task = asyncio.create_task(
+            self._resource_feedback_loop(), name="omega-resource-feedback"
+        )
+        checkpoint_task = asyncio.create_task(
+            self._autonomy_checkpoint_loop(), name="omega-autonomy-checkpoint"
+        )
+        state_checkpoint_task = asyncio.create_task(
+            self._state_checkpoint_loop(), name="omega-state-checkpoint"
+        )
+        delegation_task = asyncio.create_task(
+            self._delegation_monitor_loop(), name="omega-delegation-monitor"
+        )
+        validator_task = asyncio.create_task(
+            self._validator_watchdog_loop(), name="omega-validator-watchdog"
+        )
+        continuity_task = asyncio.create_task(
+            self._continuity_vault_loop(), name="omega-continuity-vault"
+        )
+        simulation_task: Optional[asyncio.Task[None]] = None
+        if getattr(self, "simulation", None) is not None:
+            simulation_task = asyncio.create_task(
+                self._simulation_bridge_loop(), name="omega-simulation-bridge"
+            )
+        for label, task in (
+            ("telemetry", telemetry_task),
+            ("resilience", resilience_task),
+            ("guardian", guardian_task),
+            ("resource-governor", governor_task),
+            ("autonomy-checkpoint", checkpoint_task),
+            ("state-checkpoint", state_checkpoint_task),
+            ("delegation-monitor", delegation_task),
+            ("validator-watchdog", validator_task),
+            ("continuity-vault", continuity_task),
+        ):
+            self._task_registry.register(label, task)
+            self._tasks.append(task)
+        if simulation_task is not None:
+            self._task_registry.register("simulation-bridge", simulation_task)
+            self._tasks.append(simulation_task)
+
+    async def shutdown(self) -> None:
+        await super().shutdown()
+        await self._background_pool.shutdown()
+        snapshot = self.build_long_run_snapshot()
+        await self._telemetry.record(snapshot)
+        await self._resilience.persist(snapshot, force=True)
+        await self._storyboard.capture(snapshot)
+        await asyncio.to_thread(self._write_autonomy_checkpoint, snapshot)
+        await self._state_manager.persist(self._build_state_snapshot())
+        await self._continuity_vault.persist(snapshot)
+
+    async def _control_hook(self, topic: str, payload: Dict[str, Any], publisher: str) -> None:
+        if topic != "control":
+            return
+        action = payload.get("action")
+        if action == "emergency_stop":
+            self._warning("emergency_stop_triggered", issuer=publisher)
+            self.pause()
+            await self.shutdown()
+
+    def _handle_parameter_update(self, payload: Dict[str, Any]) -> None:  # type: ignore[override]
+        super()._handle_parameter_update(payload)
+        mission_updates = payload.get("mission")
+        updated: List[str] = []
+        if isinstance(mission_updates, dict):
+            if "telemetry_interval_seconds" in mission_updates:
+                self._telemetry_interval = max(
+                    1.0, float(mission_updates["telemetry_interval_seconds"])
+                )
+                updated.append("telemetry_interval_seconds")
+            if "resilience_interval_seconds" in mission_updates:
+                self._resilience.configure(
+                    interval_seconds=float(mission_updates["resilience_interval_seconds"])
+                )
+                updated.append("resilience_interval_seconds")
+            if "resilience_retention_lines" in mission_updates:
+                self._resilience.configure(
+                    retention_lines=int(mission_updates["resilience_retention_lines"])
+                )
+                updated.append("resilience_retention_lines")
+            if "mermaid_max_nodes" in mission_updates:
+                self._telemetry.configure(
+                    max_nodes=int(mission_updates["mermaid_max_nodes"])
+                )
+                updated.append("mermaid_max_nodes")
+            if "forecast_horizon_hours" in mission_updates:
+                self._forecast_horizon_hours = max(
+                    0.0, float(mission_updates["forecast_horizon_hours"])
+                )
+                updated.append("forecast_horizon_hours")
+            if "guardian_interval_seconds" in mission_updates:
+                self._guardian_interval = max(
+                    1.0, float(mission_updates["guardian_interval_seconds"])
+                )
+                updated.append("guardian_interval_seconds")
+            if "guardian_deadline_threshold_minutes" in mission_updates:
+                minutes = float(mission_updates["guardian_deadline_threshold_minutes"])
+                self._guardian.deadline_threshold = timedelta(minutes=max(0.0, minutes))
+                updated.append("guardian_deadline_threshold_minutes")
+            if "guardian_history_lines" in mission_updates:
+                self._guardian.history_limit = max(
+                    1, int(mission_updates["guardian_history_lines"])
+                )
+                updated.append("guardian_history_lines")
+            if "resource_feedback_interval_seconds" in mission_updates:
+                self._resource_feedback_interval = max(
+                    1.0, float(mission_updates["resource_feedback_interval_seconds"])
+                )
+                updated.append("resource_feedback_interval_seconds")
+            if "resource_target_utilization" in mission_updates:
+                self._resource_governor.configure(
+                    target=float(mission_updates["resource_target_utilization"])
+                )
+                updated.append("resource_target_utilization")
+            if "resource_price_floor" in mission_updates or "resource_price_ceiling" in mission_updates:
+                self._resource_governor.configure(
+                    floor=float(mission_updates.get("resource_price_floor", self._resource_governor.floor)),
+                    ceiling=float(
+                        mission_updates.get("resource_price_ceiling", self._resource_governor.ceiling)
+                    ),
+                )
+                updated.extend([key for key in ("resource_price_floor", "resource_price_ceiling") if key in mission_updates])
+            if "autonomy_price_smoothing" in mission_updates:
+                self._resource_governor.configure(
+                    smoothing=float(mission_updates["autonomy_price_smoothing"])
+                )
+                updated.append("autonomy_price_smoothing")
+            if "storyboard_history_lines" in mission_updates:
+                self._storyboard.configure(
+                    history_limit=int(mission_updates["storyboard_history_lines"])
+                )
+                updated.append("storyboard_history_lines")
+            if "insight_history_lines" in mission_updates:
+                self._storyboard.configure(
+                    insight_history_limit=int(mission_updates["insight_history_lines"])
+                )
+                updated.append("insight_history_lines")
+            if "continuity_interval_seconds" in mission_updates:
+                self._continuity_interval = max(
+                    30.0, float(mission_updates["continuity_interval_seconds"])
+                )
+                updated.append("continuity_interval_seconds")
+            if "continuity_history_lines" in mission_updates:
+                self._continuity_vault.configure(
+                    history_limit=int(mission_updates["continuity_history_lines"])
+                )
+                updated.append("continuity_history_lines")
+            if "continuity_replicas" in mission_updates:
+                payload = _coerce_continuity_payload(mission_updates["continuity_replicas"])
+                replicas = [
+                    ContinuityReplica(name=entry["name"], path=entry["path"])
+                    for entry in payload
+                ]
+                self._continuity_vault.configure(replicas=replicas)
+                updated.append("continuity_replicas")
+            if "validator_commit_window_seconds" in mission_updates:
+                self._validator_commit_window_seconds = float(
+                    mission_updates["validator_commit_window_seconds"]
+                )
+                self._validator_council = ValidatorCouncil(
+                    commit_window=timedelta(seconds=self._validator_commit_window_seconds),
+                    reveal_window=timedelta(seconds=self._validator_reveal_window_seconds),
+                    logger=self.log,
+                )
+                updated.append("validator_commit_window_seconds")
+            if "validator_reveal_window_seconds" in mission_updates:
+                self._validator_reveal_window_seconds = float(
+                    mission_updates["validator_reveal_window_seconds"]
+                )
+                self._validator_council = ValidatorCouncil(
+                    commit_window=timedelta(seconds=self._validator_commit_window_seconds),
+                    reveal_window=timedelta(seconds=self._validator_reveal_window_seconds),
+                    logger=self.log,
+                )
+                updated.append("validator_reveal_window_seconds")
+        if updated:
+            self._info("mission_parameters_updated", fields=updated)
+
+    async def _telemetry_loop(self) -> None:
+        try:
+            while self._running:
+                await self._paused.wait()
+                snapshot = self.build_long_run_snapshot()
+                await self._telemetry.record(snapshot)
+                await self._storyboard.capture(snapshot)
+                await asyncio.sleep(max(1.0, float(self._telemetry_interval)))
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            return
+
+    async def _resilience_loop(self) -> None:
+        try:
+            while self._running:
+                await self._paused.wait()
+                snapshot = self.build_long_run_snapshot()
+                await self._resilience.persist(snapshot)
+                await asyncio.sleep(max(1.0, float(self._resilience.interval_seconds)))
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            return
+
+    async def _guardian_loop(self) -> None:
+        try:
+            while self._running:
+                await self._paused.wait()
+                report = await self._guardian.evaluate(self)
+                self._guardian_report = report
+                await asyncio.sleep(self._guardian_interval)
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            return
+
+    async def _resource_feedback_loop(self) -> None:
+        try:
+            while self._running:
+                await self._paused.wait()
+                self._governor_state = self._resource_governor.adjust()
+                await asyncio.sleep(self._resource_feedback_interval)
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            return
+
+    async def _autonomy_checkpoint_loop(self) -> None:
+        try:
+            interval = max(self._guardian_interval * 2.0, 30.0)
+            while self._running:
+                await self._paused.wait()
+                snapshot = self.build_long_run_snapshot()
+                await asyncio.to_thread(self._write_autonomy_checkpoint, snapshot)
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            return
+
+    async def _continuity_vault_loop(self) -> None:
+        try:
+            while self._running:
+                await self._paused.wait()
+                snapshot = self.build_long_run_snapshot()
+                await self._continuity_vault.persist(snapshot)
+                await asyncio.sleep(self._continuity_interval)
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            return
+
+    def _write_autonomy_checkpoint(self, snapshot: Dict[str, Any]) -> None:
+        payload = {
+            "timestamp": snapshot.get("timestamp"),
+            "mission": snapshot.get("mission"),
+            "cycle": snapshot.get("cycle"),
+            "autonomy": snapshot.get("autonomy"),
+            "resources": snapshot.get("resources"),
+            "jobs": snapshot.get("jobs"),
+        }
+        self._autonomy_checkpoint_path.write_text(
+            json.dumps(payload, indent=2), encoding="utf-8"
+        )
+
+    async def post_alpha_job(self, spec: JobSpec) -> JobRecord:  # type: ignore[override]
+        record = await super().post_alpha_job(spec)
+        if record.job_id not in self._tracked_delegations:
+            self._tracked_delegations.add(record.job_id)
+            self._delegation_engine.register(self, record)
+        self._structured_log.write(
+            "job_posted",
+            job_id=record.job_id,
+            parent_id=record.spec.parent_id,
+            title=record.spec.title,
+            reward_tokens=record.spec.reward_tokens,
+            deadline=record.spec.deadline.isoformat(),
+        )
+        return record
+
+    def _build_state_snapshot(self) -> StateSnapshot:
+        now = datetime.now(timezone.utc).isoformat()
+        jobs = list(self.job_registry.iter_jobs())
+        outstanding = sum(1 for job in jobs if job.status == JobStatus.POSTED)
+        in_progress = sum(1 for job in jobs if job.status == JobStatus.IN_PROGRESS)
+        root_jobs = sum(1 for job in jobs if not job.spec.parent_id)
+        resources_snapshot = {
+            "energy_available": float(self.resources.energy_available),
+            "compute_available": float(self.resources.compute_available),
+            "energy_capacity": float(self.resources.energy_capacity),
+            "compute_capacity": float(self.resources.compute_capacity),
+            "token_supply": float(getattr(self.resources, "token_supply", 0.0)),
+        }
+        continuity_snapshot = {
+            "interval_seconds": self._continuity_interval,
+            "history_limit": self._continuity_vault.history_limit,
+            "replicas": [
+                {"name": replica.name, "path": str(replica.path)}
+                for replica in self._continuity_vault.replicas
+            ],
+        }
+        council_snapshot = {
+            "commit_window_seconds": self._validator_commit_window_seconds,
+            "reveal_window_seconds": self._validator_reveal_window_seconds,
+            "validators": list(self.config.validator_names),
+            "open_jobs": sum(
+                1
+                for job in jobs
+                if job.status == JobStatus.COMPLETED
+                and len(job.validator_votes) < len(job.validators_with_stake)
+            ),
+            "reveals_recorded": sum(len(job.validator_votes) for job in jobs),
+        }
+        return StateSnapshot(
+            timestamp=now,
+            cycle=self._cycle,
+            running=self._running,
+            paused=not self._paused.is_set(),
+            outstanding_jobs=outstanding,
+            in_progress_jobs=in_progress,
+            root_jobs=root_jobs,
+            resources=resources_snapshot,
+            guardian=self._guardian_report,
+            council=council_snapshot,
+            continuity=continuity_snapshot,
+        )
+
+    async def _state_checkpoint_loop(self) -> None:
+        try:
+            while self._running:
+                await self._paused.wait()
+                snapshot = self._build_state_snapshot()
+                await self._state_manager.persist(snapshot)
+                await asyncio.sleep(self._checkpoint_interval)
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            return
+
+    async def _delegation_monitor_loop(self) -> None:
+        try:
+            while self._running:
+                await self._paused.wait()
+                for tracked in list(self._tracked_delegations):
+                    job = self.job_registry.get_job(tracked)
+                    if job.status not in {JobStatus.POSTED, JobStatus.IN_PROGRESS}:
+                        self._delegation_engine.complete(tracked)
+                        self._tracked_delegations.discard(tracked)
+                for job in self.job_registry.iter_jobs():
+                    if job.job_id in self._tracked_delegations:
+                        continue
+                    if job.status not in {JobStatus.POSTED, JobStatus.IN_PROGRESS}:
+                        continue
+                    self._tracked_delegations.add(job.job_id)
+                    self._delegation_engine.register(self, job)
+                await asyncio.sleep(max(15.0, self._checkpoint_interval / 2.0))
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            return
+
+    async def _initiate_validation(self, job: JobRecord) -> None:  # type: ignore[override]
+        await super()._initiate_validation(job)
+        validators = tuple(job.validators_with_stake) or tuple(self.config.validator_names)
+        await self._validator_council.stage_commits(job.job_id, validators)
+
+    async def _handle_reveal(self, job_id: str, validator: str, vote: bool) -> None:  # type: ignore[override]
+        verdict = "approve" if vote else "reject"
+        await self._validator_council.record_reveal(job_id, validator, verdict)
+        await super()._handle_reveal(job_id, validator, vote)
+
+    async def _validator_watchdog_loop(self) -> None:
+        try:
+            interval = max(30.0, self._validator_timeout_seconds / 3.0)
+            while self._running:
+                await self._paused.wait()
+                now = datetime.now(timezone.utc)
+                for job in self.job_registry.iter_jobs():
+                    if job.status != JobStatus.COMPLETED:
+                        continue
+                    pending = set(job.validators_with_stake) - set(job.validator_votes.keys())
+                    if not pending:
+                        continue
+                    if job.reveal_deadline and now <= job.reveal_deadline:
+                        continue
+                    for validator in pending:
+                        await self.bus.publish(
+                            f"validation:reminder:{job.job_id}",
+                            {
+                                "validator": validator,
+                                "job_id": job.job_id,
+                                "reveal_deadline": job.reveal_deadline.isoformat()
+                                if job.reveal_deadline
+                                else None,
+                            },
+                            "validator-watchdog",
+                        )
+                    self._warning(
+                        "validator_reminder_issued",
+                        job_id=job.job_id,
+                        pending=list(pending),
+                    )
+                await asyncio.sleep(interval)
+                await self._validator_council.prune(
+                    job.job_id for job in self.job_registry.iter_jobs()
+                )
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            return
+
+    def _build_job_graph(self, jobs: Sequence[JobRecord]) -> List[Dict[str, Any]]:
+        """Return a breadth-first ordered job graph for telemetry exports."""
+
+        children: Dict[str, List[str]] = {job.job_id: [] for job in jobs}
+        roots: List[str] = []
+        for job in jobs:
+            parent = job.spec.parent_id
+            if parent and parent in children:
+                children[parent].append(job.job_id)
+            else:
+                roots.append(job.job_id)
+        ordered_roots: List[str] = []
+        for job_id in roots:
+            if job_id not in ordered_roots:
+                ordered_roots.append(job_id)
+        if not ordered_roots:
+            ordered_roots = list(children.keys())
+        queue: List[tuple[str, int]] = [(job_id, 0) for job_id in ordered_roots]
+        visited: set[str] = set()
+        ordered: List[Dict[str, Any]] = []
+        while queue:
+            job_id, depth = queue.pop(0)
+            if job_id in visited:
+                continue
+            visited.add(job_id)
+            record = self.job_registry.get_job(job_id)
+            deadline = record.spec.deadline
+            if deadline.tzinfo is None:
+                deadline = deadline.replace(tzinfo=timezone.utc)
+            descendants = children.get(job_id, [])
+            ordered.append(
+                {
+                    "job_id": record.job_id,
+                    "title": record.spec.title,
+                    "status": record.status.value,
+                    "parent_id": record.spec.parent_id,
+                    "assigned_agent": record.assigned_agent,
+                    "depth": depth,
+                    "children": list(descendants),
+                    "deadline": deadline.isoformat(),
+                    "reward_tokens": record.spec.reward_tokens,
+                }
+            )
+            for child in descendants:
+                queue.append((child, depth + 1))
+        return ordered
+
+
+
+    async def _simulation_bridge_loop(self) -> None:
+        try:
+            while self._running:
+                await self._paused.wait()
+                state = getattr(self, "_latest_simulation_state", None)
+                if state is not None:
+                    payload = {
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "energy_output_gw": getattr(state, "energy_output_gw", None),
+                        "prosperity_index": getattr(state, "prosperity_index", None),
+                        "sustainability_index": getattr(state, "sustainability_index", None),
+                    }
+                    await self.bus.publish(
+                        "simulation:state", payload, "simulation-bridge"
+                    )
+                await asyncio.sleep(self._simulation_tick_seconds)
+        except asyncio.CancelledError:  # pragma: no cover - cooperative shutdown
+            return
+
+    def build_long_run_snapshot(self) -> Dict[str, Any]:
+        base_snapshot = self._collect_status_snapshot()
+        jobs = list(self.job_registry.iter_jobs())
+        posted_jobs = 0
+        in_progress_jobs = 0
+        now = datetime.now(timezone.utc)
+        horizon = timedelta(hours=max(0.0, self._forecast_horizon_hours))
+        due_within_horizon = 0
+        soonest_deadline: Optional[datetime] = None
+        job_records: List[Dict[str, Any]] = []
+        for job in jobs:
+            deadline = job.spec.deadline
+            if deadline.tzinfo is None:
+                deadline = deadline.replace(tzinfo=timezone.utc)
+            if deadline <= now + horizon and job.status in {JobStatus.POSTED, JobStatus.IN_PROGRESS}:
+                due_within_horizon += 1
+            if soonest_deadline is None or deadline < soonest_deadline:
+                soonest_deadline = deadline
+            job_records.append(
+                {
+                    "job_id": job.job_id,
+                    "title": job.spec.title,
+                    "status": job.status.value,
+                    "parent_id": job.spec.parent_id,
+                    "assigned_agent": job.assigned_agent,
+                    "reward_tokens": job.spec.reward_tokens,
+                    "stake_locked": job.stake_locked,
+                    "deadline": deadline.isoformat(),
+                    "energy_budget": job.spec.energy_budget,
+                    "compute_budget": job.spec.compute_budget,
+                    "metadata": dict(job.spec.metadata),
+                }
+            )
+        posted_jobs = sum(1 for job in jobs if job.status == JobStatus.POSTED)
+        in_progress_jobs = sum(1 for job in jobs if job.status == JobStatus.IN_PROGRESS)
+        base_snapshot["job_records"] = job_records
+        base_snapshot["job_graph"] = self._build_job_graph(jobs)
+        base_snapshot["long_run"] = {
+            "uptime_seconds": self.uptime_seconds,
+            "forecast_horizon_hours": self._forecast_horizon_hours,
+            "jobs_due_within_horizon": due_within_horizon,
+            "soonest_deadline": soonest_deadline.isoformat() if soonest_deadline else None,
+            "active_background_tasks": self._task_registry.active_tasks,
+        }
+        base_snapshot["autonomy"] = {
+            "guardian": self._guardian_report,
+            "resource_governor": self._resource_governor.last_state or self._governor_state,
+        }
+        base_snapshot["mission_summary"] = self._build_mission_summary(base_snapshot)
+        self._structured_log.write(
+            "long_run_snapshot",
+            cycle=int(base_snapshot.get("cycle", 0) or 0),
+            posted=posted_jobs,
+            in_progress=in_progress_jobs,
+            energy_available=float(self.resources.energy_available),
+            compute_available=float(self.resources.compute_available),
+        )
+        return base_snapshot
+
+    @property
+    def uptime_seconds(self) -> float:
+        if self._started_at is None:
+            return 0.0
+        delta = datetime.now(timezone.utc) - self._started_at
+        return max(0.0, delta.total_seconds())
+
+    def _build_mission_summary(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
+        jobs_meta = snapshot.get("jobs", {})
+        status_counts = jobs_meta.get("status_counts", {})
+        posted = float(status_counts.get("posted", 0.0))
+        in_progress = float(status_counts.get("in_progress", 0.0))
+        finalized = float(status_counts.get("finalized", 0.0))
+        completed = float(status_counts.get("completed", 0.0))
+        cancelled = float(status_counts.get("cancelled", 0.0))
+        failed = float(status_counts.get("failed", 0.0))
+        outstanding = posted + in_progress
+        total_jobs = outstanding + finalized + completed + cancelled + failed
+
+        long_run = snapshot.get("long_run", {})
+        backlog = float(long_run.get("jobs_due_within_horizon", 0.0))
+        resources = snapshot.get("resources", {})
+
+        def _utilisation(capacity: float, available: float) -> float:
+            if capacity <= 0:
+                return 0.0
+            return max(0.0, min(1.0, 1.0 - available / capacity))
+
+        energy_capacity = float(resources.get("energy_capacity") or 0.0)
+        energy_available = float(resources.get("energy_available") or 0.0)
+        compute_capacity = float(resources.get("compute_capacity") or 0.0)
+        compute_available = float(resources.get("compute_available") or 0.0)
+        energy_utilisation = _utilisation(energy_capacity, energy_available)
+        compute_utilisation = _utilisation(compute_capacity, compute_available)
+
+        guardian = snapshot.get("autonomy", {}).get("guardian") or {}
+        guardian_alerts: List[Dict[str, Any]] = guardian.get("near_deadline_jobs", [])
+        expedite_jobs: List[str] = guardian.get("expedite_jobs", []) if guardian else []
+        governor = snapshot.get("autonomy", {}).get("resource_governor") or {}
+
+        outstanding_reference = outstanding if outstanding > 0 else 1.0
+        backlog_pressure = max(0.0, min(1.0, backlog / outstanding_reference))
+        token_supply = float(resources.get("token_supply") or 0.0)
+        locked_supply = float(resources.get("locked_supply") or 0.0)
+        token_pressure = 0.0
+        if token_supply + locked_supply > 0:
+            token_pressure = locked_supply / (token_supply + locked_supply)
+
+        max_pressure = max(energy_utilisation, compute_utilisation, backlog_pressure, token_pressure)
+        confidence = max(0.0, min(1.0, 1.0 - max_pressure))
+
+        if confidence >= 0.85:
+            headline = "Mission operating at stellar efficiency"
+            phase = "ascendant"
+        elif confidence >= 0.6:
+            headline = "Mission stable with minor optimisation opportunities"
+            phase = "stabilisation"
+        else:
+            headline = "Mission requires operator guidance"
+            phase = "intervention"
+
+        actions: List[str] = []
+        if energy_utilisation > 0.7:
+            actions.append("Top up planetary energy credits or defer energy-intensive jobs.")
+        if compute_utilisation > 0.7:
+            actions.append("Provision additional compute or reprice heavy workloads.")
+        if backlog_pressure > 0.6:
+            actions.append("Accelerate delegation or approve more specialists to clear backlog.")
+        if expedite_jobs:
+            actions.append(
+                f"Authorise rapid response on jobs {', '.join(expedite_jobs[:3])}" +
+                ("…" if len(expedite_jobs) > 3 else "")
+            )
+        if not actions:
+            actions.append("No intervention required—autonomous mission is progressing smoothly.")
+
+        summary_text = (
+            f"Ω mission running with confidence {confidence:.2%}. "
+            f"{outstanding:.0f} jobs active, {finalized + completed:.0f} completed, {backlog:.0f} queued in horizon."
+        )
+
+        return {
+            "headline": headline,
+            "phase": phase,
+            "confidence": round(confidence, 4),
+            "summary": summary_text,
+            "outstanding_jobs": int(outstanding),
+            "total_jobs": int(total_jobs),
+            "jobs_completed": int(finalized + completed),
+            "jobs_failed": int(failed),
+            "jobs_cancelled": int(cancelled),
+            "backlog_horizon": int(backlog),
+            "energy_utilisation": round(energy_utilisation, 4),
+            "compute_utilisation": round(compute_utilisation, 4),
+            "token_pressure": round(token_pressure, 4),
+            "recommended_actions": actions,
+            "guardian_alerts": guardian_alerts,
+            "resource_governor": governor,
+        }
+
+
+__all__ = ["OmegaUpgradeV7Orchestrator"]

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/resilience.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/resilience.py
@@ -1,0 +1,112 @@
+"""Resilience utilities supporting multi-day orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from logging import Logger
+from pathlib import Path
+from typing import Any, Dict
+
+
+class AsyncTaskRegistry:
+    """Track background asyncio tasks and surface failures."""
+
+    def __init__(self, logger: Logger) -> None:
+        self._logger = logger
+        self._tasks: Dict[str, asyncio.Task[None]] = {}
+
+    def register(self, label: str, task: asyncio.Task[None]) -> None:
+        """Register *task* under *label* and attach failure reporting."""
+
+        self._tasks[label] = task
+        task.add_done_callback(self._make_callback(label))
+
+    def _make_callback(self, label: str):
+        def _callback(task: asyncio.Task[None]) -> None:
+            if task.cancelled():
+                return
+            exc = task.exception()
+            if exc is not None:
+                self._logger.error(
+                    "background_task_failed",
+                    extra={"event": "background_task_failed", "task": label, "error": str(exc)},
+                )
+
+        return _callback
+
+    @property
+    def active_tasks(self) -> int:
+        """Return the number of registered tasks that are still running."""
+
+        return sum(1 for task in self._tasks.values() if not task.done())
+
+
+class LongRunResilience:
+    """Maintain a long-run ledger of mission progress for restart safety."""
+
+    def __init__(self, ledger_path: Path, *, interval_seconds: float, retention_lines: int) -> None:
+        self.ledger_path = ledger_path
+        self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        self._interval = max(1.0, float(interval_seconds))
+        self._retention = max(1, int(retention_lines))
+        self._lock = asyncio.Lock()
+
+    @property
+    def interval_seconds(self) -> float:
+        return self._interval
+
+    def configure(
+        self,
+        *,
+        interval_seconds: float | None = None,
+        retention_lines: int | None = None,
+    ) -> None:
+        if interval_seconds is not None:
+            self._interval = max(1.0, float(interval_seconds))
+        if retention_lines is not None:
+            self._retention = max(1, int(retention_lines))
+
+    async def persist(self, snapshot: Dict[str, Any], *, force: bool = False) -> None:
+        """Append *snapshot* to the ledger and enforce retention."""
+
+        payload = {
+            "timestamp": snapshot.get("timestamp"),
+            "cycle": snapshot.get("cycle"),
+            "jobs": snapshot.get("jobs"),
+            "long_run": snapshot.get("long_run"),
+            "resources": {
+                "energy_available": snapshot.get("resources", {}).get("energy_available"),
+                "compute_available": snapshot.get("resources", {}).get("compute_available"),
+                "token_supply": snapshot.get("resources", {}).get("token_supply"),
+                "locked_supply": snapshot.get("resources", {}).get("locked_supply"),
+                "energy_price": snapshot.get("resources", {}).get("energy_price"),
+                "compute_price": snapshot.get("resources", {}).get("compute_price"),
+            },
+        }
+        line = json.dumps(payload, sort_keys=True)
+        async with self._lock:
+            await asyncio.to_thread(self._append_line, line, force)
+
+    def _append_line(self, line: str, force: bool) -> None:
+        with self.ledger_path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        self._truncate(force=force)
+
+    def _truncate(self, *, force: bool = False) -> None:
+        if self._retention <= 0:
+            return
+        try:
+            text = self.ledger_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return
+        lines = [line for line in text.splitlines() if line]
+        if not lines:
+            return
+        if not force and len(lines) <= self._retention:
+            return
+        trimmed = lines[-self._retention :]
+        self.ledger_path.write_text("\n".join(trimmed) + "\n", encoding="utf-8")
+
+
+__all__ = ["AsyncTaskRegistry", "LongRunResilience"]

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/storyboard.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/storyboard.py
@@ -1,0 +1,161 @@
+"""Narrative storyboard generator for non-technical operators."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class MissionStoryBoard:
+    """Render human-friendly mission summaries and maintain history ledgers."""
+
+    def __init__(
+        self,
+        *,
+        storyboard_path: Path,
+        history_path: Path,
+        history_limit: int,
+        insight_path: Path,
+        insight_limit: int,
+        mission_manifest_path: Path,
+        mission_name: str,
+    ) -> None:
+        self.storyboard_path = storyboard_path
+        self.history_path = history_path
+        self.insight_path = insight_path
+        self.mission_manifest_path = mission_manifest_path
+        self.mission_name = mission_name
+        for path in (
+            storyboard_path,
+            history_path,
+            insight_path,
+            mission_manifest_path,
+        ):
+            path.parent.mkdir(parents=True, exist_ok=True)
+        self._history_limit = max(1, int(history_limit))
+        self._insight_limit = max(1, int(insight_limit))
+        self._lock = asyncio.Lock()
+        self._manifest_written = mission_manifest_path.exists()
+
+    def configure(
+        self,
+        *,
+        history_limit: Optional[int] = None,
+        insight_history_limit: Optional[int] = None,
+    ) -> None:
+        if history_limit is not None:
+            self._history_limit = max(1, int(history_limit))
+        if insight_history_limit is not None:
+            self._insight_limit = max(1, int(insight_history_limit))
+
+    async def capture(self, snapshot: Dict[str, Any]) -> None:
+        """Persist a storyboard frame derived from the orchestrator snapshot."""
+
+        story = self._build_story(snapshot)
+        insight = self._build_insight(snapshot)
+        async with self._lock:
+            await asyncio.to_thread(self._persist, story, insight, snapshot)
+
+    def _persist(
+        self,
+        story: Dict[str, Any],
+        insight: Optional[Dict[str, Any]],
+        snapshot: Dict[str, Any],
+    ) -> None:
+        self.storyboard_path.write_text(json.dumps(story, indent=2), encoding="utf-8")
+        self._append_history(self.history_path, story, self._history_limit)
+        if insight:
+            self._append_history(self.insight_path, insight, self._insight_limit)
+        if not self._manifest_written:
+            self._write_manifest(snapshot)
+            self._manifest_written = True
+
+    def _build_story(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
+        summary = snapshot.get("mission_summary") or {}
+        timestamp = snapshot.get("timestamp") or datetime.now(timezone.utc).isoformat()
+        guardian = summary.get("guardian_alerts") or []
+        resources = snapshot.get("resources", {})
+        autonomy = snapshot.get("autonomy", {})
+        governor = autonomy.get("resource_governor") or {}
+        return {
+            "timestamp": timestamp,
+            "mission": snapshot.get("mission", self.mission_name),
+            "headline": summary.get("headline", "Mission telemetry updating"),
+            "phase": summary.get("phase", "assessment"),
+            "confidence": summary.get("confidence", 0.0),
+            "summary": summary.get("summary", "Telemetry incoming…"),
+            "recommended_actions": summary.get("recommended_actions", []),
+            "guardian_alerts": guardian,
+            "metrics": {
+                "outstanding_jobs": summary.get("outstanding_jobs"),
+                "jobs_completed": summary.get("jobs_completed"),
+                "jobs_failed": summary.get("jobs_failed"),
+                "backlog_horizon": summary.get("backlog_horizon"),
+                "energy_utilisation": summary.get("energy_utilisation"),
+                "compute_utilisation": summary.get("compute_utilisation"),
+                "token_pressure": summary.get("token_pressure"),
+                "energy_price": governor.get("energy_price"),
+                "compute_price": governor.get("compute_price"),
+            },
+            "resources": {
+                "energy_available": resources.get("energy_available"),
+                "energy_capacity": resources.get("energy_capacity"),
+                "compute_available": resources.get("compute_available"),
+                "compute_capacity": resources.get("compute_capacity"),
+                "token_supply": resources.get("token_supply"),
+                "locked_supply": resources.get("locked_supply"),
+            },
+        }
+
+    def _build_insight(self, snapshot: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        summary = snapshot.get("mission_summary") or {}
+        timestamp = snapshot.get("timestamp") or datetime.now(timezone.utc).isoformat()
+        actions: List[str] = summary.get("recommended_actions") or []
+        guardian = summary.get("guardian_alerts") or []
+        if not actions and not guardian:
+            return None
+        narrative = {
+            "timestamp": timestamp,
+            "mission": snapshot.get("mission", self.mission_name),
+            "confidence": summary.get("confidence", 0.0),
+            "actions": actions,
+        }
+        if guardian:
+            narrative["guardian_alerts"] = guardian
+        return narrative
+
+    def _append_history(self, path: Path, entry: Dict[str, Any], limit: int) -> None:
+        line = json.dumps(entry, separators=(",", ":"))
+        if path.exists():
+            existing = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        else:
+            existing = []
+        existing.append(line)
+        retained = existing[-max(1, limit) :]
+        path.write_text("\n".join(retained) + "\n", encoding="utf-8")
+
+    def _write_manifest(self, snapshot: Dict[str, Any]) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        resources = snapshot.get("resources", {})
+        manifest = {
+            "mission": snapshot.get("mission", self.mission_name),
+            "created_at": now,
+            "initial_resources": {
+                "energy_capacity": resources.get("energy_capacity"),
+                "compute_capacity": resources.get("compute_capacity"),
+                "token_supply": resources.get("token_supply"),
+            },
+            "description": (
+                "Operator-facing storyboard for the Kardashev-II Ω-grade AGI business mission "
+                "showcasing long-horizon autonomy and planetary tokenomics."
+            ),
+        }
+        self.mission_manifest_path.write_text(
+            json.dumps(manifest, indent=2), encoding="utf-8"
+        )
+
+
+__all__ = ["MissionStoryBoard"]

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/telemetry.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/telemetry.py
@@ -1,0 +1,151 @@
+"""Mission telemetry writer producing dashboards, job graphs, and JSONL payloads."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class MissionTelemetry:
+    """Persist structured telemetry, UI payloads, Mermaid diagrams, and job DAG JSON."""
+
+    def __init__(
+        self,
+        *,
+        telemetry_path: Path,
+        ui_payload_path: Path,
+        mermaid_path: Path,
+        max_nodes: int,
+        job_graph_path: Path | None = None,
+    ) -> None:
+        self.telemetry_path = telemetry_path
+        self.ui_payload_path = ui_payload_path
+        self.mermaid_path = mermaid_path
+        self.job_graph_path = job_graph_path
+        self.telemetry_path.parent.mkdir(parents=True, exist_ok=True)
+        self.ui_payload_path.parent.mkdir(parents=True, exist_ok=True)
+        self.mermaid_path.parent.mkdir(parents=True, exist_ok=True)
+        if self.job_graph_path is not None:
+            self.job_graph_path.parent.mkdir(parents=True, exist_ok=True)
+        self._max_nodes = max(1, int(max_nodes))
+        self._lock = asyncio.Lock()
+
+    def configure(self, *, max_nodes: int | None = None) -> None:
+        if max_nodes is not None:
+            self._max_nodes = max(1, int(max_nodes))
+
+    async def record(self, snapshot: Dict[str, Any]) -> None:
+        """Write *snapshot* to telemetry, UI payload, Mermaid, and job graph outputs."""
+
+        ui_payload = self._build_ui_payload(snapshot)
+        mermaid = self._build_mermaid(snapshot)
+        job_graph = self._build_job_graph_payload(snapshot)
+        async with self._lock:
+            await asyncio.to_thread(
+                self._write_payloads,
+                snapshot,
+                ui_payload,
+                mermaid,
+                job_graph,
+            )
+
+    def _build_ui_payload(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
+        resources = snapshot.get("resources", {})
+        resource_summary = {
+            "energy_available": resources.get("energy_available"),
+            "energy_capacity": resources.get("energy_capacity"),
+            "compute_available": resources.get("compute_available"),
+            "compute_capacity": resources.get("compute_capacity"),
+            "token_supply": resources.get("token_supply"),
+            "locked_supply": resources.get("locked_supply"),
+            "energy_price": resources.get("energy_price"),
+            "compute_price": resources.get("compute_price"),
+        }
+        autonomy = snapshot.get("autonomy", {})
+        job_records = snapshot.get("job_records", [])
+        visible_jobs = job_records[: self._max_nodes]
+        truncated = max(0, len(job_records) - len(visible_jobs))
+        return {
+            "timestamp": snapshot.get("timestamp"),
+            "mission": snapshot.get("mission"),
+            "cycle": snapshot.get("cycle"),
+            "jobs": snapshot.get("jobs"),
+            "visible_job_records": visible_jobs,
+            "truncated_jobs": truncated,
+            "long_run": snapshot.get("long_run"),
+            "resources": resource_summary,
+            "agents": snapshot.get("agents"),
+            "governance": snapshot.get("governance"),
+            "integrity": snapshot.get("integrity"),
+            "simulation": snapshot.get("simulation"),
+            "autonomy": {
+                "guardian": autonomy.get("guardian"),
+                "resource_governor": autonomy.get("resource_governor"),
+            },
+            "mission_summary": snapshot.get("mission_summary"),
+        }
+
+    def _build_mermaid(self, snapshot: Dict[str, Any]) -> str:
+        lines: List[str] = [
+            "flowchart TD",
+            "    operator[(Operator Treasury)] --> orchestrator{{Ω Orchestrator}}",
+        ]
+        job_records = snapshot.get("job_records", [])
+        limited = job_records[: self._max_nodes]
+        truncated = len(job_records) > len(limited)
+        id_map: Dict[str, str] = {}
+        for index, record in enumerate(limited, start=1):
+            job_id = str(record.get("job_id", f"job-{index}"))
+            safe_id = f"job_{index}"
+            id_map[job_id] = safe_id
+            title = str(record.get("title", job_id)).replace("\n", " ")
+            status = str(record.get("status", "unknown")).upper()
+            label = f"{title}\\n{status}"
+            label = label.replace('"', "'")
+            lines.append(f"    {safe_id}[\"{label}\"]")
+        for record in limited:
+            job_id = str(record.get("job_id"))
+            parent = record.get("parent_id")
+            source = id_map.get(str(parent), "orchestrator") if parent else "orchestrator"
+            target = id_map.get(job_id)
+            if target:
+                lines.append(f"    {source} --> {target}")
+        if truncated:
+            lines.append("    orchestrator -.-> ellipsis((More jobs...))")
+            lines.append("    classDef notice fill:#fdf6e3,stroke:#cb4b16,color:#073642;")
+            lines.append("    class ellipsis notice;")
+        return "\n".join(lines)
+
+    def _build_job_graph_payload(self, snapshot: Dict[str, Any]) -> List[Dict[str, Any]]:
+        graph = snapshot.get("job_graph")
+        if isinstance(graph, list):
+            return graph
+        job_records = snapshot.get("job_records", [])
+        return [
+            {
+                "job_id": record.get("job_id"),
+                "parent_id": record.get("parent_id"),
+                "title": record.get("title"),
+                "status": record.get("status"),
+                "assigned_agent": record.get("assigned_agent"),
+            }
+            for record in job_records
+        ]
+
+    def _write_payloads(
+        self,
+        snapshot: Dict[str, Any],
+        ui_payload: Dict[str, Any],
+        mermaid: str,
+        job_graph: List[Dict[str, Any]],
+    ) -> None:
+        self.telemetry_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+        self.ui_payload_path.write_text(json.dumps(ui_payload, indent=2), encoding="utf-8")
+        self.mermaid_path.write_text(mermaid + "\n", encoding="utf-8")
+        if self.job_graph_path is not None:
+            self.job_graph_path.write_text(json.dumps(job_graph, indent=2), encoding="utf-8")
+
+
+__all__ = ["MissionTelemetry"]

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/ui/mission-control.html
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/ui/mission-control.html
@@ -1,0 +1,415 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Ω Upgrade v7 Mission Control</title>
+    <style>
+      body {
+        font-family: "Inter", "Segoe UI", sans-serif;
+        margin: 0;
+        padding: 0;
+        background: radial-gradient(circle at top, #0f172a, #020617);
+        color: #e2e8f0;
+      }
+      header {
+        padding: 2rem;
+        text-align: center;
+        background: linear-gradient(135deg, #1e3a8a, #0ea5e9);
+        box-shadow: 0 4px 24px rgba(14, 165, 233, 0.35);
+      }
+      main {
+        display: grid;
+        gap: 1.5rem;
+        padding: 2rem;
+      }
+      section {
+        background: rgba(15, 23, 42, 0.85);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 1rem;
+        padding: 1.5rem;
+        box-shadow: 0 10px 40px rgba(14, 165, 233, 0.25);
+      }
+      .mission-headline {
+        font-size: 1.6rem;
+        margin: 0 0 0.75rem;
+        color: #fde68a;
+        text-transform: none;
+      }
+      .confidence-pill {
+        display: inline-block;
+        padding: 0.35rem 0.85rem;
+        border-radius: 9999px;
+        background: rgba(56, 189, 248, 0.2);
+        border: 1px solid rgba(56, 189, 248, 0.45);
+        font-weight: 600;
+      }
+      .actions-list {
+        margin: 0.75rem 0 0;
+        padding-left: 1.5rem;
+      }
+      h1 {
+        margin: 0;
+        font-size: 2.5rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      h2 {
+        margin-top: 0;
+        font-size: 1.25rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+      .grid-two {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 1.5rem;
+      }
+      .stat {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        padding: 1rem;
+        border-radius: 0.75rem;
+        background: rgba(30, 58, 138, 0.35);
+        border: 1px solid rgba(14, 165, 233, 0.35);
+      }
+      .stat strong {
+        font-size: 1.75rem;
+        color: #38bdf8;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.95rem;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+      }
+      tbody tr:hover {
+        background: rgba(56, 189, 248, 0.08);
+      }
+      pre {
+        background: rgba(15, 23, 42, 0.9);
+        padding: 1rem;
+        border-radius: 0.75rem;
+        overflow-x: auto;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+      }
+      footer {
+        text-align: center;
+        padding: 1rem;
+        color: rgba(148, 163, 184, 0.7);
+        font-size: 0.85rem;
+      }
+      .status-ok {
+        color: #22c55e;
+      }
+      .status-paused {
+        color: #f97316;
+      }
+      .status-error {
+        color: #f43f5e;
+      }
+      .mermaid {
+        background: rgba(15, 23, 42, 0.9);
+        border-radius: 0.75rem;
+        padding: 1rem;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+      }
+      a {
+        color: #38bdf8;
+      }
+    </style>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: false, theme: "dark" });
+
+      const telemetryUrl = "../artifacts/status/omega-upgrade-v7/telemetry-ui.json";
+      const mermaidUrl = "../artifacts/status/omega-upgrade-v7/job-graph.mmd";
+      const guardianPlanUrl = "../artifacts/status/omega-upgrade-v7/autonomy-plan.json";
+
+      async function fetchJson(path) {
+        try {
+          const response = await fetch(path, { cache: "no-store" });
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          return await response.json();
+        } catch (error) {
+          console.error(`Failed to load ${path}`, error);
+          return null;
+        }
+      }
+
+      async function fetchText(path) {
+        try {
+          const response = await fetch(path, { cache: "no-store" });
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          return await response.text();
+        } catch (error) {
+          console.error(`Failed to load ${path}`, error);
+          return "graph TD\n    error((Unable to render Mermaid diagram))";
+        }
+      }
+
+      function renderStats(data, plan) {
+        const statusEl = document.querySelector("#mission-status");
+        const statsEl = document.querySelector("#stats");
+        const resourceEl = document.querySelector("#resource-stats");
+        const continuityEl = document.querySelector("#continuity-stats");
+        const councilEl = document.querySelector("#council-stats");
+        const tableBody = document.querySelector("#job-table tbody");
+        const longRunEl = document.querySelector("#long-run");
+        const integrityEl = document.querySelector("#integrity-status");
+        const autonomyEl = document.querySelector("#autonomy");
+        const planEl = document.querySelector("#guardian-plan");
+        const narrativeEl = document.querySelector("#mission-summary");
+        const actionsEl = document.querySelector("#mission-actions");
+
+        if (!data) {
+          statusEl.textContent = "No telemetry captured yet.";
+          statsEl.innerHTML = "";
+          tableBody.innerHTML = "";
+          resourceEl.innerHTML = "";
+          longRunEl.innerHTML = "";
+          integrityEl.innerHTML = "";
+          autonomyEl.innerHTML = "";
+          planEl.innerHTML = "";
+          if (narrativeEl) narrativeEl.innerHTML = "";
+          if (actionsEl) actionsEl.innerHTML = "";
+          return;
+        }
+
+        const summary = data.mission_summary ?? {};
+        const jobs = data.jobs ?? {};
+        const longRun = data.long_run ?? {};
+        const resources = data.resources ?? {};
+        const autonomy = data.autonomy ?? {};
+        const guardian = autonomy.guardian ?? {};
+        const governor = autonomy.resource_governor ?? {};
+        const continuity = data.continuity ?? {};
+        const council = data.council ?? {};
+
+        statusEl.innerHTML = `
+          <strong>${data.mission ?? "Ω Mission"}</strong>
+          <span>Cycle ${data.cycle ?? 0}</span>
+          <span>Timestamp ${data.timestamp ?? "—"}</span>
+        `;
+
+        if (narrativeEl) {
+          const phase = summary.phase ?? "assessment";
+          const confidence = summary.confidence ?? 0;
+          narrativeEl.innerHTML = `
+            <div class="mission-headline">${summary.headline ?? "Mission telemetry updating"}</div>
+            <p><span class="confidence-pill">Confidence ${(confidence * 100).toFixed(1)}%</span>
+            <span style="margin-left:0.75rem;">Phase: ${phase}</span></p>
+            <p>${summary.summary ?? "Telemetry stream initialising."}</p>
+            <p><strong>Outstanding jobs:</strong> ${summary.outstanding_jobs ?? 0} ·
+            <strong>Backlog horizon:</strong> ${summary.backlog_horizon ?? 0}</p>
+          `;
+        }
+        if (actionsEl) {
+          const actions = summary.recommended_actions ?? [];
+          if (actions.length) {
+            actionsEl.innerHTML = `<ol class="actions-list">${actions
+              .map((item) => `<li>${item}</li>`)
+              .join("")}</ol>`;
+          } else {
+            actionsEl.innerHTML = "<p>Autonomous mission is fully self-managing.</p>";
+          }
+        }
+
+        statsEl.innerHTML = `
+          <div class="stat">
+            <span>Jobs Active</span>
+            <strong>${(jobs.status_counts?.in_progress ?? 0) + (jobs.status_counts?.posted ?? 0)}</strong>
+          </div>
+          <div class="stat">
+            <span>Jobs Finalized</span>
+            <strong>${jobs.status_counts?.finalized ?? 0}</strong>
+          </div>
+          <div class="stat">
+            <span>Guardian Outstanding</span>
+            <strong>${guardian.outstanding_jobs ?? 0}</strong>
+          </div>
+          <div class="stat">
+            <span>Near Deadline</span>
+            <strong>${guardian.near_deadline_jobs?.length ?? 0}</strong>
+          </div>
+        `;
+
+        resourceEl.innerHTML = `
+          <div class="stat"><span>Energy</span><strong>${Math.round(resources.energy_available ?? 0)} / ${Math.round(resources.energy_capacity ?? 0)}</strong></div>
+          <div class="stat"><span>Compute</span><strong>${Math.round(resources.compute_available ?? 0)} / ${Math.round(resources.compute_capacity ?? 0)}</strong></div>
+          <div class="stat"><span>Token Supply</span><strong>${Math.round(resources.token_supply ?? 0)}</strong></div>
+          <div class="stat"><span>Prices</span><strong>E ${resources.energy_price?.toFixed?.(2) ?? "—"} / C ${resources.compute_price?.toFixed?.(2) ?? "—"}</strong></div>
+        `;
+
+        if (continuityEl) {
+          const replicas = Array.isArray(continuity.replicas) ? continuity.replicas : [];
+          continuityEl.innerHTML = `
+            <div class="stat"><span>Replication interval</span><strong>${(continuity.interval_seconds ?? 0).toFixed?.(0)}s</strong></div>
+            <div class="stat"><span>History retention</span><strong>${continuity.history_limit ?? 0} lines</strong></div>
+            <div class="stat"><span>Replica count</span><strong>${replicas.length}</strong></div>
+            ${replicas
+              .map((replica) => `<div class="stat"><span>${replica.name}</span><strong>${replica.path}</strong></div>`)
+              .join("")}
+          `;
+        }
+
+        if (councilEl) {
+          const validators = Array.isArray(council.validators) ? council.validators : [];
+          councilEl.innerHTML = `
+            <div class="stat"><span>Validators</span><strong>${validators.length}</strong></div>
+            <div class="stat"><span>Commit window</span><strong>${(council.commit_window_seconds ?? 0).toFixed?.(0)}s</strong></div>
+            <div class="stat"><span>Reveal window</span><strong>${(council.reveal_window_seconds ?? 0).toFixed?.(0)}s</strong></div>
+            <div class="stat"><span>Roster</span><strong>${validators.join(", ") || "—"}</strong></div>
+          `;
+        }
+
+        const records = data.visible_job_records ?? [];
+        const rows = records
+          .map((record) => `
+            <tr>
+              <td>${record.job_id}</td>
+              <td>${record.title}</td>
+              <td>${record.status}</td>
+              <td>${record.assigned_agent ?? "unassigned"}</td>
+              <td>${record.deadline}</td>
+            </tr>
+          `)
+          .join("");
+        tableBody.innerHTML = rows || `<tr><td colspan="5">No active jobs.</td></tr>`;
+
+        longRunEl.innerHTML = `
+          <div><strong>Forecast horizon:</strong> ${longRun.forecast_horizon_hours ?? 0} hours</div>
+          <div><strong>Soonest deadline:</strong> ${longRun.soonest_deadline ?? "—"}</div>
+          <div><strong>Background tasks:</strong> ${longRun.active_background_tasks ?? 0}</div>
+          <div><strong>Jobs visible:</strong> ${records.length} (truncated ${data.truncated_jobs ?? 0})</div>
+        `;
+
+        const integrity = data.integrity;
+        if (integrity) {
+          const className = integrity.passed ? "status-ok" : integrity.errors?.length ? "status-error" : "status-paused";
+          integrityEl.innerHTML = `
+            <span class="${className}">Integrity checks: ${integrity.passed ? "Passed" : "Attention"}</span>
+            <pre>${JSON.stringify(integrity, null, 2)}</pre>
+          `;
+        } else {
+          integrityEl.innerHTML = "<em>No integrity report yet.</em>";
+        }
+
+        const pressure = guardian.resource_pressure ?? {};
+        autonomyEl.innerHTML = `
+          <div class="grid-two">
+            <div class="stat"><span>Paused</span><strong>${guardian.paused ? "Yes" : "No"}</strong></div>
+            <div class="stat"><span>Expedite queue</span><strong>${(guardian.expedite_jobs ?? []).length}</strong></div>
+            <div class="stat"><span>Energy pressure</span><strong>${(pressure.energy ?? 0).toFixed(2)}</strong></div>
+            <div class="stat"><span>Compute pressure</span><strong>${(pressure.compute ?? 0).toFixed(2)}</strong></div>
+            <div class="stat"><span>Token pressure</span><strong>${(pressure.token ?? 0).toFixed(2)}</strong></div>
+            <div class="stat"><span>Governor price</span><strong>E ${governor.energy_price?.toFixed?.(2) ?? "—"} / C ${governor.compute_price?.toFixed?.(2) ?? "—"}</strong></div>
+          </div>
+        `;
+
+        if (plan) {
+          planEl.innerHTML = `<pre>${JSON.stringify(plan, null, 2)}</pre>`;
+        } else {
+          planEl.innerHTML = "<em>Guardian plan not yet generated.</em>";
+        }
+      }
+
+      async function renderMermaid() {
+        const container = document.querySelector("#mermaid-diagram");
+        const code = await fetchText(mermaidUrl);
+        try {
+          const { svg } = await mermaid.render(`mermaid-${Date.now()}`, code);
+          container.innerHTML = svg;
+        } catch (error) {
+          container.innerHTML = `<pre>${code}</pre>`;
+        }
+      }
+
+      async function refresh() {
+        const telemetry = await fetchJson(telemetryUrl);
+        const plan = await fetchJson(guardianPlanUrl);
+        renderStats(telemetry, plan);
+        await renderMermaid();
+      }
+
+      refresh();
+      setInterval(refresh, 5000);
+    </script>
+  </head>
+  <body>
+    <header>
+      <h1>Ω Upgrade v7 Mission Control</h1>
+      <p>Planetary-scale α-AGI orchestration streamed from AGI Jobs v0 (v2)</p>
+    </header>
+    <main>
+      <section>
+        <h2>Mission Status</h2>
+        <div id="mission-status"></div>
+      </section>
+      <section>
+        <h2>Mission Narrative</h2>
+        <div id="mission-summary"></div>
+        <div id="mission-actions"></div>
+      </section>
+      <section>
+        <h2>Strategic Pulse</h2>
+        <div id="stats" class="grid-two"></div>
+      </section>
+      <section>
+        <h2>Planetary Resources</h2>
+        <div id="resource-stats" class="grid-two"></div>
+      </section>
+      <section>
+        <h2>Continuity Vault</h2>
+        <div id="continuity-stats" class="grid-two"></div>
+      </section>
+      <section>
+        <h2>Validator Council</h2>
+        <div id="council-stats" class="grid-two"></div>
+      </section>
+      <section>
+        <h2>Autonomy Guardian</h2>
+        <div id="autonomy"></div>
+      </section>
+      <section>
+        <h2>Job Graph</h2>
+        <div id="mermaid-diagram" class="mermaid">graph TD\n    loading((Loading job graph...))</div>
+      </section>
+      <section>
+        <h2>Long-Run Horizon</h2>
+        <div id="long-run"></div>
+      </section>
+      <section>
+        <h2>Active Jobs</h2>
+        <table id="job-table">
+          <thead>
+            <tr>
+              <th>Job ID</th>
+              <th>Title</th>
+              <th>Status</th>
+              <th>Agent</th>
+              <th>Deadline</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Integrity & Governance</h2>
+        <div id="integrity-status"></div>
+      </section>
+      <section>
+        <h2>Guardian Plan of Record</h2>
+        <div id="guardian-plan"></div>
+      </section>
+    </main>
+    <footer>
+      Run via <code>bin/launch.sh</code> and serve this UI with <code>python -m http.server</code>. Telemetry updates every 5 seconds.
+    </footer>
+  </body>
+</html>

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/wizard.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7/wizard.py
@@ -1,0 +1,178 @@
+"""Interactive-style mission configuration builder for non-technical operators."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+
+from .config import load_config_payload
+
+
+def _deep_merge(base: MutableMapping[str, Any], updates: Mapping[str, Any]) -> MutableMapping[str, Any]:
+    """Recursively merge *updates* into *base* and return *base*."""
+
+    for key, value in updates.items():
+        if isinstance(value, Mapping) and isinstance(base.get(key), Mapping):
+            _deep_merge(base[key], value)  # type: ignore[index]
+        else:
+            base[key] = copy.deepcopy(value)
+    return base
+
+
+@dataclass(slots=True)
+class WizardProfile:
+    """High-level mission profiles surfaced to the non-technical operator."""
+
+    name: str
+    description: str
+    overrides: Dict[str, Any]
+
+
+class MissionWizard:
+    """Generate tailored mission configuration payloads from operator intent."""
+
+    def __init__(self, template: Dict[str, Any]) -> None:
+        self._template = copy.deepcopy(template)
+        self._profiles = self._build_profiles()
+
+    @classmethod
+    def from_path(cls, path: Path) -> "MissionWizard":
+        return cls(load_config_payload(path))
+
+    def presets(self) -> Iterable[str]:
+        return self._profiles.keys()
+
+    def generate(
+        self,
+        preset: str,
+        *,
+        mission_name: Optional[str] = None,
+        mission_hours: Optional[float] = None,
+        energy_capacity: Optional[float] = None,
+        compute_capacity: Optional[float] = None,
+        max_cycles: Optional[int] = None,
+        reward_multiplier: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        base = copy.deepcopy(self._template)
+        profile = self._profiles.get(preset) or self._profiles["sovereign"]
+        _deep_merge(base, profile.overrides)
+        if mission_name:
+            base["mission_name"] = mission_name
+        if mission_hours is not None:
+            base["mission_target_hours"] = float(mission_hours)
+        if energy_capacity is not None:
+            base["energy_capacity"] = float(energy_capacity)
+        if compute_capacity is not None:
+            base["compute_capacity"] = float(compute_capacity)
+        if max_cycles is not None:
+            base["max_cycles"] = int(max_cycles)
+        if reward_multiplier is not None and isinstance(base.get("initial_jobs"), list):
+            scale = float(reward_multiplier)
+            for job in base["initial_jobs"]:
+                if isinstance(job, MutableMapping):
+                    if "reward_tokens" in job:
+                        job["reward_tokens"] = float(job["reward_tokens"]) * scale
+                    if "energy_budget" in job:
+                        job["energy_budget"] = float(job["energy_budget"]) * scale
+                    if "compute_budget" in job:
+                        job["compute_budget"] = float(job["compute_budget"]) * scale
+        return base
+
+    def summarise(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        jobs = payload.get("initial_jobs") or []
+        return {
+            "mission_name": payload.get("mission_name"),
+            "mission_target_hours": payload.get("mission_target_hours"),
+            "energy_capacity": payload.get("energy_capacity"),
+            "compute_capacity": payload.get("compute_capacity"),
+            "max_cycles": payload.get("max_cycles"),
+            "worker_count": len((payload.get("worker_specs") or {})),
+            "strategist_count": len((payload.get("strategist_names") or [])),
+            "validator_count": len((payload.get("validator_names") or [])),
+            "initial_job_count": len(jobs),
+        }
+
+    def _build_profiles(self) -> Dict[str, WizardProfile]:
+        return {
+            "sovereign": WizardProfile(
+                name="Sovereign Launch",
+                description="Single-operator planetary mission tuned for rapid proof of value.",
+                overrides={
+                    "mission_target_hours": 18.0,
+                    "energy_capacity": 1_200_000.0,
+                    "compute_capacity": 4_200_000.0,
+                    "worker_specs": {
+                        "energy-architect": 1.35,
+                        "supply-chain": 1.15,
+                        "validator-ops": 1.0,
+                    },
+                    "strategist_names": ["macro-strategist"],
+                    "validator_names": ["validator-1", "validator-2", "validator-3"],
+                },
+            ),
+            "consortium": WizardProfile(
+                name="Consortium Expansion",
+                description="Multi-agent expansion with extended validation depth and resilience.",
+                overrides={
+                    "mission_target_hours": 48.0,
+                    "energy_capacity": 2_400_000.0,
+                    "compute_capacity": 9_500_000.0,
+                    "worker_specs": {
+                        "energy-architect": 1.5,
+                        "supply-chain": 1.25,
+                        "validator-ops": 1.05,
+                        "planetary-logistics": 1.6,
+                        "macro-research": 1.4,
+                    },
+                    "strategist_names": ["macro-strategist", "cosmic-planner"],
+                    "validator_names": [
+                        "validator-1",
+                        "validator-2",
+                        "validator-3",
+                        "validator-4",
+                    ],
+                    "resource_target_utilization": 0.72,
+                    "autonomy_price_smoothing": 0.32,
+                },
+            ),
+            "galactic": WizardProfile(
+                name="Galactic Vanguard",
+                description="Full Ω-grade deployment with deep validator mesh and high autonomy.",
+                overrides={
+                    "mission_target_hours": 96.0,
+                    "energy_capacity": 4_800_000.0,
+                    "compute_capacity": 18_000_000.0,
+                    "worker_specs": {
+                        "energy-architect": 1.65,
+                        "supply-chain": 1.35,
+                        "validator-ops": 1.1,
+                        "planetary-logistics": 1.7,
+                        "macro-research": 1.45,
+                        "validator-guardian": 1.2,
+                        "economy-simulator": 1.3,
+                    },
+                    "strategist_names": [
+                        "macro-strategist",
+                        "cosmic-planner",
+                        "risk-governor",
+                    ],
+                    "validator_names": [
+                        "validator-1",
+                        "validator-2",
+                        "validator-3",
+                        "validator-4",
+                        "validator-5",
+                        "validator-6",
+                    ],
+                    "guardian_interval_seconds": 8.0,
+                    "resource_target_utilization": 0.68,
+                    "resource_price_floor": 0.3,
+                    "resource_price_ceiling": 18.0,
+                },
+            ),
+        }
+
+
+__all__ = ["MissionWizard", "WizardProfile"]


### PR DESCRIPTION
## Summary
- introduce the Kardashev-II Omega-Grade Upgrade v7 demo with operator-focused documentation, mission presets, and UI assets
- extend the Omega orchestrator with structured JSONL logging, recursive job graph exports, and long-run resilience updates
- enhance telemetry and configuration plumbing to emit job graph JSON alongside existing dashboards and artifacts

## Testing
- python -m compileall "demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v7"


------
https://chatgpt.com/codex/tasks/task_e_68ffc20297908333b3c657a6cfa22345