### PR TITLE
feat: enforce validator commit/reveal timelines in Validator Constellation demo

### DIFF
--- a/demo/Validator-Constellation-v0/README.md
+++ b/demo/Validator-Constellation-v0/README.md
@@ -33,6 +33,7 @@ flowchart LR
 * **Sentinel guardrails** – budget overruns or unsafe calls trigger autonomous domain pauses within the same round.
 * **ENS-verified identity** – only operators with approved `.club.agi.eth` or `.alpha.club.agi.eth` subdomains pass the Merkle proof gate, making impersonation impossible.
 * **Operator sovereignty** – one governance command updates penalties or committee size without redeploying contracts.
+* **Block-by-block accountability** – every commit, reveal, and finalization is captured with explicit block windows, letting owners audit timing SLAs and prove the protocol stayed inside governance limits.
 
 ## Quickstart for non-technical operators
 

--- a/demo/Validator-Constellation-v0/src/core/reporting.ts
+++ b/demo/Validator-Constellation-v0/src/core/reporting.ts
@@ -83,6 +83,12 @@ function generateDashboardHTML(result: DemoOrchestrationReport, context: ReportC
   const sentinelDiagram = buildSentinelDiagram(result.domainId);
   const scenarioTitle = context.scenarioName ?? 'Validator Constellation Guardian Deck';
   const ownerNotes = context.ownerNotes && Object.keys(context.ownerNotes).length > 0 ? context.ownerNotes : undefined;
+  const timeline = {
+    commitStartBlock: result.timeline.commitStartBlock,
+    commitDeadlineBlock: result.timeline.commitDeadlineBlock,
+    revealStartBlock: result.timeline.revealStartBlock,
+    revealDeadlineBlock: result.timeline.revealDeadlineBlock,
+  };
   return `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -152,6 +158,10 @@ function generateDashboardHTML(result: DemoOrchestrationReport, context: ReportC
         )}</pre>
       </section>
       <section>
+        <h2>Round Timeline</h2>
+        <pre>${JSON.stringify(timeline, null, 2)}</pre>
+      </section>
+      <section>
         <h2>Job Sample</h2>
         <pre>${JSON.stringify(jobSample, null, 2)}</pre>
       </section>
@@ -198,6 +208,7 @@ export function writeReportArtifacts(input: ArtifactInput): void {
     proof: roundResult.proof,
     alerts: roundResult.sentinelAlerts,
     slashing: roundResult.slashingEvents,
+    timeline: roundResult.timeline,
     pauseRecords: roundResult.pauseRecords,
     governance: {
       parameters: context.governance,

--- a/demo/Validator-Constellation-v0/src/core/types.ts
+++ b/demo/Validator-Constellation-v0/src/core/types.ts
@@ -53,6 +53,8 @@ export interface CommitMessage {
   validator: ValidatorIdentity;
   commitment: Hex;
   round: number;
+  submittedAtBlock: number;
+  submittedAt: number;
 }
 
 export interface RevealMessage {
@@ -60,6 +62,8 @@ export interface RevealMessage {
   vote: VoteValue;
   salt: Hex;
   round: number;
+  submittedAtBlock: number;
+  submittedAt: number;
 }
 
 export interface JobResult {
@@ -138,6 +142,7 @@ export interface DemoOrchestrationReport {
   pauseRecords: PauseRecord[];
   slashingEvents: SlashingEvent[];
   nodes: NodeIdentity[];
+  timeline: RoundTimeline;
 }
 
 export interface DomainState {
@@ -167,4 +172,11 @@ export type GovernanceUpdatable = keyof GovernanceParameters;
 export interface GovernanceController {
   updateParameter(key: GovernanceUpdatable, value: number): void;
   getParameters(): GovernanceParameters;
+}
+
+export interface RoundTimeline {
+  commitStartBlock: number;
+  commitDeadlineBlock: number;
+  revealStartBlock?: number;
+  revealDeadlineBlock?: number;
 }


### PR DESCRIPTION
## Summary
- enforce governance-defined block windows for commit, reveal, and finalize phases in the Validator Constellation coordinator
- record submission metadata, expose round timelines in orchestration reports, and document the block-level accountability upgrade
- extend the demo test suite with timeline window coverage to guarantee the new guardrails

## Testing
- npm run lint:validator-constellation
- npm run test:validator-constellation

------
https://chatgpt.com/codex/tasks/task_e_68ffcc0f4700833387785a7f39cec25b