### PR TITLE
Add domain call allowlists and sentinel guardrail

### DIFF
--- a/demo/Validator-Constellation-v0/README.md
+++ b/demo/Validator-Constellation-v0/README.md
@@ -31,6 +31,7 @@ flowchart LR
 * **Cryptographic truth** – deterministic VRF committee draws, salted commit–reveal voting, and automatic slashing mean hostile validators cannot game the outcome.
 * **Zero-knowledge throughput** – a single proof finalizes **1,000 jobs** at once while preserving privacy and auditability.
 * **Sentinel guardrails** – budget overruns or unsafe calls trigger autonomous domain pauses within the same round.
+* **Target allowlists** – per-domain call allowlists shut down exfiltration attempts before they land on unauthorized contracts.
 * **ENS-verified identity** – only operators with approved `.club.agi.eth` or `.alpha.club.agi.eth` subdomains pass the Merkle proof gate, making impersonation impossible.
 * **Operator sovereignty** – one governance command updates penalties or committee size without redeploying contracts.
 * **Block-by-block accountability** – every commit, reveal, and finalization is captured with explicit block windows, letting owners audit timing SLAs and prove the protocol stayed inside governance limits.
@@ -157,9 +158,10 @@ The CLI enforces ENS subdomain policy, budget ceilings, and governance guardrail
 4. **VRF committee draw** – derives unpredictable committee membership from mixed entropy and governance parameters.
 5. **Commit–reveal voting** – logs sealed commitments, enforces honest reveals, and slashes non-compliant validators.
 6. **Sentinel autonomy** – detects a synthetic overspend, issues a `BUDGET_OVERRUN` alert, and pauses the affected domain.
-7. **ZK batch attestation** – computes a proof for 1,000 jobs, validates it twice (prove & verify), and emits telemetry to the subgraph feed.
-8. **Entropy & proof rotation** – rotates the VRF entropy mix and ZK verifying key mid-run so owners can refresh randomness and proving assets on demand.
-9. **Transparency outputs** – writes summary JSON, NDJSON event stream, subgraph snapshots, and an immersive dashboard.
+7. **Target allowlist enforcement** – blocks any call to unauthorized contract addresses (`UNAUTHORIZED_TARGET`) and halts the offending domain instantly.
+8. **ZK batch attestation** – computes a proof for 1,000 jobs, validates it twice (prove & verify), and emits telemetry to the subgraph feed.
+9. **Entropy & proof rotation** – rotates the VRF entropy mix and ZK verifying key mid-run so owners can refresh randomness and proving assets on demand.
+10. **Transparency outputs** – writes summary JSON, NDJSON event stream, subgraph snapshots, and an immersive dashboard.
 
 ## Governance levers
 
@@ -172,6 +174,7 @@ const demo = new ValidatorConstellationDemo(setup);
 demo.updateGovernanceParameter('slashPenaltyBps', 2_500);
 demo.updateSentinelConfig({ budgetGraceRatio: 0.12 });
 demo.updateDomainSafety('deep-space-lab', { unsafeOpcodes: ['STATICCALL', 'DELEGATECALL'] });
+demo.updateDomainSafety('deep-space-lab', { allowedTargets: ['0xmission-control-safe', '0xresearch-vault'] });
 demo.pauseDomain('deep-space-lab', 'scheduled upgrade');
 demo.resumeDomain('deep-space-lab');
 demo.setAgentBudget('nova.agent.agi.eth', 2_000_000n);
@@ -238,5 +241,6 @@ After `npm run demo:validator-constellation`, inspect:
 - ✅ Governance can pause, resume, or retune parameters instantly.
 - ✅ Node orchestrators inherit the same ENS + blacklist guardrails as validators and agents.
 - ✅ Owners rotate VRF entropy and ZK verifying keys on demand without touching code.
+- ✅ Domain call allowlists block unauthorized targets with instant `UNAUTHORIZED_TARGET` sentinel brakes.
 
 Launch the demo, explore the dashboard, and experience how AGI Jobs v0 (v2) turns Kardashev-II operator control into a single command for non-technical teams.

--- a/demo/Validator-Constellation-v0/config/stellar-scenario.yaml
+++ b/demo/Validator-Constellation-v0/config/stellar-scenario.yaml
@@ -18,12 +18,17 @@ domains:
     unsafeOpcodes:
       - SELFDESTRUCT
       - DELEGATECALL
+    allowedTargets:
+      - 0xmission-control-safe
+      - 0xresearch-vault
   - id: orbital-yard
     humanName: "Orbital Manufacturing Yard"
     budgetLimit: 3000000
     unsafeOpcodes:
       - SELFDESTRUCT
       - STATICCALL
+    allowedTargets:
+      - 0xorbital-factory-safe
 validators:
   - ens: andromeda.club.agi.eth
     address: "0x1111111111111111111111111111111111111111"
@@ -74,6 +79,7 @@ anomalies:
     agentEns: sentinel.agent.agi.eth
     opcode: STATICCALL
     description: "Sentinel attempted a disallowed static call"
+    target: 0xrogue-orbital-process
 ownerActions:
   updateSentinel:
     budgetGraceRatio: 0.12
@@ -84,6 +90,10 @@ ownerActions:
         - DELEGATECALL
         - STATICCALL
         - CALLCODE
+      allowedTargets:
+        - 0xmission-control-safe
+        - 0xresearch-vault
+        - 0xdeepspace-audit-safe
   pauseDomains:
     - domainId: orbital-yard
       reason: "pre-flight drill"

--- a/demo/Validator-Constellation-v0/scripts/operatorConsole.ts
+++ b/demo/Validator-Constellation-v0/scripts/operatorConsole.ts
@@ -101,7 +101,7 @@ function describeState(state: OperatorState, mermaid = false): void {
   state.domains.forEach((domain) => {
     const pauseInfo = domain.paused && domain.pauseReason ? `paused (${domain.pauseReason.reason})` : 'active';
     console.log(
-      `  - ${domain.id} :: ${domain.humanName} :: budget=${formatAgentBudget(domain.budgetLimit)} :: ${pauseInfo} :: unsafe=${domain.unsafeOpcodes.join(', ') || 'none'}`,
+      `  - ${domain.id} :: ${domain.humanName} :: budget=${formatAgentBudget(domain.budgetLimit)} :: ${pauseInfo} :: unsafe=${domain.unsafeOpcodes.join(', ') || 'none'} :: allowed=${domain.allowedTargets.join(', ') || 'none'}`,
     );
   });
   console.log('\nNodes:');
@@ -259,6 +259,7 @@ type DomainArgs = ArgumentsCamelCase<
       humanName?: string;
       budgetLimit?: string;
       unsafeOpcode?: string[];
+      allowedTarget?: string[];
     }
 >;
 
@@ -270,6 +271,7 @@ function handleDomain(argv: DomainArgs): void {
     humanName?: string;
     budgetLimit?: bigint;
     unsafeOpcodes?: string[];
+    allowedTargets?: string[];
   } = {};
   if (argv.humanName) {
     updates.humanName = argv.humanName;
@@ -280,11 +282,19 @@ function handleDomain(argv: DomainArgs): void {
   if (argv.unsafeOpcode) {
     updates.unsafeOpcodes = argv.unsafeOpcode[0] === 'none' ? [] : argv.unsafeOpcode;
   }
+  if (argv.allowedTarget) {
+    updates.allowedTargets = argv.allowedTarget[0] === 'none' ? [] : argv.allowedTarget;
+  }
   const { state: updated, result } = withDemo(state, (demo) => demo.updateDomainSafety(argv.domain, updates));
+  const serializableResult = {
+    ...result,
+    unsafeOpcodes: Array.from(result.unsafeOpcodes),
+    allowedTargets: Array.from(result.allowedTargets),
+  };
   saveOperatorState(updated, statePath);
   summaryForAction('domain-updated', {
     before: domain,
-    after: result,
+    after: serializableResult,
   });
 }
 
@@ -616,7 +626,8 @@ function createCli(argv: string[]): void {
           .option('domain', { type: 'string', demandOption: true, describe: 'Domain identifier' })
           .option('human-name', { type: 'string', describe: 'Human readable name' })
           .option('budget-limit', { type: 'string', describe: 'Budget limit (wei)' })
-          .option('unsafe-opcode', { type: 'array', string: true, describe: 'Unsafe opcode list (use "none" to clear)' }),
+          .option('unsafe-opcode', { type: 'array', string: true, describe: 'Unsafe opcode list (use "none" to clear)' })
+          .option('allowed-target', { type: 'array', string: true, describe: 'Allowed target list (use "none" to clear)' }),
       handleDomain,
     )
     .command(

--- a/demo/Validator-Constellation-v0/scripts/runDemo.ts
+++ b/demo/Validator-Constellation-v0/scripts/runDemo.ts
@@ -2,7 +2,7 @@ import { ValidatorConstellationDemo } from '../src/core/constellation';
 import { subgraphIndexer } from '../src/core/subgraph';
 import { selectCommittee } from '../src/core/vrf';
 import { AgentAction, Hex, VoteValue } from '../src/core/types';
-import { demoLeaves, demoSetup, demoJobBatch, budgetOverrunAction } from '../src/core/fixtures';
+import { demoLeaves, demoSetup, demoJobBatch, budgetOverrunAction, unauthorizedTargetAction } from '../src/core/fixtures';
 import { writeReportArtifacts, ReportContext } from '../src/core/reporting';
 import path from 'path';
 
@@ -39,6 +39,7 @@ function main() {
   const maintenanceResume = demo.resumeDomain('lunar-foundry', 'governance:maintenance-complete');
   const updatedSafety = demo.updateDomainSafety('deep-space-lab', {
     unsafeOpcodes: new Set(['SELFDESTRUCT', 'DELEGATECALL', 'STATICCALL']),
+    allowedTargets: new Set(['0xmission-control-safe', '0xresearch-vault']),
   });
   demo.updateSentinelConfig({ budgetGraceRatio: 0.07 });
   const agentIdentity = demo.setAgentBudget(agentLeaf.ensName, 1_200_000n);
@@ -85,6 +86,13 @@ function main() {
       description: 'Overspend attempt detected by sentinel',
       metadata: { invoice: 'INV-7788' },
     },
+    unauthorizedTargetAction(
+      agentLeaf.ensName,
+      agentLeaf.owner as `0x${string}`,
+      'deep-space-lab',
+      '0xrogue-lab-exfil',
+      agentIdentity.budget,
+    ),
   ];
 
   const roundResult = demo.runValidationRound({

--- a/demo/Validator-Constellation-v0/src/core/fixtures.ts
+++ b/demo/Validator-Constellation-v0/src/core/fixtures.ts
@@ -7,18 +7,21 @@ const RAW_DOMAIN_TEMPLATES: Array<{
   humanName: string;
   budgetLimit: bigint;
   unsafeOpcodes: string[];
+  allowedTargets: string[];
 }> = [
   {
     id: 'deep-space-lab',
     humanName: 'Deep Space Research Lab',
     budgetLimit: 5_000_000n,
     unsafeOpcodes: ['SELFDESTRUCT', 'DELEGATECALL'],
+    allowedTargets: ['0xmission-control-safe', '0xresearch-vault'],
   },
   {
     id: 'lunar-foundry',
     humanName: 'Lunar Foundry',
     budgetLimit: 2_000_000n,
     unsafeOpcodes: ['SELFDESTRUCT'],
+    allowedTargets: ['0xfoundry-treasury'],
   },
 ];
 
@@ -47,7 +50,8 @@ export function defaultDomains(): DomainConfig[] {
     id: domain.id,
     humanName: domain.humanName,
     budgetLimit: domain.budgetLimit,
-    unsafeOpcodes: new Set(domain.unsafeOpcodes),
+    unsafeOpcodes: new Set(domain.unsafeOpcodes.map((opcode) => opcode.toUpperCase())),
+    allowedTargets: new Set(domain.allowedTargets.map((target) => target.toLowerCase())),
   }));
 }
 
@@ -112,5 +116,27 @@ export function budgetOverrunAction(
     type: 'TRANSFER',
     amountSpent: overspend,
     description: 'budget overrun test vector',
+  };
+}
+
+export function unauthorizedTargetAction(
+  agentEns: string,
+  agentAddress: `0x${string}`,
+  domainId: string,
+  target: string,
+  budget = 1_000_000n,
+): AgentAction {
+  return {
+    agent: {
+      ensName: agentEns,
+      address: agentAddress,
+      domainId,
+      budget,
+    },
+    domainId,
+    type: 'CALL',
+    amountSpent: 0n,
+    description: 'unauthorized target test vector',
+    target,
   };
 }

--- a/demo/Validator-Constellation-v0/src/core/operatorState.ts
+++ b/demo/Validator-Constellation-v0/src/core/operatorState.ts
@@ -46,6 +46,7 @@ export interface OperatorDomain {
   humanName: string;
   budgetLimit: string;
   unsafeOpcodes: string[];
+  allowedTargets: string[];
   paused: boolean;
   pauseReason?: OperatorDomainPause;
 }
@@ -70,6 +71,7 @@ function cloneSetupFromState(state: OperatorState): DemoSetup {
     humanName: domain.humanName,
     budgetLimit: BigInt(domain.budgetLimit),
     unsafeOpcodes: new Set(domain.unsafeOpcodes),
+    allowedTargets: new Set(domain.allowedTargets ?? []),
   }));
   return {
     domains,
@@ -150,6 +152,7 @@ export function createInitialOperatorState(): OperatorState {
     humanName: domain.humanName,
     budgetLimit: domain.budgetLimit.toString(),
     unsafeOpcodes: Array.from(domain.unsafeOpcodes),
+    allowedTargets: Array.from(domain.allowedTargets),
     paused: false,
   }));
   return {
@@ -189,6 +192,7 @@ export function loadOperatorState(filePath: string): OperatorState {
     domains: parsed.domains.map((domain) => ({
       ...domain,
       unsafeOpcodes: [...domain.unsafeOpcodes],
+      allowedTargets: [...(domain.allowedTargets ?? [])],
       pauseReason: domain.pauseReason ? { ...domain.pauseReason } : undefined,
     })),
   };
@@ -273,6 +277,7 @@ function updateDomainsFromDemo(state: OperatorState, demo: ValidatorConstellatio
       humanName: snapshot.config.humanName,
       budgetLimit: snapshot.config.budgetLimit.toString(),
       unsafeOpcodes: Array.from(snapshot.config.unsafeOpcodes),
+      allowedTargets: Array.from(snapshot.config.allowedTargets),
       paused: snapshot.paused,
       pauseReason: snapshot.pauseReason
         ? {
@@ -342,7 +347,11 @@ export function generateOperatorMermaid(state: OperatorState): string {
   const domainBlocks = state.domains
     .map((domain) => {
       const domainId = sanitizeMermaidId(`domain_${domain.id}`);
-      const header = `${domain.humanName}\\nBudget ${formatAgentBudget(domain.budgetLimit)}\\nPaused: ${domain.paused ? 'YES' : 'NO'}`;
+      const guardrails =
+        domain.allowedTargets.length > 0
+          ? `\\nAllowed: ${domain.allowedTargets.join(', ')}`
+          : '';
+      const header = `${domain.humanName}\\nBudget ${formatAgentBudget(domain.budgetLimit)}\\nPaused: ${domain.paused ? 'YES' : 'NO'}${guardrails}`;
       const agents = state.agents
         .filter((agent) => agent.domainId === domain.id)
         .map((agent) => {
@@ -375,6 +384,7 @@ export function resetDomainsToDefault(state: OperatorState): void {
     humanName: domain.humanName,
     budgetLimit: domain.budgetLimit.toString(),
     unsafeOpcodes: Array.from(domain.unsafeOpcodes),
+    allowedTargets: Array.from(domain.allowedTargets),
     paused: false,
   }));
 }

--- a/demo/Validator-Constellation-v0/src/core/reporting.ts
+++ b/demo/Validator-Constellation-v0/src/core/reporting.ts
@@ -32,6 +32,7 @@ function formatDomainState(state: DomainState): DomainState {
     config: {
       ...state.config,
       unsafeOpcodes: new Set(state.config.unsafeOpcodes),
+      allowedTargets: new Set(state.config.allowedTargets),
     },
     pauseReason: state.pauseReason ? { ...state.pauseReason } : undefined,
   };
@@ -41,6 +42,7 @@ function cloneDomainConfig(config: DomainConfig): DomainConfig {
   return {
     ...config,
     unsafeOpcodes: new Set(config.unsafeOpcodes),
+    allowedTargets: new Set(config.allowedTargets),
   };
 }
 
@@ -83,6 +85,7 @@ function generateDashboardHTML(result: DemoOrchestrationReport, context: ReportC
   const sentinelDiagram = buildSentinelDiagram(result.domainId);
   const scenarioTitle = context.scenarioName ?? 'Validator Constellation Guardian Deck';
   const ownerNotes = context.ownerNotes && Object.keys(context.ownerNotes).length > 0 ? context.ownerNotes : undefined;
+  const allowedTargets = Array.from(context.primaryDomain.config.allowedTargets);
   const timeline = {
     commitStartBlock: result.timeline.commitStartBlock,
     commitDeadlineBlock: result.timeline.commitDeadlineBlock,
@@ -158,6 +161,18 @@ function generateDashboardHTML(result: DemoOrchestrationReport, context: ReportC
         )}</pre>
       </section>
       <section>
+        <h2>Domain Guardrails</h2>
+        <pre>${JSON.stringify(
+          {
+            domain: context.primaryDomain.config.id,
+            unsafeOpcodes: Array.from(context.primaryDomain.config.unsafeOpcodes),
+            allowedTargets,
+          },
+          null,
+          2,
+        )}</pre>
+      </section>
+      <section>
         <h2>Round Timeline</h2>
         <pre>${JSON.stringify(timeline, null, 2)}</pre>
       </section>
@@ -224,12 +239,14 @@ export function writeReportArtifacts(input: ArtifactInput): void {
         config: {
           ...formattedDomain.config,
           unsafeOpcodes: Array.from(formattedDomain.config.unsafeOpcodes),
+          allowedTargets: Array.from(formattedDomain.config.allowedTargets),
         },
       },
       updatedSafety: updatedSafety
         ? {
             ...updatedSafety,
             unsafeOpcodes: Array.from(updatedSafety.unsafeOpcodes),
+            allowedTargets: Array.from(updatedSafety.allowedTargets),
           }
         : undefined,
     },

--- a/demo/Validator-Constellation-v0/src/core/types.ts
+++ b/demo/Validator-Constellation-v0/src/core/types.ts
@@ -7,6 +7,7 @@ export interface DomainConfig {
   humanName: string;
   budgetLimit: bigint;
   unsafeOpcodes: Set<string>;
+  allowedTargets: Set<string>;
 }
 
 export interface GovernanceParameters {
@@ -155,6 +156,7 @@ export interface DomainSafetyUpdate {
   humanName?: string;
   budgetLimit?: bigint;
   unsafeOpcodes?: Iterable<string>;
+  allowedTargets?: Iterable<string>;
 }
 
 export interface ValidatorEventBus extends EventEmitter {


### PR DESCRIPTION
## Summary
- extend domain configuration with per-domain call allowlists enforced by the sentinel and exposed through reporting, dashboard, and documentation
- update scenario, operator console, and CLI tooling so non-technical owners can configure allowed targets and review them in state snapshots
- expand tests and demo flows to cover unauthorized target detection, ensuring new guardrails surface in artifacts and docs

## Testing
- `npm run lint:validator-constellation`
- `npm run test:validator-constellation`


------
https://chatgpt.com/codex/tasks/task_e_68ffd6100f1c8333a2dde8579b4257e0