### PR TITLE
Enhance validator constellation sentinel guardrails

### DIFF
--- a/demo/Validator-Constellation-v0/config/stellar-scenario.yaml
+++ b/demo/Validator-Constellation-v0/config/stellar-scenario.yaml
@@ -18,12 +18,19 @@ domains:
     unsafeOpcodes:
       - SELFDESTRUCT
       - DELEGATECALL
+    allowedTargets:
+      - "0xa11ce5c1e11ce000000000000000000000000000"
+      - "0xbeac0babe00000000000000000000000000000000"
+    maxCalldataBytes: 4096
   - id: orbital-yard
     humanName: "Orbital Manufacturing Yard"
     budgetLimit: 3000000
     unsafeOpcodes:
       - SELFDESTRUCT
       - STATICCALL
+    allowedTargets:
+      - "0xf0undry0ps000000000000000000000000000000"
+    maxCalldataBytes: 2048
 validators:
   - ens: andromeda.club.agi.eth
     address: "0x1111111111111111111111111111111111111111"
@@ -74,6 +81,16 @@ anomalies:
     agentEns: sentinel.agent.agi.eth
     opcode: STATICCALL
     description: "Sentinel attempted a disallowed static call"
+    calldataBytes: 8192
+  - kind: unauthorized-target
+    agentEns: nova.agent.agi.eth
+    target: "0xd15a11ee00000000000000000000000000000000"
+    description: "Nova attempted to reach an unapproved contract"
+  - kind: calldata-spike
+    agentEns: nova.agent.agi.eth
+    calldataBytes: 16384
+    description: "Nova attempted to upload an oversized payload"
+    target: "0xa11ce5c1e11ce000000000000000000000000000"
 ownerActions:
   updateSentinel:
     budgetGraceRatio: 0.12
@@ -84,6 +101,10 @@ ownerActions:
         - DELEGATECALL
         - STATICCALL
         - CALLCODE
+      allowedTargets:
+        - "0xa11ce5c1e11ce000000000000000000000000000"
+        - "0xbeac0babe00000000000000000000000000000000"
+      maxCalldataBytes: 6144
   pauseDomains:
     - domainId: orbital-yard
       reason: "pre-flight drill"

--- a/demo/Validator-Constellation-v0/scripts/operatorConsole.ts
+++ b/demo/Validator-Constellation-v0/scripts/operatorConsole.ts
@@ -101,7 +101,7 @@ function describeState(state: OperatorState, mermaid = false): void {
   state.domains.forEach((domain) => {
     const pauseInfo = domain.paused && domain.pauseReason ? `paused (${domain.pauseReason.reason})` : 'active';
     console.log(
-      `  - ${domain.id} :: ${domain.humanName} :: budget=${formatAgentBudget(domain.budgetLimit)} :: ${pauseInfo} :: unsafe=${domain.unsafeOpcodes.join(', ') || 'none'}`,
+      `  - ${domain.id} :: ${domain.humanName} :: budget=${formatAgentBudget(domain.budgetLimit)} :: ${pauseInfo} :: unsafe=${domain.unsafeOpcodes.join(', ') || 'none'} :: allowedTargets=${domain.allowedTargets.join(', ') || 'any'} :: calldata<=${domain.maxCalldataBytes}b`,
     );
   });
   console.log('\nNodes:');

--- a/demo/Validator-Constellation-v0/scripts/runDemo.ts
+++ b/demo/Validator-Constellation-v0/scripts/runDemo.ts
@@ -39,6 +39,11 @@ function main() {
   const maintenanceResume = demo.resumeDomain('lunar-foundry', 'governance:maintenance-complete');
   const updatedSafety = demo.updateDomainSafety('deep-space-lab', {
     unsafeOpcodes: new Set(['SELFDESTRUCT', 'DELEGATECALL', 'STATICCALL']),
+    allowedTargets: [
+      '0xa11ce5c1e11ce000000000000000000000000000',
+      '0xbeac0babe00000000000000000000000000000000',
+    ],
+    maxCalldataBytes: 6144,
   });
   demo.updateSentinelConfig({ budgetGraceRatio: 0.07 });
   const agentIdentity = demo.setAgentBudget(agentLeaf.ensName, 1_200_000n);
@@ -78,6 +83,8 @@ function main() {
       amountSpent: 12_500n,
       opcode: 'STATICCALL',
       description: 'Unsafe opcode invoked during maintenance bypass',
+      calldataBytes: 8_192,
+      metadata: { calldataBytes: 8_192 },
     },
     {
       ...budgetOverrunAction(
@@ -89,6 +96,24 @@ function main() {
       ),
       description: 'Overspend attempt detected by sentinel',
       metadata: { invoice: 'INV-7788' },
+    },
+    {
+      agent: agentIdentity,
+      domainId: 'deep-space-lab',
+      type: 'CALL',
+      amountSpent: 1_000n,
+      target: '0xd15a11ee00000000000000000000000000000000',
+      description: 'Call routed to unauthorized contract',
+    },
+    {
+      agent: agentIdentity,
+      domainId: 'deep-space-lab',
+      type: 'CALL',
+      amountSpent: 500n,
+      target: '0xa11ce5c1e11ce000000000000000000000000000',
+      calldataBytes: 16_384,
+      description: 'Oversized calldata surge',
+      metadata: { calldataBytes: 16_384 },
     },
   ];
 

--- a/demo/Validator-Constellation-v0/src/core/fixtures.ts
+++ b/demo/Validator-Constellation-v0/src/core/fixtures.ts
@@ -7,18 +7,27 @@ const RAW_DOMAIN_TEMPLATES: Array<{
   humanName: string;
   budgetLimit: bigint;
   unsafeOpcodes: string[];
+  allowedTargets: string[];
+  maxCalldataBytes: number;
 }> = [
   {
     id: 'deep-space-lab',
     humanName: 'Deep Space Research Lab',
     budgetLimit: 5_000_000n,
     unsafeOpcodes: ['SELFDESTRUCT', 'DELEGATECALL'],
+    allowedTargets: [
+      '0xa11ce5c1e11ce000000000000000000000000000',
+      '0xbeac0babe00000000000000000000000000000000',
+    ],
+    maxCalldataBytes: 4096,
   },
   {
     id: 'lunar-foundry',
     humanName: 'Lunar Foundry',
     budgetLimit: 2_000_000n,
     unsafeOpcodes: ['SELFDESTRUCT'],
+    allowedTargets: ['0xf0undry0ps000000000000000000000000000000'],
+    maxCalldataBytes: 2048,
   },
 ];
 
@@ -48,6 +57,8 @@ export function defaultDomains(): DomainConfig[] {
     humanName: domain.humanName,
     budgetLimit: domain.budgetLimit,
     unsafeOpcodes: new Set(domain.unsafeOpcodes),
+    allowedTargets: new Set(domain.allowedTargets.map((target) => target.toLowerCase())),
+    maxCalldataBytes: domain.maxCalldataBytes,
   }));
 }
 

--- a/demo/Validator-Constellation-v0/src/core/operatorState.ts
+++ b/demo/Validator-Constellation-v0/src/core/operatorState.ts
@@ -46,6 +46,8 @@ export interface OperatorDomain {
   humanName: string;
   budgetLimit: string;
   unsafeOpcodes: string[];
+  allowedTargets: string[];
+  maxCalldataBytes: number;
   paused: boolean;
   pauseReason?: OperatorDomainPause;
 }
@@ -70,6 +72,8 @@ function cloneSetupFromState(state: OperatorState): DemoSetup {
     humanName: domain.humanName,
     budgetLimit: BigInt(domain.budgetLimit),
     unsafeOpcodes: new Set(domain.unsafeOpcodes),
+    allowedTargets: new Set(domain.allowedTargets.map((target) => target.toLowerCase())),
+    maxCalldataBytes: domain.maxCalldataBytes,
   }));
   return {
     domains,
@@ -150,6 +154,8 @@ export function createInitialOperatorState(): OperatorState {
     humanName: domain.humanName,
     budgetLimit: domain.budgetLimit.toString(),
     unsafeOpcodes: Array.from(domain.unsafeOpcodes),
+    allowedTargets: Array.from(domain.allowedTargets),
+    maxCalldataBytes: domain.maxCalldataBytes,
     paused: false,
   }));
   return {
@@ -273,6 +279,8 @@ function updateDomainsFromDemo(state: OperatorState, demo: ValidatorConstellatio
       humanName: snapshot.config.humanName,
       budgetLimit: snapshot.config.budgetLimit.toString(),
       unsafeOpcodes: Array.from(snapshot.config.unsafeOpcodes),
+      allowedTargets: Array.from(snapshot.config.allowedTargets),
+      maxCalldataBytes: snapshot.config.maxCalldataBytes,
       paused: snapshot.paused,
       pauseReason: snapshot.pauseReason
         ? {
@@ -375,6 +383,8 @@ export function resetDomainsToDefault(state: OperatorState): void {
     humanName: domain.humanName,
     budgetLimit: domain.budgetLimit.toString(),
     unsafeOpcodes: Array.from(domain.unsafeOpcodes),
+    allowedTargets: Array.from(domain.allowedTargets),
+    maxCalldataBytes: domain.maxCalldataBytes,
     paused: false,
   }));
 }

--- a/demo/Validator-Constellation-v0/src/core/reporting.ts
+++ b/demo/Validator-Constellation-v0/src/core/reporting.ts
@@ -32,6 +32,7 @@ function formatDomainState(state: DomainState): DomainState {
     config: {
       ...state.config,
       unsafeOpcodes: new Set(state.config.unsafeOpcodes),
+      allowedTargets: new Set(state.config.allowedTargets),
     },
     pauseReason: state.pauseReason ? { ...state.pauseReason } : undefined,
   };
@@ -41,6 +42,7 @@ function cloneDomainConfig(config: DomainConfig): DomainConfig {
   return {
     ...config,
     unsafeOpcodes: new Set(config.unsafeOpcodes),
+    allowedTargets: new Set(config.allowedTargets),
   };
 }
 
@@ -159,6 +161,7 @@ function generateDashboardHTML(result: DemoOrchestrationReport, context: ReportC
           {
             parameters: context.governance,
             sentinelGraceRatio: context.sentinelGraceRatio,
+            domainCalldataLimit: context.primaryDomain.config.maxCalldataBytes,
           },
           null,
           2,
@@ -177,6 +180,18 @@ function generateDashboardHTML(result: DemoOrchestrationReport, context: ReportC
         <pre>${JSON.stringify(
           ownerNotes ?? {
             message: 'Provide scenario owner notes via context.ownerNotes',
+          },
+          null,
+          2,
+        )}</pre>
+      </section>
+      <section>
+        <h2>Domain Guardrails</h2>
+        <pre>${JSON.stringify(
+          {
+            unsafeOpcodes: Array.from(context.primaryDomain.config.unsafeOpcodes),
+            allowedTargets: Array.from(context.primaryDomain.config.allowedTargets),
+            maxCalldataBytes: context.primaryDomain.config.maxCalldataBytes,
           },
           null,
           2,
@@ -235,12 +250,16 @@ export function writeReportArtifacts(input: ArtifactInput): void {
         config: {
           ...formattedDomain.config,
           unsafeOpcodes: Array.from(formattedDomain.config.unsafeOpcodes),
+          allowedTargets: Array.from(formattedDomain.config.allowedTargets),
+          maxCalldataBytes: formattedDomain.config.maxCalldataBytes,
         },
       },
       updatedSafety: updatedSafety
         ? {
             ...updatedSafety,
             unsafeOpcodes: Array.from(updatedSafety.unsafeOpcodes),
+            allowedTargets: Array.from(updatedSafety.allowedTargets),
+            maxCalldataBytes: updatedSafety.maxCalldataBytes,
           }
         : undefined,
     },

--- a/demo/Validator-Constellation-v0/src/core/sentinel.ts
+++ b/demo/Validator-Constellation-v0/src/core/sentinel.ts
@@ -1,3 +1,4 @@
+import { keccak256, toUtf8Bytes } from 'ethers';
 import { eventBus } from './eventBus';
 import { DomainPauseController } from './domainPause';
 import { AgentAction, DomainConfig, Hex, SentinelAlert } from './types';
@@ -5,12 +6,23 @@ import { AgentAction, DomainConfig, Hex, SentinelAlert } from './types';
 interface SentinelConfig {
   budgetGraceRatio: number;
   unsafeOpcodes: Map<string, Set<string>>;
+  allowedTargets: Map<string, Set<string>>;
+  allowedTargetHashes: Map<string, Set<string>>;
+  maxCalldataBytes: Map<string, number>;
 }
 
 export class SentinelMonitor {
   private readonly spendTracker = new Map<Hex, bigint>();
 
   constructor(private readonly domainController: DomainPauseController, private readonly config: SentinelConfig) {}
+
+  private normalizeTarget(target: string): string {
+    return target.trim().toLowerCase();
+  }
+
+  private hashTarget(target: string): string {
+    return keccak256(toUtf8Bytes(target));
+  }
 
   private getDomainConfig(domainId: string): DomainConfig {
     return this.domainController.getState(domainId).config;
@@ -41,6 +53,47 @@ export class SentinelMonitor {
     const updated = previous + action.amountSpent;
     this.spendTracker.set(action.agent.address, updated);
 
+    const unsafeOpcodes = this.config.unsafeOpcodes.get(domain.id) ?? domain.unsafeOpcodes;
+    if (action.opcode && unsafeOpcodes.has(action.opcode)) {
+      return this.raiseAlert(action, 'UNSAFE_OPCODE', `unsafe opcode ${action.opcode} invoked`, 'HIGH', {
+        opcode: action.opcode,
+        target: action.target,
+      });
+    }
+
+    if (action.target) {
+      const allowed = this.config.allowedTargets.get(domain.id) ?? domain.allowedTargets;
+      if (allowed.size > 0) {
+        const normalizedTarget = this.normalizeTarget(action.target);
+        const hashedTarget = this.hashTarget(normalizedTarget);
+        const hashedSet = this.config.allowedTargetHashes.get(domain.id);
+        const hashedMatch = hashedSet ? hashedSet.has(hashedTarget) : allowed.has(normalizedTarget);
+        if (!allowed.has(normalizedTarget) || !hashedMatch) {
+          return this.raiseAlert(action, 'UNAUTHORIZED_TARGET', `target ${action.target} is not authorized`, 'CRITICAL', {
+            target: action.target,
+            normalizedTarget,
+            hashedTarget,
+            allowedTargets: Array.from(allowed),
+          });
+        }
+      }
+    }
+
+    const threshold = this.config.maxCalldataBytes.get(domain.id) ?? domain.maxCalldataBytes;
+    if (threshold > 0) {
+      const calldataBytes =
+        action.calldataBytes ??
+        (typeof action.metadata?.calldataBytes === 'number'
+          ? action.metadata.calldataBytes
+          : Number(action.metadata?.calldataBytes ?? 0));
+      if (Number.isFinite(calldataBytes) && calldataBytes > threshold) {
+        return this.raiseAlert(action, 'CALLDATA_EXPLOSION', `calldata size ${calldataBytes}b exceeds limit`, 'HIGH', {
+          calldataBytes,
+          threshold,
+        });
+      }
+    }
+
     const graceRatio = BigInt(Math.round(this.config.budgetGraceRatio * 1000));
     const grace = (action.agent.budget * graceRatio) / 1000n;
     if (updated > action.agent.budget + grace) {
@@ -48,14 +101,6 @@ export class SentinelMonitor {
         spent: updated.toString(),
         budget: action.agent.budget.toString(),
         grace: grace.toString(),
-      });
-    }
-
-    const unsafeOpcodes = this.config.unsafeOpcodes.get(domain.id) ?? domain.unsafeOpcodes;
-    if (action.opcode && unsafeOpcodes.has(action.opcode)) {
-      return this.raiseAlert(action, 'UNSAFE_OPCODE', `unsafe opcode ${action.opcode} invoked`, 'HIGH', {
-        opcode: action.opcode,
-        target: action.target,
       });
     }
 
@@ -84,5 +129,32 @@ export class SentinelMonitor {
       return new Set(fromConfig);
     }
     return new Set(this.getDomainConfig(domainId).unsafeOpcodes);
+  }
+
+  updateAllowedTargets(domainId: string, targets: Iterable<string>): void {
+    const normalized = Array.from(targets, (target) => this.normalizeTarget(target));
+    this.config.allowedTargets.set(domainId, new Set(normalized));
+    const hashed = normalized.map((target) => this.hashTarget(target));
+    this.config.allowedTargetHashes.set(domainId, new Set(hashed));
+  }
+
+  getAllowedTargets(domainId: string): Set<string> {
+    const fromConfig = this.config.allowedTargets.get(domainId);
+    if (fromConfig) {
+      return new Set(fromConfig);
+    }
+    const domainTargets = this.getDomainConfig(domainId).allowedTargets;
+    return new Set(Array.from(domainTargets, (target) => this.normalizeTarget(target)));
+  }
+
+  updateMaxCalldataBytes(domainId: string, limit: number): void {
+    if (!Number.isFinite(limit) || limit < 0) {
+      throw new Error('invalid calldata limit');
+    }
+    this.config.maxCalldataBytes.set(domainId, Math.floor(limit));
+  }
+
+  getMaxCalldataBytes(domainId: string): number {
+    return this.config.maxCalldataBytes.get(domainId) ?? this.getDomainConfig(domainId).maxCalldataBytes;
   }
 }

--- a/demo/Validator-Constellation-v0/src/core/types.ts
+++ b/demo/Validator-Constellation-v0/src/core/types.ts
@@ -17,6 +17,8 @@ export interface DomainConfig {
   humanName: string;
   budgetLimit: bigint;
   unsafeOpcodes: Set<string>;
+  allowedTargets: Set<string>;
+  maxCalldataBytes: number;
 }
 
 export interface GovernanceParameters {
@@ -54,6 +56,7 @@ export interface AgentAction {
   description: string;
   opcode?: string;
   target?: string;
+  calldataBytes?: number;
   metadata?: Record<string, unknown>;
 }
 
@@ -166,6 +169,8 @@ export interface DomainSafetyUpdate {
   humanName?: string;
   budgetLimit?: bigint;
   unsafeOpcodes?: Iterable<string>;
+  allowedTargets?: Iterable<string>;
+  maxCalldataBytes?: number;
 }
 
 export interface ValidatorEventBus extends EventEmitter {


### PR DESCRIPTION
## Summary
- enforce domain allowlists, calldata ceilings, and hashed witness reporting across the validator constellation sentinel
- extend scenario automation, CLI tooling, and reporting outputs to surface new guardrail metadata for non-technical operators
- expand test coverage for unauthorized targets, calldata surges, and ensure scenario alerts surface in generated artifacts

## Testing
- npm run lint:validator-constellation
- npm run test:validator-constellation

------
https://chatgpt.com/codex/tasks/task_e_69000e0c90f48333bbd6b369401f6d37