### PR TITLE
feat: expand economic power sovereignty controls

### DIFF
--- a/demo/Economic-Power-v0/README.md
+++ b/demo/Economic-Power-v0/README.md
@@ -25,6 +25,7 @@ Outputs land in `demo/Economic-Power-v0/reports/`:
 - `flow.mmd` – architecture graph for immediate inclusion in runbooks and dashboards.
 - `timeline.mmd` – Gantt macro for orchestration cadence.
 - `owner-control.json` – up-to-the-minute control matrix for the owner’s multi-sig.
+- `owner-sovereignty.json` – sovereign safety mesh blueprint (pause/resume drills, circuit breakers, upgrade commands, and coverage metrics).
 
 > **Non-technical quick start** – run `npm run demo:economic-power` then open `demo/Economic-Power-v0/ui/index.html` with any static server (`npx http-server demo/Economic-Power-v0/ui`). The dashboard autoloads the generated reports.
 
@@ -87,9 +88,11 @@ The CLI recalculates ROI, payback horizon, validator confidence, and writes the 
 The UI inside `demo/Economic-Power-v0/ui/` offers:
 
 - Metric cards covering ROI, net yield, validator confidence, throughput, and treasury position.
+- Expanded metrics for **Stability Index** and **Owner Command Coverage** quantifying how completely the multi-sig governs the stack.
 - Interactive job-to-agent tables to inspect assignments and validator stakes.
 - Live Mermaid rendering of the architecture and timeline.
 - Drag-and-drop support for alternative `summary.json` files for instant what-if exploration.
+- Sovereign safety mesh panel cataloguing pause/resume playbooks, emergency contacts, circuit breakers, and module upgrade routes.
 
 Launch with:
 

--- a/demo/Economic-Power-v0/reports/owner-sovereignty.json
+++ b/demo/Economic-Power-v0/reports/owner-sovereignty.json
@@ -1,0 +1,52 @@
+{
+  "pauseScript": "npm run owner:system-pause",
+  "resumeScript": "npm run owner:update-all",
+  "responseMinutes": 9,
+  "emergencyContacts": [
+    "governance@agijobs.ai",
+    "security-operations@agijobs.ai",
+    "treasury@agijobs.ai"
+  ],
+  "circuitBreakers": [
+    {
+      "metric": "validatorConfidence",
+      "comparator": "<",
+      "threshold": 0.95,
+      "action": "npm run owner:system-pause",
+      "description": "Pause contracts if validator confidence slips below 95% to protect settlement integrity."
+    },
+    {
+      "metric": "automationScore",
+      "comparator": "<",
+      "threshold": 0.8,
+      "action": "npm run owner:parameters",
+      "description": "Recalibrate automation if orchestration coverage drops under 80%."
+    },
+    {
+      "metric": "treasuryAfterRun",
+      "comparator": "<",
+      "threshold": 1800000,
+      "action": "npm run owner:audit",
+      "description": "Trigger treasury forensic audit when buffers fall below the defensive floor."
+    }
+  ],
+  "upgradePaths": [
+    {
+      "module": "JobRegistry",
+      "script": "npm run owner:update-all",
+      "description": "Ships the hardened JobRegistry bundle with deterministic migration plan."
+    },
+    {
+      "module": "ValidationModule",
+      "script": "npm run owner:upgrade",
+      "description": "Activates the upgraded validator commit–reveal consensus parameters."
+    },
+    {
+      "module": "StakeManager",
+      "script": "npm run owner:parameters",
+      "description": "Rebalances stake requirements to throttle spam and fortify incentives."
+    }
+  ],
+  "stabilityIndex": 0.736,
+  "ownerCommandCoverage": 0.313
+}

--- a/demo/Economic-Power-v0/reports/summary.json
+++ b/demo/Economic-Power-v0/reports/summary.json
@@ -1,7 +1,7 @@
 {
   "scenarioId": "economic-power-v0-baseline",
   "title": "AGIJobs Economic Power Launch",
-  "generatedAt": "2025-10-28T01:46:10.015Z",
+  "generatedAt": "2025-10-28T05:33:41.741Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -17,7 +17,9 @@
     "throughputJobsPerDay": 0.87,
     "validatorConfidence": 0.9812,
     "automationScore": 0.852,
-    "riskMitigationScore": 0.912
+    "riskMitigationScore": 0.912,
+    "stabilityIndex": 0.736,
+    "ownerCommandCoverage": 0.313
   },
   "ownerControl": {
     "threshold": "4-of-7",
@@ -44,6 +46,56 @@
         "target": "USDC v2",
         "script": "npm run owner:update-all",
         "description": "Owner upgrades fiat on/off-ramp adapter with improved slippage guarantees."
+      }
+    ]
+  },
+  "ownerSovereignty": {
+    "pauseScript": "npm run owner:system-pause",
+    "resumeScript": "npm run owner:update-all",
+    "responseMinutes": 9,
+    "emergencyContacts": [
+      "governance@agijobs.ai",
+      "security-operations@agijobs.ai",
+      "treasury@agijobs.ai"
+    ],
+    "circuitBreakers": [
+      {
+        "metric": "validatorConfidence",
+        "comparator": "<",
+        "threshold": 0.95,
+        "action": "npm run owner:system-pause",
+        "description": "Pause contracts if validator confidence slips below 95% to protect settlement integrity."
+      },
+      {
+        "metric": "automationScore",
+        "comparator": "<",
+        "threshold": 0.8,
+        "action": "npm run owner:parameters",
+        "description": "Recalibrate automation if orchestration coverage drops under 80%."
+      },
+      {
+        "metric": "treasuryAfterRun",
+        "comparator": "<",
+        "threshold": 1800000,
+        "action": "npm run owner:audit",
+        "description": "Trigger treasury forensic audit when buffers fall below the defensive floor."
+      }
+    ],
+    "upgradePaths": [
+      {
+        "module": "JobRegistry",
+        "script": "npm run owner:update-all",
+        "description": "Ships the hardened JobRegistry bundle with deterministic migration plan."
+      },
+      {
+        "module": "ValidationModule",
+        "script": "npm run owner:upgrade",
+        "description": "Activates the upgraded validator commit–reveal consensus parameters."
+      },
+      {
+        "module": "StakeManager",
+        "script": "npm run owner:parameters",
+        "description": "Rebalances stake requirements to throttle spam and fortify incentives."
       }
     ]
   },

--- a/demo/Economic-Power-v0/scenario/baseline.json
+++ b/demo/Economic-Power-v0/scenario/baseline.json
@@ -203,6 +203,59 @@
       "monitoring/grafana/economic-flightdeck.json",
       "monitoring/grafana/validator-health.json"
     ],
-    "alertChannels": ["slack://agi-ops-economic-power", "pagerduty://agi-critical"]
+    "alertChannels": [
+      "slack://agi-ops-economic-power",
+      "pagerduty://agi-critical"
+    ]
+  },
+  "safeguards": {
+    "pauseScript": "npm run owner:system-pause",
+    "resumeScript": "npm run owner:update-all",
+    "responseMinutes": 9,
+    "emergencyContacts": [
+      "governance@agijobs.ai",
+      "security-operations@agijobs.ai",
+      "treasury@agijobs.ai"
+    ],
+    "circuitBreakers": [
+      {
+        "metric": "validatorConfidence",
+        "comparator": "<",
+        "threshold": 0.95,
+        "action": "npm run owner:system-pause",
+        "description": "Pause contracts if validator confidence slips below 95% to protect settlement integrity."
+      },
+      {
+        "metric": "automationScore",
+        "comparator": "<",
+        "threshold": 0.8,
+        "action": "npm run owner:parameters",
+        "description": "Recalibrate automation if orchestration coverage drops under 80%."
+      },
+      {
+        "metric": "treasuryAfterRun",
+        "comparator": "<",
+        "threshold": 1800000,
+        "action": "npm run owner:audit",
+        "description": "Trigger treasury forensic audit when buffers fall below the defensive floor."
+      }
+    ],
+    "upgradePaths": [
+      {
+        "module": "JobRegistry",
+        "script": "npm run owner:update-all",
+        "description": "Ships the hardened JobRegistry bundle with deterministic migration plan."
+      },
+      {
+        "module": "ValidationModule",
+        "script": "npm run owner:upgrade",
+        "description": "Activates the upgraded validator commit–reveal consensus parameters."
+      },
+      {
+        "module": "StakeManager",
+        "script": "npm run owner:parameters",
+        "description": "Rebalances stake requirements to throttle spam and fortify incentives."
+      }
+    ]
   }
 }

--- a/demo/Economic-Power-v0/test/economic_power_demo.test.ts
+++ b/demo/Economic-Power-v0/test/economic_power_demo.test.ts
@@ -16,10 +16,28 @@ test('economic power simulation produces deterministic metrics', async () => {
   assert(summary.metrics.paybackHours > 0, 'Payback hours should be positive');
   assert(summary.mermaidFlow.includes('graph TD'), 'Flow mermaid diagram should be rendered');
   assert(summary.mermaidTimeline.includes('gantt'), 'Timeline mermaid diagram should be rendered');
+  assert(summary.metrics.stabilityIndex >= 0.65, 'Stability index should be within resilience band');
+  assert(summary.metrics.ownerCommandCoverage > 0.2, 'Owner command coverage should be non-trivial');
 
   const ownerParameters = summary.ownerControl.controls.map((control) => control.parameter);
   for (const control of scenario.owner.controls) {
     assert(ownerParameters.includes(control.parameter));
   }
+
+  assert.equal(
+    summary.ownerSovereignty.pauseScript,
+    scenario.safeguards.pauseScript,
+    'Pause script should mirror scenario safeguards',
+  );
+  assert.equal(
+    summary.ownerSovereignty.resumeScript,
+    scenario.safeguards.resumeScript,
+    'Resume script should mirror scenario safeguards',
+  );
+  assert.equal(
+    summary.ownerSovereignty.circuitBreakers.length,
+    scenario.safeguards.circuitBreakers.length,
+    'Circuit breaker counts should align',
+  );
 });
 

--- a/demo/Economic-Power-v0/ui/data/default-summary.json
+++ b/demo/Economic-Power-v0/ui/data/default-summary.json
@@ -1,7 +1,7 @@
 {
   "scenarioId": "economic-power-v0-baseline",
   "title": "AGIJobs Economic Power Launch",
-  "generatedAt": "2025-01-01T00:00:00.000Z",
+  "generatedAt": "2025-10-28T05:33:23.409Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -17,7 +17,9 @@
     "throughputJobsPerDay": 0.87,
     "validatorConfidence": 0.9812,
     "automationScore": 0.852,
-    "riskMitigationScore": 0.912
+    "riskMitigationScore": 0.912,
+    "stabilityIndex": 0.736,
+    "ownerCommandCoverage": 0.313
   },
   "ownerControl": {
     "threshold": "4-of-7",
@@ -44,6 +46,56 @@
         "target": "USDC v2",
         "script": "npm run owner:update-all",
         "description": "Owner upgrades fiat on/off-ramp adapter with improved slippage guarantees."
+      }
+    ]
+  },
+  "ownerSovereignty": {
+    "pauseScript": "npm run owner:system-pause",
+    "resumeScript": "npm run owner:update-all",
+    "responseMinutes": 9,
+    "emergencyContacts": [
+      "governance@agijobs.ai",
+      "security-operations@agijobs.ai",
+      "treasury@agijobs.ai"
+    ],
+    "circuitBreakers": [
+      {
+        "metric": "validatorConfidence",
+        "comparator": "<",
+        "threshold": 0.95,
+        "action": "npm run owner:system-pause",
+        "description": "Pause contracts if validator confidence slips below 95% to protect settlement integrity."
+      },
+      {
+        "metric": "automationScore",
+        "comparator": "<",
+        "threshold": 0.8,
+        "action": "npm run owner:parameters",
+        "description": "Recalibrate automation if orchestration coverage drops under 80%."
+      },
+      {
+        "metric": "treasuryAfterRun",
+        "comparator": "<",
+        "threshold": 1800000,
+        "action": "npm run owner:audit",
+        "description": "Trigger treasury forensic audit when buffers fall below the defensive floor."
+      }
+    ],
+    "upgradePaths": [
+      {
+        "module": "JobRegistry",
+        "script": "npm run owner:update-all",
+        "description": "Ships the hardened JobRegistry bundle with deterministic migration plan."
+      },
+      {
+        "module": "ValidationModule",
+        "script": "npm run owner:upgrade",
+        "description": "Activates the upgraded validator commit–reveal consensus parameters."
+      },
+      {
+        "module": "StakeManager",
+        "script": "npm run owner:parameters",
+        "description": "Rebalances stake requirements to throttle spam and fortify incentives."
       }
     ]
   },

--- a/demo/Economic-Power-v0/ui/index.html
+++ b/demo/Economic-Power-v0/ui/index.html
@@ -44,6 +44,52 @@
         </table>
       </section>
 
+      <section class="panel" aria-labelledby="sovereignty-heading">
+        <div class="panel-header">
+          <h2 id="sovereignty-heading">Sovereign safety mesh</h2>
+          <p>Pause, resume, and upgrade the entire economic fabric with deterministic commands.</p>
+        </div>
+        <div class="sovereignty-grid">
+          <article class="sovereignty-card" aria-label="Pause and resume playbooks">
+            <h3>Immediate actions</h3>
+            <div id="pause-resume"></div>
+            <h4>Emergency contacts</h4>
+            <ul id="emergency-contacts"></ul>
+          </article>
+          <article class="sovereignty-card" aria-label="Circuit breakers">
+            <h3>Circuit breakers</h3>
+            <div class="table-wrapper">
+              <table id="circuit-table">
+                <thead>
+                  <tr>
+                    <th>Metric</th>
+                    <th>Threshold</th>
+                    <th>Action</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </article>
+          <article class="sovereignty-card" aria-label="Upgrade routes">
+            <h3>Upgrade paths</h3>
+            <div class="table-wrapper">
+              <table id="upgrade-table">
+                <thead>
+                  <tr>
+                    <th>Module</th>
+                    <th>Command</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </article>
+        </div>
+      </section>
+
       <section class="panel" aria-labelledby="assignment-heading">
         <div class="panel-header">
           <h2 id="assignment-heading">Job deployment map</h2>

--- a/demo/Economic-Power-v0/ui/styles.css
+++ b/demo/Economic-Power-v0/ui/styles.css
@@ -124,6 +124,67 @@ main {
   box-shadow: 0 25px 45px rgba(8, 20, 40, 0.55);
 }
 
+.sovereignty-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.sovereignty-card {
+  background: rgba(7, 13, 26, 0.75);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 20px 35px rgba(4, 10, 24, 0.55);
+}
+
+.sovereignty-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--accent);
+}
+
+.sovereignty-card h4 {
+  margin: 0.5rem 0 0.25rem;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+#pause-resume p {
+  margin: 0.35rem 0;
+  font-size: 0.9rem;
+}
+
+#pause-resume code,
+#circuit-table code,
+#upgrade-table code {
+  background: rgba(56, 189, 248, 0.12);
+  padding: 0.15rem 0.35rem;
+  border-radius: 0.4rem;
+  font-size: 0.85rem;
+}
+
+#emergency-contacts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+#emergency-contacts li {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(94, 234, 212, 0.2);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.85rem;
+}
+
 .panel-header h2 {
   margin: 0 0 0.5rem 0;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- extend the Economic Power scenario and simulator with sovereignty safeguards, stability modelling, and owner command coverage metrics
- emit a new owner-sovereignty artifact and surface the controls, circuit breakers, and upgrade paths in the UI dashboard
- document the new control surfaces and harden demo tests around sovereignty and stability guarantees

## Testing
- npm run demo:economic-power:ci
- npm run test:economic-power

------
https://chatgpt.com/codex/tasks/task_e_690054ac07ac8333a88087d4f1afe845