### PR TITLE
Add global expansion analytics to Economic Power demo

### DIFF
--- a/demo/Economic-Power-v0/README.md
+++ b/demo/Economic-Power-v0/README.md
@@ -24,8 +24,10 @@ Outputs land in `demo/Economic-Power-v0/reports/`:
 - `summary.json` – canonical metrics ledger (ROI, payback, validator confidence, automation score).
 - `flow.mmd` – architecture graph for immediate inclusion in runbooks and dashboards.
 - `timeline.mmd` – Gantt macro for orchestration cadence.
+- `expansion.mmd` – cross-chain expansion graph capturing bridge throughput and deployment waves.
 - `owner-control.json` – up-to-the-minute control matrix for the owner’s multi-sig.
 - `owner-sovereignty.json` – sovereign safety mesh blueprint (pause/resume drills, circuit breakers, upgrade commands, and coverage metrics).
+- `global-expansion.json` – structured dataset of bridge capacity, compliance posture, unstoppable mirrors, and runway metrics for analytics pipelines.
 
 > **Non-technical quick start** – run `npm run demo:economic-power` then open `demo/Economic-Power-v0/ui/index.html` with any static server (`npx http-server demo/Economic-Power-v0/ui`). The dashboard autoloads the generated reports.
 
@@ -89,10 +91,21 @@ The UI inside `demo/Economic-Power-v0/ui/` offers:
 
 - Metric cards covering ROI, net yield, validator confidence, throughput, and treasury position.
 - Expanded metrics for **Stability Index** and **Owner Command Coverage** quantifying how completely the multi-sig governs the stack.
+- New capital velocity, validator utilisation, and treasury runway gauges so operators can reason about scale and survivability instantly.
 - Interactive job-to-agent tables to inspect assignments and validator stakes.
 - Live Mermaid rendering of the architecture and timeline.
 - Drag-and-drop support for alternative `summary.json` files for instant what-if exploration.
 - Sovereign safety mesh panel cataloguing pause/resume playbooks, emergency contacts, circuit breakers, and module upgrade routes.
+- Global expansion matrix for bridge status, deployment waves, and unstoppable access surfaces.
+
+## Global expansion oversight
+
+Every scenario now packages a `global-expansion.json` and `expansion.mmd` artefact so the owner can trace where throughput comes from, which bridges are online, and how unstoppable access is hardened. The dashboard exposes:
+
+- **Bridge posture** – throughput, average gas cost, and the operations safe responsible for each L2 ramp.
+- **Deployment waves** – readiness scoring with explicit objectives, letting the owner fast-track or pause regional launches.
+- **Unstoppable mesh** – Tor/IPFS/Arweave mirrors and jurisdictional policies surfaced for instant compliance sign-off.
+- **Runway analytics** – capital velocity, validator utilisation, and treasury runway metrics update with each run, proving the economy’s survivability.
 
 Launch with:
 
@@ -125,5 +138,6 @@ This guarantees a **fully green v2 CI gate**. Pull requests and `main` share ide
 - ✅ Owner-first command catalog for every mutable lever.
 - ✅ Observability artefacts (Mermaid, JSON, HTML dashboard).
 - ✅ Non-technical operations workflow from single command to actionable dashboard.
+- ✅ Planetary expansion dossier marrying throughput, compliance and unstoppable infrastructure.
 
 Run the loop, inspect the telemetry, execute the owner change-set, and step into an economy-scale command role.

--- a/demo/Economic-Power-v0/reports/expansion.mmd
+++ b/demo/Economic-Power-v0/reports/expansion.mmd
@@ -1,0 +1,19 @@
+graph TD
+    Mainnet[Ethereum Mainnet Treasury]
+    Mainnet -->|Bridge ops| Arbitrum_One[Arbitrum One\nPILOT\n1,800 jobs/day\n$0.18 avg tx]
+    Mainnet -->|Bridge ops| Optimism[Optimism\nREADY\n2,200 jobs/day\n$0.21 avg tx]
+    Mainnet -->|Bridge ops| Base[Base\nLIVE\n2,600 jobs/day\n$0.16 avg tx]
+    Wave_phase_1[Testnet Beta Swarm\nStart +0h\nReadiness 92%]
+      Wave_phase_1 --> Objective_0_0[Simulate 500 concurrent jobs]
+      Wave_phase_1 --> Objective_0_1[Stress validator committee rotation]
+      Wave_phase_1 --> Objective_0_2[Collect latency telemetry]
+    Wave_phase_1 --> Wave_phase_2
+    Wave_phase_2[Mainnet Pilot Guild\nStart +120h\nReadiness 88%]
+      Wave_phase_2 --> Objective_1_0[Onboard curated Fortune 100 tasks]
+      Wave_phase_2 --> Objective_1_1[Validate fiat on-ramp flows]
+      Wave_phase_2 --> Objective_1_2[Exercise dispute escalations]
+    Wave_phase_2 --> Wave_phase_3
+    Wave_phase_3[Global Unlocked Mesh\nStart +240h\nReadiness 81%]
+      Wave_phase_3 --> Objective_2_0[Open participation to global agents]
+      Wave_phase_3 --> Objective_2_1[Activate cross-chain liquidity gauges]
+      Wave_phase_3 --> Objective_2_2[Launch policy observatory]

--- a/demo/Economic-Power-v0/reports/global-expansion.json
+++ b/demo/Economic-Power-v0/reports/global-expansion.json
@@ -1,0 +1,87 @@
+{
+  "l2Bridges": [
+    {
+      "network": "Arbitrum One",
+      "status": "pilot",
+      "throughputPerDay": 1800,
+      "txCostUsd": 0.18,
+      "operationsSafe": "0xArbitrumOpsSafe00000000000000000000001"
+    },
+    {
+      "network": "Optimism",
+      "status": "ready",
+      "throughputPerDay": 2200,
+      "txCostUsd": 0.21,
+      "operationsSafe": "0xOptimismOpsSafe0000000000000000000002"
+    },
+    {
+      "network": "Base",
+      "status": "live",
+      "throughputPerDay": 2600,
+      "txCostUsd": 0.16,
+      "operationsSafe": "0xBaseOpsSafe000000000000000000000003"
+    }
+  ],
+  "deploymentWaves": [
+    {
+      "id": "phase-1",
+      "title": "Testnet Beta Swarm",
+      "startHour": 0,
+      "readinessScore": 0.92,
+      "objectives": [
+        "Simulate 500 concurrent jobs",
+        "Stress validator committee rotation",
+        "Collect latency telemetry"
+      ]
+    },
+    {
+      "id": "phase-2",
+      "title": "Mainnet Pilot Guild",
+      "startHour": 120,
+      "readinessScore": 0.88,
+      "objectives": [
+        "Onboard curated Fortune 100 tasks",
+        "Validate fiat on-ramp flows",
+        "Exercise dispute escalations"
+      ]
+    },
+    {
+      "id": "phase-3",
+      "title": "Global Unlocked Mesh",
+      "startHour": 240,
+      "readinessScore": 0.81,
+      "objectives": [
+        "Open participation to global agents",
+        "Activate cross-chain liquidity gauges",
+        "Launch policy observatory"
+      ]
+    }
+  ],
+  "compliance": {
+    "jurisdictions": [
+      "US",
+      "EU",
+      "SG"
+    ],
+    "policies": [
+      "Automated withholding & tax memo",
+      "Validator KYC attestation registry",
+      "Real-time sanction screening"
+    ],
+    "unstoppableAccess": [
+      "Tor hidden service endpoint",
+      "IPFS pinset mirror",
+      "Arweave resilience archive"
+    ],
+    "unstoppableMirrors": [
+      "agijobs.eth",
+      "agi-jobs.limo",
+      "agi-jobs.ipns.link"
+    ]
+  },
+  "metrics": {
+    "capitalVelocity": 0.573,
+    "validatorUtilization": 1,
+    "treasuryRunwayDays": 30.25
+  }
+}

--- a/demo/Economic-Power-v0/reports/owner-sovereignty.json
+++ b/demo/Economic-Power-v0/reports/owner-sovereignty.json
@@ -39,7 +39,7 @@
     {
       "module": "ValidationModule",
       "script": "npm run owner:upgrade",
-      "description": "Activates the upgraded validator commit–reveal consensus parameters."
+      "description": "Activates the upgraded validator commit\u2013reveal consensus parameters."
     },
     {
       "module": "StakeManager",

--- a/demo/Economic-Power-v0/reports/summary.json
+++ b/demo/Economic-Power-v0/reports/summary.json
@@ -1,7 +1,7 @@
 {
   "scenarioId": "economic-power-v0-baseline",
   "title": "AGIJobs Economic Power Launch",
-  "generatedAt": "2025-10-28T05:33:41.741Z",
+  "generatedAt": "2025-10-28T11:42:22.792Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -19,7 +19,10 @@
     "automationScore": 0.852,
     "riskMitigationScore": 0.912,
     "stabilityIndex": 0.736,
-    "ownerCommandCoverage": 0.313
+    "ownerCommandCoverage": 0.313,
+    "capitalVelocity": 0.573,
+    "validatorUtilization": 1,
+    "treasuryRunwayDays": 30.25
   },
   "ownerControl": {
     "threshold": "4-of-7",
@@ -90,7 +93,7 @@
       {
         "module": "ValidationModule",
         "script": "npm run owner:upgrade",
-        "description": "Activates the upgraded validator commit–reveal consensus parameters."
+        "description": "Activates the upgraded validator commit\u2013reveal consensus parameters."
       },
       {
         "module": "StakeManager",
@@ -249,5 +252,88 @@
     }
   ],
   "mermaidFlow": "graph TD\n    OwnerSafe[Owner Multi-Sig\\nThreshold 4-of-7] -->|Configures| Orchestrator[Economic Power Orchestrator]\n    OwnerSafe[Owner Multi-Sig\\nThreshold 4-of-7] -->|Funds| Treasury[Treasury Escrow Vault]\n    Treasury[Treasury Escrow Vault] -->|Swaps| StablecoinAdapter[Stablecoin Adapter]\n    StablecoinAdapter[Stablecoin Adapter] -->|Escrow| Orchestrator[Economic Power Orchestrator]\n    Orchestrator[Economic Power Orchestrator]\n        Job_job_ai_lab_fusion[AI Lab Fusion Accelerator]\n    Job_job_supply_chain[Autonomous Supply Mesh]\n    Job_job_governance_upgrade[Governance Upgrade Launch]\n    Job_job_market_expansion[Market Expansion Omniloop]\n    Job_job_oracle_integration[Oracle Integration Spine]\n    Orchestrator -->|Posts| Job_job_ai_lab_fusion\n    Job_job_ai_lab_fusion -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_ai_lab_fusion -->|Validates| ValidatorSet_job_ai_lab_fusion[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta, Validator Epsilon]\n    Orchestrator -->|Posts| Job_job_supply_chain\n    Job_job_supply_chain -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_supply_chain -->|Validates| ValidatorSet_job_supply_chain[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta]\n    Orchestrator -->|Posts| Job_job_governance_upgrade\n    Job_job_governance_upgrade -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_governance_upgrade -->|Validates| ValidatorSet_job_governance_upgrade[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta, Validator Epsilon]\n    Orchestrator -->|Posts| Job_job_market_expansion\n    Job_job_market_expansion -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_market_expansion -->|Validates| ValidatorSet_job_market_expansion[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta]\n    Orchestrator -->|Posts| Job_job_oracle_integration\n    Job_job_oracle_integration -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_oracle_integration -->|Validates| ValidatorSet_job_oracle_integration[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma]",
-  "mermaidTimeline": "gantt\n    title Economic Power Execution Timeline\n    dateFormat X\n    section AI Lab Fusion Accelerator\n      Atlas Strategic Model Forge :active, job-ai-lab-fusion, 0.0h, 36.5h\n    section Autonomous Supply Mesh\n      Atlas Strategic Model Forge :active, job-supply-chain, 36.5h, 26.9h\n    section Governance Upgrade Launch\n      Atlas Strategic Model Forge :active, job-governance-upgrade, 63.4h, 28.4h\n    section Market Expansion Omniloop\n      Atlas Strategic Model Forge :active, job-market-expansion, 91.8h, 23.4h\n    section Oracle Integration Spine\n      Atlas Strategic Model Forge :active, job-oracle-integration, 115.2h, 22.3h"
+  "mermaidTimeline": "gantt\n    title Economic Power Execution Timeline\n    dateFormat X\n    section AI Lab Fusion Accelerator\n      Atlas Strategic Model Forge :active, job-ai-lab-fusion, 0.0h, 36.5h\n    section Autonomous Supply Mesh\n      Atlas Strategic Model Forge :active, job-supply-chain, 36.5h, 26.9h\n    section Governance Upgrade Launch\n      Atlas Strategic Model Forge :active, job-governance-upgrade, 63.4h, 28.4h\n    section Market Expansion Omniloop\n      Atlas Strategic Model Forge :active, job-market-expansion, 91.8h, 23.4h\n    section Oracle Integration Spine\n      Atlas Strategic Model Forge :active, job-oracle-integration, 115.2h, 22.3h",
+  "mermaidExpansion": "graph TD\n    Mainnet[Ethereum Mainnet Treasury]\n    Mainnet -->|Bridge ops| Arbitrum_One[Arbitrum One\\nPILOT\\n1,800 jobs/day\\n$0.18 avg tx]\n    Mainnet -->|Bridge ops| Optimism[Optimism\\nREADY\\n2,200 jobs/day\\n$0.21 avg tx]\n    Mainnet -->|Bridge ops| Base[Base\\nLIVE\\n2,600 jobs/day\\n$0.16 avg tx]\n    Wave_phase_1[Testnet Beta Swarm\\nStart +0h\\nReadiness 92%]\n      Wave_phase_1 --> Objective_0_0[Simulate 500 concurrent jobs]\n      Wave_phase_1 --> Objective_0_1[Stress validator committee rotation]\n      Wave_phase_1 --> Objective_0_2[Collect latency telemetry]\n    Wave_phase_1 --> Wave_phase_2\n    Wave_phase_2[Mainnet Pilot Guild\\nStart +120h\\nReadiness 88%]\n      Wave_phase_2 --> Objective_1_0[Onboard curated Fortune 100 tasks]\n      Wave_phase_2 --> Objective_1_1[Validate fiat on-ramp flows]\n      Wave_phase_2 --> Objective_1_2[Exercise dispute escalations]\n    Wave_phase_2 --> Wave_phase_3\n    Wave_phase_3[Global Unlocked Mesh\\nStart +240h\\nReadiness 81%]\n      Wave_phase_3 --> Objective_2_0[Open participation to global agents]\n      Wave_phase_3 --> Objective_2_1[Activate cross-chain liquidity gauges]\n      Wave_phase_3 --> Objective_2_2[Launch policy observatory]",
+  "expansion": {
+    "l2Bridges": [
+      {
+        "network": "Arbitrum One",
+        "status": "pilot",
+        "throughputPerDay": 1800,
+        "txCostUsd": 0.18,
+        "operationsSafe": "0xArbitrumOpsSafe00000000000000000000001"
+      },
+      {
+        "network": "Optimism",
+        "status": "ready",
+        "throughputPerDay": 2200,
+        "txCostUsd": 0.21,
+        "operationsSafe": "0xOptimismOpsSafe0000000000000000000002"
+      },
+      {
+        "network": "Base",
+        "status": "live",
+        "throughputPerDay": 2600,
+        "txCostUsd": 0.16,
+        "operationsSafe": "0xBaseOpsSafe000000000000000000000003"
+      }
+    ],
+    "deploymentWaves": [
+      {
+        "id": "phase-1",
+        "title": "Testnet Beta Swarm",
+        "startHour": 0,
+        "readinessScore": 0.92,
+        "objectives": [
+          "Simulate 500 concurrent jobs",
+          "Stress validator committee rotation",
+          "Collect latency telemetry"
+        ]
+      },
+      {
+        "id": "phase-2",
+        "title": "Mainnet Pilot Guild",
+        "startHour": 120,
+        "readinessScore": 0.88,
+        "objectives": [
+          "Onboard curated Fortune 100 tasks",
+          "Validate fiat on-ramp flows",
+          "Exercise dispute escalations"
+        ]
+      },
+      {
+        "id": "phase-3",
+        "title": "Global Unlocked Mesh",
+        "startHour": 240,
+        "readinessScore": 0.81,
+        "objectives": [
+          "Open participation to global agents",
+          "Activate cross-chain liquidity gauges",
+          "Launch policy observatory"
+        ]
+      }
+    ],
+    "compliance": {
+      "jurisdictions": [
+        "US",
+        "EU",
+        "SG"
+      ],
+      "policies": [
+        "Automated withholding & tax memo",
+        "Validator KYC attestation registry",
+        "Real-time sanction screening"
+      ],
+      "unstoppableAccess": [
+        "Tor hidden service endpoint",
+        "IPFS pinset mirror",
+        "Arweave resilience archive"
+      ],
+      "unstoppableMirrors": [
+        "agijobs.eth",
+        "agi-jobs.limo",
+        "agi-jobs.ipns.link"
+      ]
+    }
+  }
 }

--- a/demo/Economic-Power-v0/scenario/baseline.json
+++ b/demo/Economic-Power-v0/scenario/baseline.json
@@ -257,5 +257,83 @@
         "description": "Rebalances stake requirements to throttle spam and fortify incentives."
       }
     ]
+  },
+  "expansion": {
+    "l2Bridges": [
+      {
+        "network": "Arbitrum One",
+        "status": "pilot",
+        "throughputPerDay": 1800,
+        "txCostUsd": 0.18,
+        "operationsSafe": "0xArbitrumOpsSafe00000000000000000000001"
+      },
+      {
+        "network": "Optimism",
+        "status": "ready",
+        "throughputPerDay": 2200,
+        "txCostUsd": 0.21,
+        "operationsSafe": "0xOptimismOpsSafe0000000000000000000002"
+      },
+      {
+        "network": "Base",
+        "status": "live",
+        "throughputPerDay": 2600,
+        "txCostUsd": 0.16,
+        "operationsSafe": "0xBaseOpsSafe000000000000000000000003"
+      }
+    ],
+    "deploymentWaves": [
+      {
+        "id": "phase-1",
+        "title": "Testnet Beta Swarm",
+        "startHour": 0,
+        "readinessScore": 0.92,
+        "objectives": [
+          "Simulate 500 concurrent jobs",
+          "Stress validator committee rotation",
+          "Collect latency telemetry"
+        ]
+      },
+      {
+        "id": "phase-2",
+        "title": "Mainnet Pilot Guild",
+        "startHour": 120,
+        "readinessScore": 0.88,
+        "objectives": [
+          "Onboard curated Fortune 100 tasks",
+          "Validate fiat on-ramp flows",
+          "Exercise dispute escalations"
+        ]
+      },
+      {
+        "id": "phase-3",
+        "title": "Global Unlocked Mesh",
+        "startHour": 240,
+        "readinessScore": 0.81,
+        "objectives": [
+          "Open participation to global agents",
+          "Activate cross-chain liquidity gauges",
+          "Launch policy observatory"
+        ]
+      }
+    ],
+    "compliance": {
+      "jurisdictions": ["US", "EU", "SG"],
+      "policies": [
+        "Automated withholding & tax memo",
+        "Validator KYC attestation registry",
+        "Real-time sanction screening"
+      ],
+      "unstoppableAccess": [
+        "Tor hidden service endpoint",
+        "IPFS pinset mirror",
+        "Arweave resilience archive"
+      ],
+      "unstoppableMirrors": [
+        "agijobs.eth",
+        "agi-jobs.limo",
+        "agi-jobs.ipns.link"
+      ]
+    }
   }
 }

--- a/demo/Economic-Power-v0/test/economic_power_demo.test.ts
+++ b/demo/Economic-Power-v0/test/economic_power_demo.test.ts
@@ -18,6 +18,9 @@ test('economic power simulation produces deterministic metrics', async () => {
   assert(summary.mermaidTimeline.includes('gantt'), 'Timeline mermaid diagram should be rendered');
   assert(summary.metrics.stabilityIndex >= 0.65, 'Stability index should be within resilience band');
   assert(summary.metrics.ownerCommandCoverage > 0.2, 'Owner command coverage should be non-trivial');
+  assert(summary.metrics.capitalVelocity > 0, 'Capital velocity should be positive');
+  assert(summary.metrics.validatorUtilization <= 1, 'Validator utilisation is capped at 100%');
+  assert(summary.metrics.treasuryRunwayDays > 0, 'Treasury runway should be positive');
 
   const ownerParameters = summary.ownerControl.controls.map((control) => control.parameter);
   for (const control of scenario.owner.controls) {
@@ -39,5 +42,9 @@ test('economic power simulation produces deterministic metrics', async () => {
     scenario.safeguards.circuitBreakers.length,
     'Circuit breaker counts should align',
   );
+
+  assert(summary.expansion.l2Bridges.length > 0, 'Expansion bridges should be populated');
+  assert(summary.expansion.deploymentWaves.length > 0, 'Deployment waves should be present');
+  assert(summary.mermaidExpansion.includes('graph TD'), 'Expansion mermaid diagram should be rendered');
 });
 

--- a/demo/Economic-Power-v0/ui/data/default-summary.json
+++ b/demo/Economic-Power-v0/ui/data/default-summary.json
@@ -1,7 +1,7 @@
 {
   "scenarioId": "economic-power-v0-baseline",
   "title": "AGIJobs Economic Power Launch",
-  "generatedAt": "2025-10-28T05:33:23.409Z",
+  "generatedAt": "2025-10-28T11:41:25.810Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -19,7 +19,10 @@
     "automationScore": 0.852,
     "riskMitigationScore": 0.912,
     "stabilityIndex": 0.736,
-    "ownerCommandCoverage": 0.313
+    "ownerCommandCoverage": 0.313,
+    "capitalVelocity": 0.573,
+    "validatorUtilization": 1,
+    "treasuryRunwayDays": 30.25
   },
   "ownerControl": {
     "threshold": "4-of-7",
@@ -90,7 +93,7 @@
       {
         "module": "ValidationModule",
         "script": "npm run owner:upgrade",
-        "description": "Activates the upgraded validator commit–reveal consensus parameters."
+        "description": "Activates the upgraded validator commit\u2013reveal consensus parameters."
       },
       {
         "module": "StakeManager",
@@ -249,5 +252,88 @@
     }
   ],
   "mermaidFlow": "graph TD\n    OwnerSafe[Owner Multi-Sig\\nThreshold 4-of-7] -->|Configures| Orchestrator[Economic Power Orchestrator]\n    OwnerSafe[Owner Multi-Sig\\nThreshold 4-of-7] -->|Funds| Treasury[Treasury Escrow Vault]\n    Treasury[Treasury Escrow Vault] -->|Swaps| StablecoinAdapter[Stablecoin Adapter]\n    StablecoinAdapter[Stablecoin Adapter] -->|Escrow| Orchestrator[Economic Power Orchestrator]\n    Orchestrator[Economic Power Orchestrator]\n        Job_job_ai_lab_fusion[AI Lab Fusion Accelerator]\n    Job_job_supply_chain[Autonomous Supply Mesh]\n    Job_job_governance_upgrade[Governance Upgrade Launch]\n    Job_job_market_expansion[Market Expansion Omniloop]\n    Job_job_oracle_integration[Oracle Integration Spine]\n    Orchestrator -->|Posts| Job_job_ai_lab_fusion\n    Job_job_ai_lab_fusion -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_ai_lab_fusion -->|Validates| ValidatorSet_job_ai_lab_fusion[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta, Validator Epsilon]\n    Orchestrator -->|Posts| Job_job_supply_chain\n    Job_job_supply_chain -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_supply_chain -->|Validates| ValidatorSet_job_supply_chain[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta]\n    Orchestrator -->|Posts| Job_job_governance_upgrade\n    Job_job_governance_upgrade -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_governance_upgrade -->|Validates| ValidatorSet_job_governance_upgrade[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta, Validator Epsilon]\n    Orchestrator -->|Posts| Job_job_market_expansion\n    Job_job_market_expansion -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_market_expansion -->|Validates| ValidatorSet_job_market_expansion[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta]\n    Orchestrator -->|Posts| Job_job_oracle_integration\n    Job_job_oracle_integration -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_oracle_integration -->|Validates| ValidatorSet_job_oracle_integration[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma]",
-  "mermaidTimeline": "gantt\n    title Economic Power Execution Timeline\n    dateFormat X\n    section AI Lab Fusion Accelerator\n      Atlas Strategic Model Forge :active, job-ai-lab-fusion, 0.0h, 36.5h\n    section Autonomous Supply Mesh\n      Atlas Strategic Model Forge :active, job-supply-chain, 36.5h, 26.9h\n    section Governance Upgrade Launch\n      Atlas Strategic Model Forge :active, job-governance-upgrade, 63.4h, 28.4h\n    section Market Expansion Omniloop\n      Atlas Strategic Model Forge :active, job-market-expansion, 91.8h, 23.4h\n    section Oracle Integration Spine\n      Atlas Strategic Model Forge :active, job-oracle-integration, 115.2h, 22.3h"
+  "mermaidTimeline": "gantt\n    title Economic Power Execution Timeline\n    dateFormat X\n    section AI Lab Fusion Accelerator\n      Atlas Strategic Model Forge :active, job-ai-lab-fusion, 0.0h, 36.5h\n    section Autonomous Supply Mesh\n      Atlas Strategic Model Forge :active, job-supply-chain, 36.5h, 26.9h\n    section Governance Upgrade Launch\n      Atlas Strategic Model Forge :active, job-governance-upgrade, 63.4h, 28.4h\n    section Market Expansion Omniloop\n      Atlas Strategic Model Forge :active, job-market-expansion, 91.8h, 23.4h\n    section Oracle Integration Spine\n      Atlas Strategic Model Forge :active, job-oracle-integration, 115.2h, 22.3h",
+  "mermaidExpansion": "graph TD\n    Mainnet[Ethereum Mainnet Treasury]\n    Mainnet -->|Bridge ops| Arbitrum_One[Arbitrum One\\nPILOT\\n1,800 jobs/day\\n$0.18 avg tx]\n    Mainnet -->|Bridge ops| Optimism[Optimism\\nREADY\\n2,200 jobs/day\\n$0.21 avg tx]\n    Mainnet -->|Bridge ops| Base[Base\\nLIVE\\n2,600 jobs/day\\n$0.16 avg tx]\n    Wave_phase_1[Testnet Beta Swarm\\nStart +0h\\nReadiness 92%]\n      Wave_phase_1 --> Objective_0_0[Simulate 500 concurrent jobs]\n      Wave_phase_1 --> Objective_0_1[Stress validator committee rotation]\n      Wave_phase_1 --> Objective_0_2[Collect latency telemetry]\n    Wave_phase_1 --> Wave_phase_2\n    Wave_phase_2[Mainnet Pilot Guild\\nStart +120h\\nReadiness 88%]\n      Wave_phase_2 --> Objective_1_0[Onboard curated Fortune 100 tasks]\n      Wave_phase_2 --> Objective_1_1[Validate fiat on-ramp flows]\n      Wave_phase_2 --> Objective_1_2[Exercise dispute escalations]\n    Wave_phase_2 --> Wave_phase_3\n    Wave_phase_3[Global Unlocked Mesh\\nStart +240h\\nReadiness 81%]\n      Wave_phase_3 --> Objective_2_0[Open participation to global agents]\n      Wave_phase_3 --> Objective_2_1[Activate cross-chain liquidity gauges]\n      Wave_phase_3 --> Objective_2_2[Launch policy observatory]",
+  "expansion": {
+    "l2Bridges": [
+      {
+        "network": "Arbitrum One",
+        "status": "pilot",
+        "throughputPerDay": 1800,
+        "txCostUsd": 0.18,
+        "operationsSafe": "0xArbitrumOpsSafe00000000000000000000001"
+      },
+      {
+        "network": "Optimism",
+        "status": "ready",
+        "throughputPerDay": 2200,
+        "txCostUsd": 0.21,
+        "operationsSafe": "0xOptimismOpsSafe0000000000000000000002"
+      },
+      {
+        "network": "Base",
+        "status": "live",
+        "throughputPerDay": 2600,
+        "txCostUsd": 0.16,
+        "operationsSafe": "0xBaseOpsSafe000000000000000000000003"
+      }
+    ],
+    "deploymentWaves": [
+      {
+        "id": "phase-1",
+        "title": "Testnet Beta Swarm",
+        "startHour": 0,
+        "readinessScore": 0.92,
+        "objectives": [
+          "Simulate 500 concurrent jobs",
+          "Stress validator committee rotation",
+          "Collect latency telemetry"
+        ]
+      },
+      {
+        "id": "phase-2",
+        "title": "Mainnet Pilot Guild",
+        "startHour": 120,
+        "readinessScore": 0.88,
+        "objectives": [
+          "Onboard curated Fortune 100 tasks",
+          "Validate fiat on-ramp flows",
+          "Exercise dispute escalations"
+        ]
+      },
+      {
+        "id": "phase-3",
+        "title": "Global Unlocked Mesh",
+        "startHour": 240,
+        "readinessScore": 0.81,
+        "objectives": [
+          "Open participation to global agents",
+          "Activate cross-chain liquidity gauges",
+          "Launch policy observatory"
+        ]
+      }
+    ],
+    "compliance": {
+      "jurisdictions": [
+        "US",
+        "EU",
+        "SG"
+      ],
+      "policies": [
+        "Automated withholding & tax memo",
+        "Validator KYC attestation registry",
+        "Real-time sanction screening"
+      ],
+      "unstoppableAccess": [
+        "Tor hidden service endpoint",
+        "IPFS pinset mirror",
+        "Arweave resilience archive"
+      ],
+      "unstoppableMirrors": [
+        "agijobs.eth",
+        "agi-jobs.limo",
+        "agi-jobs.ipns.link"
+      ]
+    }
+  }
 }

--- a/demo/Economic-Power-v0/ui/index.html
+++ b/demo/Economic-Power-v0/ui/index.html
@@ -133,6 +133,73 @@
         <div class="mermaid" id="mermaid-timeline"></div>
       </section>
 
+      <section class="panel" aria-labelledby="expansion-heading">
+        <div class="panel-header">
+          <h2 id="expansion-heading">Global expansion mesh</h2>
+          <p>
+            Cross-chain throughput, deployment waves, and unstoppable access pillars that
+            keep the economy online everywhere.
+          </p>
+        </div>
+        <div class="expansion-grid">
+          <article class="expansion-card" aria-label="Layer-2 bridge status">
+            <h3>Layer-2 Bridges</h3>
+            <div class="table-wrapper">
+              <table id="l2-bridges-table">
+                <thead>
+                  <tr>
+                    <th>Network</th>
+                    <th>Status</th>
+                    <th>Throughput</th>
+                    <th>Avg tx cost</th>
+                    <th>Ops safe</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </article>
+          <article class="expansion-card" aria-label="Deployment waves">
+            <h3>Deployment Waves</h3>
+            <div class="table-wrapper">
+              <table id="waves-table">
+                <thead>
+                  <tr>
+                    <th>Wave</th>
+                    <th>Start</th>
+                    <th>Readiness</th>
+                    <th>Objectives</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </article>
+          <article class="expansion-card" aria-label="Compliance and unstoppable mesh">
+            <h3>Compliance &amp; Sovereignty</h3>
+            <div class="compliance-grid">
+              <div>
+                <h4>Jurisdictions</h4>
+                <ul id="jurisdiction-list"></ul>
+              </div>
+              <div>
+                <h4>Policies</h4>
+                <ul id="policy-list"></ul>
+              </div>
+              <div>
+                <h4>Unstoppable access</h4>
+                <ul id="unstoppable-access"></ul>
+              </div>
+              <div>
+                <h4>Mirrors</h4>
+                <ul id="unstoppable-mirrors"></ul>
+              </div>
+            </div>
+          </article>
+        </div>
+        <div class="mermaid" id="mermaid-expansion"></div>
+      </section>
+
       <section class="panel dropzone" aria-labelledby="dropzone-heading">
         <div class="panel-header">
           <h2 id="dropzone-heading">Drop a summary file</h2>

--- a/demo/Economic-Power-v0/ui/styles.css
+++ b/demo/Economic-Power-v0/ui/styles.css
@@ -196,6 +196,64 @@ main {
   color: var(--text-secondary);
 }
 
+.expansion-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.expansion-card {
+  background: rgba(10, 16, 30, 0.82);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 25px 45px rgba(6, 12, 24, 0.6);
+}
+
+.expansion-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--accent);
+}
+
+.compliance-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.compliance-grid ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.compliance-grid li {
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 0.75rem;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.objective-chip {
+  display: inline-block;
+  margin: 0.15rem 0.2rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+}
+
 .table-wrapper {
   overflow-x: auto;
   margin-top: 1rem;


### PR DESCRIPTION
## Summary
- add expansion, capital velocity, validator utilisation and runway analytics to the Economic Power simulation pipeline and reports
- enrich the baseline scenario and generated assets with multi-chain bridge, deployment wave and compliance data for the owner
- extend the dashboard to surface the new metrics, mermaid expansion graph and unstoppable-access controls with updated documentation

## Testing
- npm run demo:economic-power
- npm run demo:economic-power:ci
- npm run test:economic-power

------
https://chatgpt.com/codex/tasks/task_e_6900aa455854833389437dcac7f0ac3a