### PR TITLE
Add owner command playbook and capital trajectory to Economic Power demo

### DIFF
--- a/demo/Economic-Power-v0/README.md
+++ b/demo/Economic-Power-v0/README.md
@@ -27,6 +27,9 @@ Outputs land in `demo/Economic-Power-v0/reports/`:
 - `owner-control.json` – up-to-the-minute control matrix for the owner’s multi-sig.
 - `owner-sovereignty.json` – sovereign safety mesh blueprint (pause/resume drills, circuit breakers, upgrade commands, and coverage metrics).
 - `deployment-map.json` – mainnet-ready custody catalogue listing each v2 module, owner, upgrade command, and audit freshness.
+- `owner-command.mmd` – owner command mermaid graph linking pause/resume authority, parameter scripts, and module custody.
+- `owner-command-plan.md` – markdown playbook summarising quick actions, scripted upgrades, circuit breakers, and capital checkpoints in plain language.
+- `treasury-trajectory.json` – treasury state, yield, validator confidence, and automation lift captured after each job.
 
 > **Non-technical quick start** – run `npm run demo:economic-power` then open `demo/Economic-Power-v0/ui/index.html` with any static server (`npx http-server demo/Economic-Power-v0/ui`). The dashboard autoloads the generated reports.
 
@@ -92,7 +95,9 @@ The UI inside `demo/Economic-Power-v0/ui/` offers:
 - Expanded metrics for **Stability Index** and **Owner Command Coverage** quantifying how completely the multi-sig governs the stack.
 - Sovereign control gauge mirroring the custody score produced in CI alongside a live on-chain module inventory.
 - Interactive job-to-agent tables to inspect assignments and validator stakes.
+- Capital trajectory tracker visualising treasury strength, validator confidence, and automation lift after every job.
 - Live Mermaid rendering of the architecture and timeline.
+- Owner command Mermaid graph mapping multi-sig authority to every module, circuit breaker, and upgrade path.
 - Drag-and-drop support for alternative `summary.json` files for instant what-if exploration.
 - Sovereign safety mesh panel cataloguing pause/resume playbooks, emergency contacts, circuit breakers, and module upgrade routes.
 

--- a/demo/Economic-Power-v0/reports/owner-command-plan.md
+++ b/demo/Economic-Power-v0/reports/owner-command-plan.md
@@ -1,0 +1,39 @@
+# Owner Command Playbook
+
+Generated 10/28/2025, 12:57:19 PM (UTC)
+
+Command coverage: 22.7% — Coverage below defensive target – prioritise scripting additional command hooks.
+
+## Quick actions
+
+- **Pause execution:** `npm run owner:system-pause`
+- **Resume execution:** `npm run owner:update-all`
+- **Median operator response time:** 9 minutes
+
+## Parameter controls
+
+- `jobDuration`: 72 → 48 via `npm run owner:parameters` — Owner reduces maximum job duration to enforce faster settlement loops and higher capital velocity.
+- `validatorQuorum`: 3 → 5 via `npm run owner:upgrade` — Owner increases validator quorum for premium workstreams to maintain uncompromising trust levels.
+- `stablecoinAdapter`: USDC v1 → USDC v2 via `npm run owner:update-all` — Owner upgrades fiat on/off-ramp adapter with improved slippage guarantees.
+
+## Circuit breakers
+
+- validatorConfidence < 0.95: run `npm run owner:system-pause` — Pause contracts if validator confidence slips below 95% to protect settlement integrity.
+- automationScore < 0.8: run `npm run owner:parameters` — Recalibrate automation if orchestration coverage drops under 80%.
+- treasuryAfterRun < 1800000: run `npm run owner:audit` — Trigger treasury forensic audit when buffers fall below the defensive floor.
+
+## Upgrade routes
+
+- JobRegistry: `npm run owner:update-all` — Ships the hardened JobRegistry bundle with deterministic migration plan.
+- ValidationModule: `npm run owner:upgrade` — Activates the upgraded validator commit–reveal consensus parameters.
+- StakeManager: `npm run owner:parameters` — Rebalances stake requirements to throttle spam and fortify incentives.
+
+## Capital trajectory checkpoints
+
+- Step 1 • AI Lab Fusion Accelerator: treasury 1,570,400 AGI, net yield 293,000 AGI
+- Step 2 • Autonomous Supply Mesh: treasury 1,794,000 AGI, net yield 500,000 AGI
+- Step 3 • Governance Upgrade Launch: treasury 1,963,800 AGI, net yield 659,500 AGI
+- Step 4 • Market Expansion Omniloop: treasury 2,119,400 AGI, net yield 806,000 AGI
+- Step 5 • Oracle Integration Spine: treasury 2,254,040 AGI, net yield 933,800 AGI
+
+All commands are multi-sig ready and validated by deterministic CI.

--- a/demo/Economic-Power-v0/reports/owner-command.mmd
+++ b/demo/Economic-Power-v0/reports/owner-command.mmd
@@ -1,0 +1,38 @@
+graph LR
+    OwnerMultiSig["Owner Multi-Sig (4-of-7)"]
+    PauseCommand["Pause • npm run owner:system-pause"]
+    ResumeCommand["Resume • npm run owner:update-all"]
+    CoverageGauge["Coverage 22.7%"]
+    Parameter_0_jobDuration["jobDuration\n72 → 48\nnpm run owner:parameters"]
+    Parameter_1_validatorQuorum["validatorQuorum\n3 → 5\nnpm run owner:upgrade"]
+    Parameter_2_stablecoinAdapter["stablecoinAdapter\nUSDC v1 → USDC v2\nnpm run owner:update-all"]
+    Upgrade_0_JobRegistry["JobRegistry Upgrade\nnpm run owner:update-all"]
+    Upgrade_1_ValidationModule["ValidationModule Upgrade\nnpm run owner:upgrade"]
+    Upgrade_2_StakeManager["StakeManager Upgrade\nnpm run owner:parameters"]
+    Module_0_job_registry["JobRegistry\n0xA1000000…"]
+    Module_1_stake_manager["StakeManager\n0xA1000000…"]
+    Module_2_validation_module["ValidationModule\n0xA1000000…"]
+    Module_3_reputation_engine["ReputationEngine\n0xA1000000…"]
+    Module_4_dispute_module["DisputeModule\n0xA1000000…"]
+    Module_5_certificate_nft["CertificateNFT\n0xA1000000…"]
+    Breaker_0_validatorConfidence["validatorConfidence < 0.95\nnpm run owner:system-pause"]
+    Breaker_1_automationScore["automationScore < 0.8\nnpm run owner:parameters"]
+    Breaker_2_treasuryAfterRun["treasuryAfterRun < 1800000\nnpm run owner:audit"]
+    OwnerMultiSig -->|Verify| CoverageGauge
+    OwnerMultiSig -->|Pause| PauseCommand
+    OwnerMultiSig -->|Resume| ResumeCommand
+    OwnerMultiSig -->|Run| Parameter_0_jobDuration
+    OwnerMultiSig -->|Run| Parameter_1_validatorQuorum
+    OwnerMultiSig -->|Run| Parameter_2_stablecoinAdapter
+    OwnerMultiSig -->|Promote| Upgrade_0_JobRegistry
+    OwnerMultiSig -->|Promote| Upgrade_1_ValidationModule
+    OwnerMultiSig -->|Promote| Upgrade_2_StakeManager
+    OwnerMultiSig -->|Custody| Module_0_job_registry
+    OwnerMultiSig -->|Custody| Module_1_stake_manager
+    OwnerMultiSig -->|Custody| Module_2_validation_module
+    OwnerMultiSig -->|Custody| Module_3_reputation_engine
+    OwnerMultiSig -->|Custody| Module_4_dispute_module
+    OwnerMultiSig -->|Custody| Module_5_certificate_nft
+    Breaker_0_validatorConfidence -->|Triggers| PauseCommand
+    Breaker_1_automationScore -->|Triggers| PauseCommand
+    Breaker_2_treasuryAfterRun -->|Triggers| PauseCommand

--- a/demo/Economic-Power-v0/reports/summary.json
+++ b/demo/Economic-Power-v0/reports/summary.json
@@ -1,7 +1,7 @@
 {
   "scenarioId": "economic-power-v0-baseline",
   "title": "AGIJobs Economic Power Launch",
-  "generatedAt": "2025-10-28T12:23:06.007Z",
+  "generatedAt": "2025-10-28T12:57:19.375Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -251,6 +251,146 @@
   ],
   "mermaidFlow": "graph TD\n    OwnerSafe[Owner Multi-Sig\\nThreshold 4-of-7] -->|Configures| Orchestrator[Economic Power Orchestrator]\n    OwnerSafe[Owner Multi-Sig\\nThreshold 4-of-7] -->|Funds| Treasury[Treasury Escrow Vault]\n    Treasury[Treasury Escrow Vault] -->|Swaps| StablecoinAdapter[Stablecoin Adapter]\n    StablecoinAdapter[Stablecoin Adapter] -->|Escrow| Orchestrator[Economic Power Orchestrator]\n    Orchestrator[Economic Power Orchestrator]\n        Job_job_ai_lab_fusion[AI Lab Fusion Accelerator]\n    Job_job_supply_chain[Autonomous Supply Mesh]\n    Job_job_governance_upgrade[Governance Upgrade Launch]\n    Job_job_market_expansion[Market Expansion Omniloop]\n    Job_job_oracle_integration[Oracle Integration Spine]\n    Orchestrator -->|Posts| Job_job_ai_lab_fusion\n    Job_job_ai_lab_fusion -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_ai_lab_fusion -->|Validates| ValidatorSet_job_ai_lab_fusion[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta, Validator Epsilon]\n    Orchestrator -->|Posts| Job_job_supply_chain\n    Job_job_supply_chain -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_supply_chain -->|Validates| ValidatorSet_job_supply_chain[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta]\n    Orchestrator -->|Posts| Job_job_governance_upgrade\n    Job_job_governance_upgrade -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_governance_upgrade -->|Validates| ValidatorSet_job_governance_upgrade[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta, Validator Epsilon]\n    Orchestrator -->|Posts| Job_job_market_expansion\n    Job_job_market_expansion -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_market_expansion -->|Validates| ValidatorSet_job_market_expansion[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta]\n    Orchestrator -->|Posts| Job_job_oracle_integration\n    Job_job_oracle_integration -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_oracle_integration -->|Validates| ValidatorSet_job_oracle_integration[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma]",
   "mermaidTimeline": "gantt\n    title Economic Power Execution Timeline\n    dateFormat X\n    section AI Lab Fusion Accelerator\n      Atlas Strategic Model Forge :active, job-ai-lab-fusion, 0.0h, 36.5h\n    section Autonomous Supply Mesh\n      Atlas Strategic Model Forge :active, job-supply-chain, 36.5h, 26.9h\n    section Governance Upgrade Launch\n      Atlas Strategic Model Forge :active, job-governance-upgrade, 63.4h, 28.4h\n    section Market Expansion Omniloop\n      Atlas Strategic Model Forge :active, job-market-expansion, 91.8h, 23.4h\n    section Oracle Integration Spine\n      Atlas Strategic Model Forge :active, job-oracle-integration, 115.2h, 22.3h",
+  "ownerCommandMermaid": "graph LR\n    OwnerMultiSig[\"Owner Multi-Sig (4-of-7)\"]\n    PauseCommand[\"Pause • npm run owner:system-pause\"]\n    ResumeCommand[\"Resume • npm run owner:update-all\"]\n    CoverageGauge[\"Coverage 22.7%\"]\n    Parameter_0_jobDuration[\"jobDuration\\n72 → 48\\nnpm run owner:parameters\"]\n    Parameter_1_validatorQuorum[\"validatorQuorum\\n3 → 5\\nnpm run owner:upgrade\"]\n    Parameter_2_stablecoinAdapter[\"stablecoinAdapter\\nUSDC v1 → USDC v2\\nnpm run owner:update-all\"]\n    Upgrade_0_JobRegistry[\"JobRegistry Upgrade\\nnpm run owner:update-all\"]\n    Upgrade_1_ValidationModule[\"ValidationModule Upgrade\\nnpm run owner:upgrade\"]\n    Upgrade_2_StakeManager[\"StakeManager Upgrade\\nnpm run owner:parameters\"]\n    Module_0_job_registry[\"JobRegistry\\n0xA1000000…\"]\n    Module_1_stake_manager[\"StakeManager\\n0xA1000000…\"]\n    Module_2_validation_module[\"ValidationModule\\n0xA1000000…\"]\n    Module_3_reputation_engine[\"ReputationEngine\\n0xA1000000…\"]\n    Module_4_dispute_module[\"DisputeModule\\n0xA1000000…\"]\n    Module_5_certificate_nft[\"CertificateNFT\\n0xA1000000…\"]\n    Breaker_0_validatorConfidence[\"validatorConfidence < 0.95\\nnpm run owner:system-pause\"]\n    Breaker_1_automationScore[\"automationScore < 0.8\\nnpm run owner:parameters\"]\n    Breaker_2_treasuryAfterRun[\"treasuryAfterRun < 1800000\\nnpm run owner:audit\"]\n    OwnerMultiSig -->|Verify| CoverageGauge\n    OwnerMultiSig -->|Pause| PauseCommand\n    OwnerMultiSig -->|Resume| ResumeCommand\n    OwnerMultiSig -->|Run| Parameter_0_jobDuration\n    OwnerMultiSig -->|Run| Parameter_1_validatorQuorum\n    OwnerMultiSig -->|Run| Parameter_2_stablecoinAdapter\n    OwnerMultiSig -->|Promote| Upgrade_0_JobRegistry\n    OwnerMultiSig -->|Promote| Upgrade_1_ValidationModule\n    OwnerMultiSig -->|Promote| Upgrade_2_StakeManager\n    OwnerMultiSig -->|Custody| Module_0_job_registry\n    OwnerMultiSig -->|Custody| Module_1_stake_manager\n    OwnerMultiSig -->|Custody| Module_2_validation_module\n    OwnerMultiSig -->|Custody| Module_3_reputation_engine\n    OwnerMultiSig -->|Custody| Module_4_dispute_module\n    OwnerMultiSig -->|Custody| Module_5_certificate_nft\n    Breaker_0_validatorConfidence -->|Triggers| PauseCommand\n    Breaker_1_automationScore -->|Triggers| PauseCommand\n    Breaker_2_treasuryAfterRun -->|Triggers| PauseCommand",
+  "ownerCommandPlan": {
+    "quickActions": {
+      "pause": "npm run owner:system-pause",
+      "resume": "npm run owner:update-all",
+      "responseMinutes": 9
+    },
+    "parameterControls": [
+      {
+        "parameter": "jobDuration",
+        "current": 72,
+        "target": 48,
+        "script": "npm run owner:parameters",
+        "description": "Owner reduces maximum job duration to enforce faster settlement loops and higher capital velocity."
+      },
+      {
+        "parameter": "validatorQuorum",
+        "current": 3,
+        "target": 5,
+        "script": "npm run owner:upgrade",
+        "description": "Owner increases validator quorum for premium workstreams to maintain uncompromising trust levels."
+      },
+      {
+        "parameter": "stablecoinAdapter",
+        "current": "USDC v1",
+        "target": "USDC v2",
+        "script": "npm run owner:update-all",
+        "description": "Owner upgrades fiat on/off-ramp adapter with improved slippage guarantees."
+      }
+    ],
+    "circuitBreakers": [
+      {
+        "metric": "validatorConfidence",
+        "comparator": "<",
+        "threshold": 0.95,
+        "action": "npm run owner:system-pause",
+        "description": "Pause contracts if validator confidence slips below 95% to protect settlement integrity."
+      },
+      {
+        "metric": "automationScore",
+        "comparator": "<",
+        "threshold": 0.8,
+        "action": "npm run owner:parameters",
+        "description": "Recalibrate automation if orchestration coverage drops under 80%."
+      },
+      {
+        "metric": "treasuryAfterRun",
+        "comparator": "<",
+        "threshold": 1800000,
+        "action": "npm run owner:audit",
+        "description": "Trigger treasury forensic audit when buffers fall below the defensive floor."
+      }
+    ],
+    "upgradePaths": [
+      {
+        "module": "JobRegistry",
+        "script": "npm run owner:update-all",
+        "description": "Ships the hardened JobRegistry bundle with deterministic migration plan."
+      },
+      {
+        "module": "ValidationModule",
+        "script": "npm run owner:upgrade",
+        "description": "Activates the upgraded validator commit–reveal consensus parameters."
+      },
+      {
+        "module": "StakeManager",
+        "script": "npm run owner:parameters",
+        "description": "Rebalances stake requirements to throttle spam and fortify incentives."
+      }
+    ],
+    "commandCoverage": 0.227,
+    "coverageNarrative": "Coverage below defensive target – prioritise scripting additional command hooks."
+  },
+  "treasuryTrajectory": [
+    {
+      "step": 1,
+      "jobId": "job-ai-lab-fusion",
+      "jobName": "AI Lab Fusion Accelerator",
+      "startHour": 0,
+      "endHour": 36.54,
+      "treasuryAfterJob": 1570400,
+      "cumulativeValue": 450000,
+      "cumulativeCost": 157000,
+      "netYield": 293000,
+      "validatorConfidence": 0.9774,
+      "automationLift": 0.8554
+    },
+    {
+      "step": 2,
+      "jobId": "job-supply-chain",
+      "jobName": "Autonomous Supply Mesh",
+      "startHour": 36.54,
+      "endHour": 63.39,
+      "treasuryAfterJob": 1794000,
+      "cumulativeValue": 760000,
+      "cumulativeCost": 260000,
+      "netYield": 500000,
+      "validatorConfidence": 0.9826,
+      "automationLift": 0.8873
+    },
+    {
+      "step": 3,
+      "jobId": "job-governance-upgrade",
+      "jobName": "Governance Upgrade Launch",
+      "startHour": 63.39,
+      "endHour": 91.81,
+      "treasuryAfterJob": 1963800,
+      "cumulativeValue": 1000000,
+      "cumulativeCost": 340500,
+      "netYield": 659500,
+      "validatorConfidence": 0.9795,
+      "automationLift": 0.8211
+    },
+    {
+      "step": 4,
+      "jobId": "job-market-expansion",
+      "jobName": "Market Expansion Omniloop",
+      "startHour": 91.81,
+      "endHour": 115.21,
+      "treasuryAfterJob": 2119400,
+      "cumulativeValue": 1215000,
+      "cumulativeCost": 409000,
+      "netYield": 806000,
+      "validatorConfidence": 0.9846,
+      "automationLift": 0.8623
+    },
+    {
+      "step": 5,
+      "jobId": "job-oracle-integration",
+      "jobName": "Oracle Integration Spine",
+      "startHour": 115.21,
+      "endHour": 137.54,
+      "treasuryAfterJob": 2254040,
+      "cumulativeValue": 1395000,
+      "cumulativeCost": 461200,
+      "netYield": 933800,
+      "validatorConfidence": 0.982,
+      "automationLift": 0.8347
+    }
+  ],
   "deployment": {
     "network": {
       "name": "Ethereum Mainnet",

--- a/demo/Economic-Power-v0/reports/treasury-trajectory.json
+++ b/demo/Economic-Power-v0/reports/treasury-trajectory.json
@@ -1,0 +1,67 @@
+[
+  {
+    "step": 1,
+    "jobId": "job-ai-lab-fusion",
+    "jobName": "AI Lab Fusion Accelerator",
+    "startHour": 0,
+    "endHour": 36.54,
+    "treasuryAfterJob": 1570400,
+    "cumulativeValue": 450000,
+    "cumulativeCost": 157000,
+    "netYield": 293000,
+    "validatorConfidence": 0.9774,
+    "automationLift": 0.8554
+  },
+  {
+    "step": 2,
+    "jobId": "job-supply-chain",
+    "jobName": "Autonomous Supply Mesh",
+    "startHour": 36.54,
+    "endHour": 63.39,
+    "treasuryAfterJob": 1794000,
+    "cumulativeValue": 760000,
+    "cumulativeCost": 260000,
+    "netYield": 500000,
+    "validatorConfidence": 0.9826,
+    "automationLift": 0.8873
+  },
+  {
+    "step": 3,
+    "jobId": "job-governance-upgrade",
+    "jobName": "Governance Upgrade Launch",
+    "startHour": 63.39,
+    "endHour": 91.81,
+    "treasuryAfterJob": 1963800,
+    "cumulativeValue": 1000000,
+    "cumulativeCost": 340500,
+    "netYield": 659500,
+    "validatorConfidence": 0.9795,
+    "automationLift": 0.8211
+  },
+  {
+    "step": 4,
+    "jobId": "job-market-expansion",
+    "jobName": "Market Expansion Omniloop",
+    "startHour": 91.81,
+    "endHour": 115.21,
+    "treasuryAfterJob": 2119400,
+    "cumulativeValue": 1215000,
+    "cumulativeCost": 409000,
+    "netYield": 806000,
+    "validatorConfidence": 0.9846,
+    "automationLift": 0.8623
+  },
+  {
+    "step": 5,
+    "jobId": "job-oracle-integration",
+    "jobName": "Oracle Integration Spine",
+    "startHour": 115.21,
+    "endHour": 137.54,
+    "treasuryAfterJob": 2254040,
+    "cumulativeValue": 1395000,
+    "cumulativeCost": 461200,
+    "netYield": 933800,
+    "validatorConfidence": 0.982,
+    "automationLift": 0.8347
+  }
+]

--- a/demo/Economic-Power-v0/test/economic_power_demo.test.ts
+++ b/demo/Economic-Power-v0/test/economic_power_demo.test.ts
@@ -25,6 +25,19 @@ test('economic power simulation produces deterministic metrics', async () => {
     assert(ownerParameters.includes(control.parameter));
   }
 
+  assert(summary.ownerCommandPlan.commandCoverage >= 0.2, 'Owner command coverage should be recorded');
+  assert(summary.ownerCommandPlan.coverageNarrative.length > 0, 'Coverage narrative should be present');
+  assert(summary.ownerCommandMermaid.includes('graph LR'), 'Owner command mermaid graph should render');
+  assert.equal(
+    summary.treasuryTrajectory.length,
+    summary.assignments.length,
+    'Treasury trajectory should include one entry per assignment',
+  );
+  for (const entry of summary.treasuryTrajectory) {
+    assert(entry.treasuryAfterJob > 0, 'Treasury levels should remain positive');
+    assert(entry.validatorConfidence > 0.9, 'Validator confidence checkpoints should stay high');
+  }
+
   assert.equal(
     summary.ownerSovereignty.pauseScript,
     scenario.safeguards.pauseScript,

--- a/demo/Economic-Power-v0/ui/data/default-summary.json
+++ b/demo/Economic-Power-v0/ui/data/default-summary.json
@@ -1,7 +1,7 @@
 {
   "scenarioId": "economic-power-v0-baseline",
   "title": "AGIJobs Economic Power Launch",
-  "generatedAt": "2025-10-28T12:22:30.576Z",
+  "generatedAt": "2025-10-28T12:57:19.375Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -251,6 +251,146 @@
   ],
   "mermaidFlow": "graph TD\n    OwnerSafe[Owner Multi-Sig\\nThreshold 4-of-7] -->|Configures| Orchestrator[Economic Power Orchestrator]\n    OwnerSafe[Owner Multi-Sig\\nThreshold 4-of-7] -->|Funds| Treasury[Treasury Escrow Vault]\n    Treasury[Treasury Escrow Vault] -->|Swaps| StablecoinAdapter[Stablecoin Adapter]\n    StablecoinAdapter[Stablecoin Adapter] -->|Escrow| Orchestrator[Economic Power Orchestrator]\n    Orchestrator[Economic Power Orchestrator]\n        Job_job_ai_lab_fusion[AI Lab Fusion Accelerator]\n    Job_job_supply_chain[Autonomous Supply Mesh]\n    Job_job_governance_upgrade[Governance Upgrade Launch]\n    Job_job_market_expansion[Market Expansion Omniloop]\n    Job_job_oracle_integration[Oracle Integration Spine]\n    Orchestrator -->|Posts| Job_job_ai_lab_fusion\n    Job_job_ai_lab_fusion -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_ai_lab_fusion -->|Validates| ValidatorSet_job_ai_lab_fusion[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta, Validator Epsilon]\n    Orchestrator -->|Posts| Job_job_supply_chain\n    Job_job_supply_chain -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_supply_chain -->|Validates| ValidatorSet_job_supply_chain[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta]\n    Orchestrator -->|Posts| Job_job_governance_upgrade\n    Job_job_governance_upgrade -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_governance_upgrade -->|Validates| ValidatorSet_job_governance_upgrade[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta, Validator Epsilon]\n    Orchestrator -->|Posts| Job_job_market_expansion\n    Job_job_market_expansion -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_market_expansion -->|Validates| ValidatorSet_job_market_expansion[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma, Validator Delta]\n    Orchestrator -->|Posts| Job_job_oracle_integration\n    Job_job_oracle_integration -->|Executes| Agent_atlas[Atlas Strategic Model Forge]\n    Job_job_oracle_integration -->|Validates| ValidatorSet_job_oracle_integration[Validator Constellation\\nValidator Alpha, Validator Beta, Validator Gamma]",
   "mermaidTimeline": "gantt\n    title Economic Power Execution Timeline\n    dateFormat X\n    section AI Lab Fusion Accelerator\n      Atlas Strategic Model Forge :active, job-ai-lab-fusion, 0.0h, 36.5h\n    section Autonomous Supply Mesh\n      Atlas Strategic Model Forge :active, job-supply-chain, 36.5h, 26.9h\n    section Governance Upgrade Launch\n      Atlas Strategic Model Forge :active, job-governance-upgrade, 63.4h, 28.4h\n    section Market Expansion Omniloop\n      Atlas Strategic Model Forge :active, job-market-expansion, 91.8h, 23.4h\n    section Oracle Integration Spine\n      Atlas Strategic Model Forge :active, job-oracle-integration, 115.2h, 22.3h",
+  "ownerCommandMermaid": "graph LR\n    OwnerMultiSig[\"Owner Multi-Sig (4-of-7)\"]\n    PauseCommand[\"Pause • npm run owner:system-pause\"]\n    ResumeCommand[\"Resume • npm run owner:update-all\"]\n    CoverageGauge[\"Coverage 22.7%\"]\n    Parameter_0_jobDuration[\"jobDuration\\n72 → 48\\nnpm run owner:parameters\"]\n    Parameter_1_validatorQuorum[\"validatorQuorum\\n3 → 5\\nnpm run owner:upgrade\"]\n    Parameter_2_stablecoinAdapter[\"stablecoinAdapter\\nUSDC v1 → USDC v2\\nnpm run owner:update-all\"]\n    Upgrade_0_JobRegistry[\"JobRegistry Upgrade\\nnpm run owner:update-all\"]\n    Upgrade_1_ValidationModule[\"ValidationModule Upgrade\\nnpm run owner:upgrade\"]\n    Upgrade_2_StakeManager[\"StakeManager Upgrade\\nnpm run owner:parameters\"]\n    Module_0_job_registry[\"JobRegistry\\n0xA1000000…\"]\n    Module_1_stake_manager[\"StakeManager\\n0xA1000000…\"]\n    Module_2_validation_module[\"ValidationModule\\n0xA1000000…\"]\n    Module_3_reputation_engine[\"ReputationEngine\\n0xA1000000…\"]\n    Module_4_dispute_module[\"DisputeModule\\n0xA1000000…\"]\n    Module_5_certificate_nft[\"CertificateNFT\\n0xA1000000…\"]\n    Breaker_0_validatorConfidence[\"validatorConfidence < 0.95\\nnpm run owner:system-pause\"]\n    Breaker_1_automationScore[\"automationScore < 0.8\\nnpm run owner:parameters\"]\n    Breaker_2_treasuryAfterRun[\"treasuryAfterRun < 1800000\\nnpm run owner:audit\"]\n    OwnerMultiSig -->|Verify| CoverageGauge\n    OwnerMultiSig -->|Pause| PauseCommand\n    OwnerMultiSig -->|Resume| ResumeCommand\n    OwnerMultiSig -->|Run| Parameter_0_jobDuration\n    OwnerMultiSig -->|Run| Parameter_1_validatorQuorum\n    OwnerMultiSig -->|Run| Parameter_2_stablecoinAdapter\n    OwnerMultiSig -->|Promote| Upgrade_0_JobRegistry\n    OwnerMultiSig -->|Promote| Upgrade_1_ValidationModule\n    OwnerMultiSig -->|Promote| Upgrade_2_StakeManager\n    OwnerMultiSig -->|Custody| Module_0_job_registry\n    OwnerMultiSig -->|Custody| Module_1_stake_manager\n    OwnerMultiSig -->|Custody| Module_2_validation_module\n    OwnerMultiSig -->|Custody| Module_3_reputation_engine\n    OwnerMultiSig -->|Custody| Module_4_dispute_module\n    OwnerMultiSig -->|Custody| Module_5_certificate_nft\n    Breaker_0_validatorConfidence -->|Triggers| PauseCommand\n    Breaker_1_automationScore -->|Triggers| PauseCommand\n    Breaker_2_treasuryAfterRun -->|Triggers| PauseCommand",
+  "ownerCommandPlan": {
+    "quickActions": {
+      "pause": "npm run owner:system-pause",
+      "resume": "npm run owner:update-all",
+      "responseMinutes": 9
+    },
+    "parameterControls": [
+      {
+        "parameter": "jobDuration",
+        "current": 72,
+        "target": 48,
+        "script": "npm run owner:parameters",
+        "description": "Owner reduces maximum job duration to enforce faster settlement loops and higher capital velocity."
+      },
+      {
+        "parameter": "validatorQuorum",
+        "current": 3,
+        "target": 5,
+        "script": "npm run owner:upgrade",
+        "description": "Owner increases validator quorum for premium workstreams to maintain uncompromising trust levels."
+      },
+      {
+        "parameter": "stablecoinAdapter",
+        "current": "USDC v1",
+        "target": "USDC v2",
+        "script": "npm run owner:update-all",
+        "description": "Owner upgrades fiat on/off-ramp adapter with improved slippage guarantees."
+      }
+    ],
+    "circuitBreakers": [
+      {
+        "metric": "validatorConfidence",
+        "comparator": "<",
+        "threshold": 0.95,
+        "action": "npm run owner:system-pause",
+        "description": "Pause contracts if validator confidence slips below 95% to protect settlement integrity."
+      },
+      {
+        "metric": "automationScore",
+        "comparator": "<",
+        "threshold": 0.8,
+        "action": "npm run owner:parameters",
+        "description": "Recalibrate automation if orchestration coverage drops under 80%."
+      },
+      {
+        "metric": "treasuryAfterRun",
+        "comparator": "<",
+        "threshold": 1800000,
+        "action": "npm run owner:audit",
+        "description": "Trigger treasury forensic audit when buffers fall below the defensive floor."
+      }
+    ],
+    "upgradePaths": [
+      {
+        "module": "JobRegistry",
+        "script": "npm run owner:update-all",
+        "description": "Ships the hardened JobRegistry bundle with deterministic migration plan."
+      },
+      {
+        "module": "ValidationModule",
+        "script": "npm run owner:upgrade",
+        "description": "Activates the upgraded validator commit–reveal consensus parameters."
+      },
+      {
+        "module": "StakeManager",
+        "script": "npm run owner:parameters",
+        "description": "Rebalances stake requirements to throttle spam and fortify incentives."
+      }
+    ],
+    "commandCoverage": 0.227,
+    "coverageNarrative": "Coverage below defensive target – prioritise scripting additional command hooks."
+  },
+  "treasuryTrajectory": [
+    {
+      "step": 1,
+      "jobId": "job-ai-lab-fusion",
+      "jobName": "AI Lab Fusion Accelerator",
+      "startHour": 0,
+      "endHour": 36.54,
+      "treasuryAfterJob": 1570400,
+      "cumulativeValue": 450000,
+      "cumulativeCost": 157000,
+      "netYield": 293000,
+      "validatorConfidence": 0.9774,
+      "automationLift": 0.8554
+    },
+    {
+      "step": 2,
+      "jobId": "job-supply-chain",
+      "jobName": "Autonomous Supply Mesh",
+      "startHour": 36.54,
+      "endHour": 63.39,
+      "treasuryAfterJob": 1794000,
+      "cumulativeValue": 760000,
+      "cumulativeCost": 260000,
+      "netYield": 500000,
+      "validatorConfidence": 0.9826,
+      "automationLift": 0.8873
+    },
+    {
+      "step": 3,
+      "jobId": "job-governance-upgrade",
+      "jobName": "Governance Upgrade Launch",
+      "startHour": 63.39,
+      "endHour": 91.81,
+      "treasuryAfterJob": 1963800,
+      "cumulativeValue": 1000000,
+      "cumulativeCost": 340500,
+      "netYield": 659500,
+      "validatorConfidence": 0.9795,
+      "automationLift": 0.8211
+    },
+    {
+      "step": 4,
+      "jobId": "job-market-expansion",
+      "jobName": "Market Expansion Omniloop",
+      "startHour": 91.81,
+      "endHour": 115.21,
+      "treasuryAfterJob": 2119400,
+      "cumulativeValue": 1215000,
+      "cumulativeCost": 409000,
+      "netYield": 806000,
+      "validatorConfidence": 0.9846,
+      "automationLift": 0.8623
+    },
+    {
+      "step": 5,
+      "jobId": "job-oracle-integration",
+      "jobName": "Oracle Integration Spine",
+      "startHour": 115.21,
+      "endHour": 137.54,
+      "treasuryAfterJob": 2254040,
+      "cumulativeValue": 1395000,
+      "cumulativeCost": 461200,
+      "netYield": 933800,
+      "validatorConfidence": 0.982,
+      "automationLift": 0.8347
+    }
+  ],
   "deployment": {
     "network": {
       "name": "Ethereum Mainnet",

--- a/demo/Economic-Power-v0/ui/index.html
+++ b/demo/Economic-Power-v0/ui/index.html
@@ -53,6 +53,11 @@
           <article class="sovereignty-card" aria-label="Pause and resume playbooks">
             <h3>Immediate actions</h3>
             <div id="pause-resume"></div>
+            <p>
+              <strong>Command coverage:</strong>
+              <span id="coverage-percent"></span>
+            </p>
+            <p id="coverage-narrative" class="narrative"></p>
             <h4>Emergency contacts</h4>
             <ul id="emergency-contacts"></ul>
           </article>
@@ -186,6 +191,37 @@
           <p>Gantt macro for throughput and capital velocity analytics.</p>
         </div>
         <div class="mermaid" id="mermaid-timeline"></div>
+      </section>
+
+      <section class="panel" aria-labelledby="command-mermaid-heading">
+        <div class="panel-header">
+          <h2 id="command-mermaid-heading">Owner command graph</h2>
+          <p>Deterministic map of multi-sig authority across modules and emergency actions.</p>
+        </div>
+        <div class="mermaid" id="mermaid-command"></div>
+      </section>
+
+      <section class="panel" aria-labelledby="trajectory-heading">
+        <div class="panel-header">
+          <h2 id="trajectory-heading">Capital trajectory</h2>
+          <p>Track treasury strength, validator confidence, and automation lift after every job.</p>
+        </div>
+        <div class="table-wrapper">
+          <table id="trajectory-table">
+            <thead>
+              <tr>
+                <th>Step</th>
+                <th>Job</th>
+                <th>Window (h)</th>
+                <th>Treasury (AGI)</th>
+                <th>Net Yield (AGI)</th>
+                <th>Validator Confidence</th>
+                <th>Automation Lift</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
       </section>
 
       <section class="panel dropzone" aria-labelledby="dropzone-heading">

--- a/demo/Economic-Power-v0/ui/styles.css
+++ b/demo/Economic-Power-v0/ui/styles.css
@@ -188,6 +188,17 @@ main {
   font-size: 0.85rem;
 }
 
+.narrative {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+#coverage-percent {
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
 #emergency-contacts {
   list-style: none;
   margin: 0;
@@ -325,6 +336,11 @@ tr:hover td {
   background: rgba(9, 14, 28, 0.9);
   border-radius: 1rem;
   padding: 1.25rem;
+}
+
+#trajectory-table tbody td:nth-child(6),
+#trajectory-table tbody td:nth-child(7) {
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 }
 
 .dropzone {


### PR DESCRIPTION
## Summary
- extend the Economic Power simulator to emit an owner command playbook, mermaid command graph, and treasury trajectory outputs
- expose the new command surfaces and capital checkpoints in the UI with refreshed baseline data and documentation
- add regression coverage to ensure the new trajectory analytics and owner control graph stay deterministic

## Testing
- npm run demo:economic-power
- npm run test:economic-power

------
https://chatgpt.com/codex/tasks/task_e_6900bb8b41d0833397792054beb7f1b3