### PR TITLE
Add forbidden selector sentinel guardrail to validator constellation demo

### DIFF
--- a/demo/Validator-Constellation-v0/README.md
+++ b/demo/Validator-Constellation-v0/README.md
@@ -33,6 +33,7 @@ flowchart LR
 * **Sentinel guardrails** – budget overruns, forbidden opcodes, unauthorized targets, or calldata floods trigger autonomous domain pauses within the same round.
 * **Validator life-cycle telemetry** – every registration and ban emits dedicated events mirrored in the subgraph, so owners can watch validator health in real time.
 * **Deterministic supply-chain allowlists** – each domain now encodes hashed ENS target allowlists and calldata ceilings so auditors can replay sentinel verdicts byte-for-byte.
+* **Selector firewalls** – domains ship with banned function selectors so the sentinel can terminate ERC-20/721 drains or other malicious call patterns the moment they appear.
 * **ENS-verified identity** – only operators with approved `.club.agi.eth` or `.alpha.club.agi.eth` subdomains pass the Merkle proof gate, making impersonation impossible.
 * **Operator sovereignty** – one governance command updates penalties or committee size without redeploying contracts.
 * **Block-by-block accountability** – every commit, reveal, and finalization is captured with explicit block windows, letting owners audit timing SLAs and prove the protocol stayed inside governance limits.
@@ -228,6 +229,7 @@ Guardrail metadata now includes:
 
 * `UNAUTHORIZED_TARGET` – triggered with dual verification (`target` + `keccak(target)`) whenever an agent reaches outside the allowlist.
 * `CALLDATA_EXPLOSION` – activates if a call attempts to exceed the domain-specific byte ceiling; the alert bundles the observed payload size so downstream monitors can replay the decision.
+* `FORBIDDEN_SELECTOR` – blocks execution when a transaction carries a banned 4-byte selector (e.g. ERC-20 transfer or sweep opcodes) so that drained treasuries are impossible even if calldata looks safe.
 
 ## Files of interest
 

--- a/demo/Validator-Constellation-v0/config/stellar-scenario.yaml
+++ b/demo/Validator-Constellation-v0/config/stellar-scenario.yaml
@@ -22,6 +22,9 @@ domains:
       - "0xa11ce5c1e11ce000000000000000000000000000"
       - "0xbeac0babe00000000000000000000000000000000"
     maxCalldataBytes: 4096
+    forbiddenSelectors:
+      - "0xa9059cbb"
+      - "0x23b872dd"
   - id: orbital-yard
     humanName: "Orbital Manufacturing Yard"
     budgetLimit: 3000000
@@ -31,6 +34,8 @@ domains:
     allowedTargets:
       - "0xf0undry0ps000000000000000000000000000000"
     maxCalldataBytes: 2048
+    forbiddenSelectors:
+      - "0xd0edefb0"
 validators:
   - ens: andromeda.club.agi.eth
     address: "0x1111111111111111111111111111111111111111"
@@ -91,6 +96,11 @@ anomalies:
     calldataBytes: 16384
     description: "Nova attempted to upload an oversized payload"
     target: "0xa11ce5c1e11ce000000000000000000000000000"
+  - kind: forbidden-selector
+    agentEns: nova.agent.agi.eth
+    selector: "0xa9059cbb"
+    description: "Nova attempted to move funds via a blocked selector"
+    target: "0xa11ce5c1e11ce000000000000000000000000000"
 ownerActions:
   updateSentinel:
     budgetGraceRatio: 0.12
@@ -105,6 +115,9 @@ ownerActions:
         - "0xa11ce5c1e11ce000000000000000000000000000"
         - "0xbeac0babe00000000000000000000000000000000"
       maxCalldataBytes: 6144
+      forbiddenSelectors:
+        - "0xa9059cbb"
+        - "0x23b872dd"
   pauseDomains:
     - domainId: orbital-yard
       reason: "pre-flight drill"

--- a/demo/Validator-Constellation-v0/scripts/runDemo.ts
+++ b/demo/Validator-Constellation-v0/scripts/runDemo.ts
@@ -44,6 +44,7 @@ function main() {
       '0xbeac0babe00000000000000000000000000000000',
     ],
     maxCalldataBytes: 6144,
+    forbiddenSelectors: ['0xa9059cbb', '0x23b872dd'],
   });
   demo.updateSentinelConfig({ budgetGraceRatio: 0.07 });
   const agentIdentity = demo.setAgentBudget(agentLeaf.ensName, 1_200_000n);
@@ -104,6 +105,16 @@ function main() {
       amountSpent: 1_000n,
       target: '0xd15a11ee00000000000000000000000000000000',
       description: 'Call routed to unauthorized contract',
+    },
+    {
+      agent: agentIdentity,
+      domainId: 'deep-space-lab',
+      type: 'CALL',
+      amountSpent: 750n,
+      target: '0xa11ce5c1e11ce000000000000000000000000000',
+      functionSelector: '0xa9059cbb',
+      description: 'Forbidden token transfer selector invoked',
+      metadata: { functionSelector: '0xa9059cbb' },
     },
     {
       agent: agentIdentity,

--- a/demo/Validator-Constellation-v0/src/core/domainPause.ts
+++ b/demo/Validator-Constellation-v0/src/core/domainPause.ts
@@ -11,6 +11,7 @@ export class DomainPauseController {
           ...config,
           unsafeOpcodes: new Set(config.unsafeOpcodes),
           allowedTargets: new Set(config.allowedTargets),
+          forbiddenSelectors: new Set(config.forbiddenSelectors),
         },
         paused: false,
       });
@@ -64,6 +65,7 @@ export class DomainPauseController {
         ...state.config,
         unsafeOpcodes: new Set(state.config.unsafeOpcodes),
         allowedTargets: new Set(state.config.allowedTargets),
+        forbiddenSelectors: new Set(state.config.forbiddenSelectors),
       },
       paused: state.paused,
       pauseReason: state.pauseReason ? { ...state.pauseReason } : undefined,
@@ -78,6 +80,10 @@ export class DomainPauseController {
       updates.allowedTargets !== undefined
         ? new Set(Array.from(updates.allowedTargets, (target) => target.toLowerCase()))
         : new Set(state.config.allowedTargets);
+    const forbiddenSelectors =
+      updates.forbiddenSelectors !== undefined
+        ? new Set(Array.from(updates.forbiddenSelectors, (selector) => selector.toLowerCase()))
+        : new Set(state.config.forbiddenSelectors);
     const maxCalldataBytes = updates.maxCalldataBytes ?? state.config.maxCalldataBytes;
     const updated: DomainConfig = {
       ...state.config,
@@ -86,6 +92,7 @@ export class DomainPauseController {
       unsafeOpcodes,
       allowedTargets,
       maxCalldataBytes,
+      forbiddenSelectors,
     };
     state.config = updated;
     return updated;

--- a/demo/Validator-Constellation-v0/src/core/fixtures.ts
+++ b/demo/Validator-Constellation-v0/src/core/fixtures.ts
@@ -9,6 +9,7 @@ const RAW_DOMAIN_TEMPLATES: Array<{
   unsafeOpcodes: string[];
   allowedTargets: string[];
   maxCalldataBytes: number;
+  forbiddenSelectors: string[];
 }> = [
   {
     id: 'deep-space-lab',
@@ -20,6 +21,7 @@ const RAW_DOMAIN_TEMPLATES: Array<{
       '0xbeac0babe00000000000000000000000000000000',
     ],
     maxCalldataBytes: 4096,
+    forbiddenSelectors: ['0xa9059cbb', '0x095ea7b3'],
   },
   {
     id: 'lunar-foundry',
@@ -28,6 +30,7 @@ const RAW_DOMAIN_TEMPLATES: Array<{
     unsafeOpcodes: ['SELFDESTRUCT'],
     allowedTargets: ['0xf0undry0ps000000000000000000000000000000'],
     maxCalldataBytes: 2048,
+    forbiddenSelectors: ['0xd0edefb0'],
   },
 ];
 
@@ -59,6 +62,7 @@ export function defaultDomains(): DomainConfig[] {
     unsafeOpcodes: new Set(domain.unsafeOpcodes),
     allowedTargets: new Set(domain.allowedTargets.map((target) => target.toLowerCase())),
     maxCalldataBytes: domain.maxCalldataBytes,
+    forbiddenSelectors: new Set(domain.forbiddenSelectors.map((selector) => selector.toLowerCase())),
   }));
 }
 

--- a/demo/Validator-Constellation-v0/src/core/operatorState.ts
+++ b/demo/Validator-Constellation-v0/src/core/operatorState.ts
@@ -48,6 +48,7 @@ export interface OperatorDomain {
   unsafeOpcodes: string[];
   allowedTargets: string[];
   maxCalldataBytes: number;
+  forbiddenSelectors: string[];
   paused: boolean;
   pauseReason?: OperatorDomainPause;
 }
@@ -74,6 +75,7 @@ function cloneSetupFromState(state: OperatorState): DemoSetup {
     unsafeOpcodes: new Set(domain.unsafeOpcodes),
     allowedTargets: new Set(domain.allowedTargets.map((target) => target.toLowerCase())),
     maxCalldataBytes: domain.maxCalldataBytes,
+    forbiddenSelectors: new Set(domain.forbiddenSelectors.map((selector) => selector.toLowerCase())),
   }));
   return {
     domains,
@@ -156,6 +158,7 @@ export function createInitialOperatorState(): OperatorState {
     unsafeOpcodes: Array.from(domain.unsafeOpcodes),
     allowedTargets: Array.from(domain.allowedTargets),
     maxCalldataBytes: domain.maxCalldataBytes,
+    forbiddenSelectors: Array.from(domain.forbiddenSelectors),
     paused: false,
   }));
   return {
@@ -195,6 +198,7 @@ export function loadOperatorState(filePath: string): OperatorState {
     domains: parsed.domains.map((domain) => ({
       ...domain,
       unsafeOpcodes: [...domain.unsafeOpcodes],
+      forbiddenSelectors: [...(domain.forbiddenSelectors ?? [])],
       pauseReason: domain.pauseReason ? { ...domain.pauseReason } : undefined,
     })),
   };
@@ -281,6 +285,7 @@ function updateDomainsFromDemo(state: OperatorState, demo: ValidatorConstellatio
       unsafeOpcodes: Array.from(snapshot.config.unsafeOpcodes),
       allowedTargets: Array.from(snapshot.config.allowedTargets),
       maxCalldataBytes: snapshot.config.maxCalldataBytes,
+      forbiddenSelectors: Array.from(snapshot.config.forbiddenSelectors),
       paused: snapshot.paused,
       pauseReason: snapshot.pauseReason
         ? {
@@ -385,6 +390,7 @@ export function resetDomainsToDefault(state: OperatorState): void {
     unsafeOpcodes: Array.from(domain.unsafeOpcodes),
     allowedTargets: Array.from(domain.allowedTargets),
     maxCalldataBytes: domain.maxCalldataBytes,
+    forbiddenSelectors: Array.from(domain.forbiddenSelectors),
     paused: false,
   }));
 }

--- a/demo/Validator-Constellation-v0/src/core/types.ts
+++ b/demo/Validator-Constellation-v0/src/core/types.ts
@@ -19,6 +19,7 @@ export interface DomainConfig {
   unsafeOpcodes: Set<string>;
   allowedTargets: Set<string>;
   maxCalldataBytes: number;
+  forbiddenSelectors: Set<string>;
 }
 
 export interface GovernanceParameters {
@@ -57,6 +58,7 @@ export interface AgentAction {
   opcode?: string;
   target?: string;
   calldataBytes?: number;
+  functionSelector?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -187,6 +189,7 @@ export interface DomainSafetyUpdate {
   unsafeOpcodes?: Iterable<string>;
   allowedTargets?: Iterable<string>;
   maxCalldataBytes?: number;
+  forbiddenSelectors?: Iterable<string>;
 }
 
 export interface ValidatorEventBus extends EventEmitter {


### PR DESCRIPTION
## Summary
- add selector firewall configuration to validator domains and scenario automation
- extend sentinel monitor, operator console, and reporting pipelines to enforce and surface forbidden selectors
- update demo scripts, fixtures, and tests to exercise the new selector guardrail for non-technical operators

## Testing
- npm run lint:validator-constellation
- npm run test:validator-constellation
- npm run demo:validator-constellation:ci

------
https://chatgpt.com/codex/tasks/task_e_6900b899eb848333a98c19bd148b5e96