### PR TITLE
feat: expand meta-agentic alpha demo with sovereign phase analytics

### DIFF
--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/README.md
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/README.md
@@ -8,6 +8,7 @@
 - **Owner supremacy baked-in** – the owner multi-sig can pause, resume, upgrade, and reallocate capital instantly using the generated command playbook and CI verifications.
 - **Non-technical friendly** – a guided CLI, self-updating dashboard, and mermaid blueprints make the system legible to any operator while keeping the underlying power uncompromised.
 - **CI enforced** – the demo surfaces the exact CI commands that keep AGI Jobs v0 (v2) branch-protected and green. Nothing ships unless governance + automation agree.
+- **Sovereign orchestration telemetry** – alpha velocity metrics, phase matrices, and the sovereign phase flow expose how each stage compounds value while remaining owner-controlled.
 
 ## Golden path – unleash the Meta-Agentic α-AGI
 
@@ -28,13 +29,15 @@ Outputs land in `demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/`:
 | `architecture.mmd` | Mermaid systems graph linking owner, agents, validators, and modules. |
 | `timeline.mmd` | Gantt view of the Identify → Execute flow for each opportunity. |
 | `coordination.mmd` | Agent-to-agent + validator mesh showing real-time coordination wiring. |
+| `phase-flow.mmd` | Sovereign Identify → Out-Learn → Out-Think → Out-Design → Out-Strategise → Out-Execute orchestration. |
+| `phase-matrix.json` | Phase force-multiplier matrix with reliability, automation support, and validator reach. |
 | `knowledge-base.json` | Opportunity knowledge graph nodes + edges for downstream analytics. |
 | `world-model.json` | Simulation curriculum, fidelity scores, and stress outcomes feeding plan selection. |
 | `execution-ledger.json` | SHA-256 checksummed execution ledger for audit and compliance. |
 | `ci-status.json` | Branch-protection guardrails (lint, tests, coverage, governance verifications). |
 | `dashboard.json` | Data model consumed by the web UI for at-a-glance monitoring. |
 
-> **Open the dashboard** – start any static server (for example, `npx http-server demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/ui`) and navigate to `http://localhost:8080`. The UI reads the latest `dashboard.json`, renders the metrics, and injects live Mermaid diagrams.
+> **Open the dashboard** – start any static server (for example, `npx http-server demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/ui`) and navigate to `http://localhost:8080`. The UI reads the latest `dashboard.json`, renders the metrics and phase matrix, and injects live Mermaid diagrams for architecture, timeline, coordination, and the sovereign phase flow.
 
 ## Architecture in one glance
 

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/dashboard.json
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/dashboard.json
@@ -14,6 +14,9 @@
     "stabilityReserve": 11467974.5,
     "paybackHours": 19.309091460640076,
     "treasuryVelocity": 9.772127752566202,
+    "alphaCaptureVelocity": 575092.0673076923,
+    "ownerSovereigntyLag": 8,
+    "governanceDeterminism": 0.6666666666666666,
     "ciStatus": "green"
   },
   "assignments": [
@@ -125,5 +128,85 @@
       "npm run ci:verify-branch-protection"
     ],
     "status": "green"
-  }
+  },
+  "phaseMatrix": [
+    {
+      "phase": "identify",
+      "title": "Identify",
+      "agents": [
+        "Polymath Opportunity Scout (scout.meta-agi.eth)"
+      ],
+      "averageReliability": 0.97,
+      "maxParallel": 4,
+      "activeOpportunities": 4,
+      "opportunityValue": 120460000,
+      "validatorSupport": 3,
+      "automationSupport": 0.9175
+    },
+    {
+      "phase": "outlearn",
+      "title": "Out-Learn",
+      "agents": [
+        "Self-Evolving Curriculum Forge (forge.meta-agi.eth)"
+      ],
+      "averageReliability": 0.95,
+      "maxParallel": 3,
+      "activeOpportunities": 3,
+      "opportunityValue": 97960000,
+      "validatorSupport": 3,
+      "automationSupport": 0.9233333333333333
+    },
+    {
+      "phase": "outthink",
+      "title": "Out-Think",
+      "agents": [
+        "Meta-Agentic Planner (planner.meta-agi.eth)"
+      ],
+      "averageReliability": 0.98,
+      "maxParallel": 2,
+      "activeOpportunities": 4,
+      "opportunityValue": 120460000,
+      "validatorSupport": 3,
+      "automationSupport": 0.9175
+    },
+    {
+      "phase": "outdesign",
+      "title": "Out-Design",
+      "agents": [
+        "Creative Solution Savant (designer.meta-agi.eth)"
+      ],
+      "averageReliability": 0.94,
+      "maxParallel": 3,
+      "activeOpportunities": 3,
+      "opportunityValue": 86620000,
+      "validatorSupport": 3,
+      "automationSupport": 0.91
+    },
+    {
+      "phase": "outstrategise",
+      "title": "Out-Strategise",
+      "agents": [
+        "Meta-Strategist (strategist.meta-agi.eth)"
+      ],
+      "averageReliability": 0.96,
+      "maxParallel": 2,
+      "activeOpportunities": 4,
+      "opportunityValue": 106380000,
+      "validatorSupport": 2.75,
+      "automationSupport": 0.9275
+    },
+    {
+      "phase": "outexecute",
+      "title": "Out-Execute",
+      "agents": [
+        "Autonomous Executor (executor.meta-agi.eth)"
+      ],
+      "averageReliability": 0.99,
+      "maxParallel": 5,
+      "activeOpportunities": 5,
+      "opportunityValue": 131860000,
+      "validatorSupport": 2.8,
+      "automationSupport": 0.924
+    }
+  ]
 }

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/owner-playbook.md
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/owner-playbook.md
@@ -3,6 +3,9 @@
 - **Governance Safe**: 0xF39Fd6e51aad88F6F4ce6aB8827279cffFb92266 (threshold 4 of 6)
 - **Automation Coverage**: 92.4%
 - **Sovereign Control Score**: 100.0%
+- **Alpha Capture Velocity**: $575092/h
+- **Owner Response Lag**: 8 minutes
+- **Governance Determinism**: 66.7%
 
 ## Immediate Actions
 - `globalPause` → Halts all orchestrated execution within 60 seconds. — `npm run owner:system-pause -- --action pause`
@@ -36,3 +39,11 @@
 - **Bio-Innovation Discovery Loop** (biotech) – ROI 7.03x, automation 91.0%, approvals governanceSafe
 - **Infrastructure Efficiency Cascade** (infrastructure) – ROI 9.29x, automation 90.0%, approvals timelock
 - **On-Chain Governance Elevation** (governance) – ROI 8.86x, automation 95.0%, approvals timelock
+
+## Phase Matrix
+- **Identify** → 1 agents, reliability 97.0%, automation 91.8%, opportunities 4
+- **Out-Learn** → 1 agents, reliability 95.0%, automation 92.3%, opportunities 3
+- **Out-Think** → 1 agents, reliability 98.0%, automation 91.8%, opportunities 4
+- **Out-Design** → 1 agents, reliability 94.0%, automation 91.0%, opportunities 3
+- **Out-Strategise** → 1 agents, reliability 96.0%, automation 92.8%, opportunities 4
+- **Out-Execute** → 1 agents, reliability 99.0%, automation 92.4%, opportunities 5

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/phase-flow.mmd
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/phase-flow.mmd
@@ -1,0 +1,15 @@
+graph LR
+    identify[Identify\nAgents 1\nReliability 97.0%]
+    outlearn[Out-Learn\nAgents 1\nReliability 95.0%]
+    outthink[Out-Think\nAgents 1\nReliability 98.0%]
+    outdesign[Out-Design\nAgents 1\nReliability 94.0%]
+    outstrategise[Out-Strategise\nAgents 1\nReliability 96.0%]
+    outexecute[Out-Execute\nAgents 1\nReliability 99.0%]
+    identify -->|α 92% · validators 3.0| outlearn
+    outlearn -->|α 92% · validators 3.0| outthink
+    outthink -->|α 91% · validators 3.0| outdesign
+    outdesign -->|α 93% · validators 2.8| outstrategise
+    outstrategise -->|α 92% · validators 2.8| outexecute
+    roi[Portfolio ROI 10.77x\nAlpha Velocity $575092/h]
+    outexecute --> roi
+  

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/phase-matrix.json
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/phase-matrix.json
@@ -1,0 +1,80 @@
+[
+  {
+    "phase": "identify",
+    "title": "Identify",
+    "agents": [
+      "Polymath Opportunity Scout (scout.meta-agi.eth)"
+    ],
+    "averageReliability": 0.97,
+    "maxParallel": 4,
+    "activeOpportunities": 4,
+    "opportunityValue": 120460000,
+    "validatorSupport": 3,
+    "automationSupport": 0.9175
+  },
+  {
+    "phase": "outlearn",
+    "title": "Out-Learn",
+    "agents": [
+      "Self-Evolving Curriculum Forge (forge.meta-agi.eth)"
+    ],
+    "averageReliability": 0.95,
+    "maxParallel": 3,
+    "activeOpportunities": 3,
+    "opportunityValue": 97960000,
+    "validatorSupport": 3,
+    "automationSupport": 0.9233333333333333
+  },
+  {
+    "phase": "outthink",
+    "title": "Out-Think",
+    "agents": [
+      "Meta-Agentic Planner (planner.meta-agi.eth)"
+    ],
+    "averageReliability": 0.98,
+    "maxParallel": 2,
+    "activeOpportunities": 4,
+    "opportunityValue": 120460000,
+    "validatorSupport": 3,
+    "automationSupport": 0.9175
+  },
+  {
+    "phase": "outdesign",
+    "title": "Out-Design",
+    "agents": [
+      "Creative Solution Savant (designer.meta-agi.eth)"
+    ],
+    "averageReliability": 0.94,
+    "maxParallel": 3,
+    "activeOpportunities": 3,
+    "opportunityValue": 86620000,
+    "validatorSupport": 3,
+    "automationSupport": 0.91
+  },
+  {
+    "phase": "outstrategise",
+    "title": "Out-Strategise",
+    "agents": [
+      "Meta-Strategist (strategist.meta-agi.eth)"
+    ],
+    "averageReliability": 0.96,
+    "maxParallel": 2,
+    "activeOpportunities": 4,
+    "opportunityValue": 106380000,
+    "validatorSupport": 2.75,
+    "automationSupport": 0.9275
+  },
+  {
+    "phase": "outexecute",
+    "title": "Out-Execute",
+    "agents": [
+      "Autonomous Executor (executor.meta-agi.eth)"
+    ],
+    "averageReliability": 0.99,
+    "maxParallel": 5,
+    "activeOpportunities": 5,
+    "opportunityValue": 131860000,
+    "validatorSupport": 2.8,
+    "automationSupport": 0.924
+  }
+]

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/summary.json
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/summary.json
@@ -13,5 +13,8 @@
   "stabilityReserve": 11467974.5,
   "paybackHours": 19.309091460640076,
   "treasuryVelocity": 9.772127752566202,
+  "alphaCaptureVelocity": 575092.0673076923,
+  "ownerSovereigntyLag": 8,
+  "governanceDeterminism": 0.6666666666666666,
   "ciStatus": "green"
 }

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/test/meta_agentic_demo.test.ts
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/test/meta_agentic_demo.test.ts
@@ -18,18 +18,34 @@ test('meta-agentic demo generates unstoppable economic intelligence artefacts', 
   assert(summary.metrics.sovereignControlScore >= 0.7, 'Owner control score should stay within sovereign range');
   assert(summary.metrics.antifragilityIndex >= 0.8, 'Antifragility must be ≥0.8 to learn from shocks');
   assert(summary.metrics.ownerCommandCoverage >= 0.75, 'Owner command coverage must be ≥75%');
+  assert(summary.metrics.alphaCaptureVelocity > 0, 'Alpha capture velocity should be positive');
+  assert.equal(
+    summary.metrics.ownerSovereigntyLag,
+    scenario.owner.emergency.responseMinutes,
+    'Owner sovereignty lag mirrors emergency response window',
+  );
+  assert(summary.metrics.governanceDeterminism >= 0.6, 'Governance determinism should exceed 60%');
   assert(summary.knowledgeBase.opportunities.length === scenario.opportunities.length);
   assert(summary.executionLedger.every((entry) => entry.checksum.length === 64), 'Checksums should be SHA-256 hex values');
   assert(summary.ownerPlaybook.includes('Governance Safe'));
+  assert.equal(summary.phaseMatrix.length, 6);
+  assert(summary.mermaidPhaseFlow.includes('graph LR'), 'Phase flow diagram should be generated');
 
   await writeReports(summary, reportsDir);
 
   const summaryJson = JSON.parse(await fs.readFile(path.join(reportsDir, 'summary.json'), 'utf8'));
   assert.equal(summaryJson.totalOpportunities, scenario.opportunities.length);
   assert(summaryJson.automationCoverage > 0.85);
+  assert(summaryJson.alphaCaptureVelocity > 0);
 
   const ownerControl = JSON.parse(await fs.readFile(path.join(reportsDir, 'owner-control.json'), 'utf8'));
   assert(ownerControl.controls.some((control: { parameter: string }) => control.parameter === 'globalPause'));
+
+  const phaseMatrix = JSON.parse(await fs.readFile(path.join(reportsDir, 'phase-matrix.json'), 'utf8'));
+  assert(Array.isArray(phaseMatrix));
+  assert.equal(phaseMatrix.length, 6);
+  const phaseFlow = await fs.readFile(path.join(reportsDir, 'phase-flow.mmd'), 'utf8');
+  assert(phaseFlow.includes('Alpha Velocity'), 'Phase flow mermaid should annotate alpha velocity');
 
   await fs.rm(reportsDir, { recursive: true, force: true });
 });

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/ui/index.html
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/ui/index.html
@@ -37,6 +37,11 @@
         <pre class="mermaid" id="coordination-diagram" aria-live="polite"></pre>
       </section>
 
+      <section class="charts" aria-labelledby="phase-flow-title">
+        <h2 id="phase-flow-title">Sovereign Phase Flow</h2>
+        <pre class="mermaid" id="phase-flow-diagram" aria-live="polite"></pre>
+      </section>
+
       <section class="assignments" aria-labelledby="assignments-title">
         <h2 id="assignments-title">Opportunity Portfolio</h2>
         <table>
@@ -51,6 +56,24 @@
             </tr>
           </thead>
           <tbody id="assignments-body"></tbody>
+        </table>
+      </section>
+
+      <section class="assignments" aria-labelledby="phases-title">
+        <h2 id="phases-title">Meta-Agentic Phase Matrix</h2>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Phase</th>
+              <th scope="col">Agents</th>
+              <th scope="col">Reliability</th>
+              <th scope="col">Automation Support</th>
+              <th scope="col">Active Opportunities</th>
+              <th scope="col">Validator Support</th>
+              <th scope="col">Opportunity Value</th>
+            </tr>
+          </thead>
+          <tbody id="phases-body"></tbody>
         </table>
       </section>
 


### PR DESCRIPTION
## Summary
- add alpha capture, governance determinism, and phase matrix telemetry to the Meta-Agentic α-AGI Jobs orchestration reports
- surface the sovereign phase flow and matrix in the control-room dashboard with updated owner playbook documentation
- extend the deterministic test suite to assert the new analytics artefacts and generated files

## Testing
- npm run demo:meta-agentic-alpha
- npm run test:meta-agentic-alpha


------
https://chatgpt.com/codex/tasks/task_e_6900cf0dd744833399a811221466a85f