### PR TITLE
Add governance governance ledger analytics to Economic Power demo

### DIFF
--- a/demo/Economic-Power-v0/README.md
+++ b/demo/Economic-Power-v0/README.md
@@ -29,6 +29,7 @@ Outputs land in `demo/Economic-Power-v0/reports/`:
 - `deployment-map.json` – mainnet-ready custody catalogue listing each v2 module, owner, upgrade command, and audit freshness.
 - `owner-command.mmd` – owner command mermaid graph linking pause/resume authority, parameter scripts, and module custody.
 - `owner-command-plan.md` – markdown playbook summarising quick actions, scripted upgrades, circuit breakers, and capital checkpoints in plain language.
+- `owner-governance-ledger.json` – deterministic custody ledger detailing module ownership, audit freshness, scripts, and alertable coverage gaps for governance dashboards.
 - `treasury-trajectory.json` – treasury state, yield, validator confidence, and automation lift captured after each job.
 - `assertions.json` – machine-readable verification ledger covering owner dominance, custody, validator strength, and treasury solvency.
 
@@ -102,6 +103,7 @@ The UI inside `demo/Economic-Power-v0/ui/` offers:
 - Owner command Mermaid graph mapping multi-sig authority to every module, circuit breaker, and upgrade path.
 - Drag-and-drop support for alternative `summary.json` files for instant what-if exploration.
 - Sovereign safety mesh panel cataloguing pause/resume playbooks, emergency contacts, circuit breakers, and module upgrade routes.
+- Governance ledger visual linking custody posture, audit staleness, and alert feed directly from `owner-governance-ledger.json`.
 
 Launch with:
 

--- a/demo/Economic-Power-v0/reports/baseline-summary.json
+++ b/demo/Economic-Power-v0/reports/baseline-summary.json
@@ -1,7 +1,9 @@
 {
   "scenarioId": "economic-power-v0-baseline",
   "title": "AGIJobs Economic Power Launch",
-  "generatedAt": "2025-10-28T13:59:52.100Z",
+  "generatedAt": "2025-02-01T00:00:00.000Z",
+  "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+  "executionTimestamp": "2025-10-28T15:06:06.385Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -590,5 +592,118 @@
         "pagerduty://agi-critical"
       ]
     }
+  },
+  "governanceLedger": {
+    "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+    "ownerSafe": "0xAGIJobsOperator00000000000000000000000000002",
+    "governanceSafe": "0xAGIJobsGovernor0000000000000000000000003",
+    "treasurySafe": "0xAGIJobsOwnerSafe0000000000000000000000001",
+    "threshold": 4,
+    "commandCoverage": 0.227,
+    "coverageNarrative": "Coverage below defensive target – prioritise scripting additional command hooks.",
+    "pauseScript": "npm run owner:system-pause",
+    "resumeScript": "npm run owner:update-all",
+    "scripts": [
+      "npm run owner:audit",
+      "npm run owner:parameters",
+      "npm run owner:system-pause",
+      "npm run owner:update-all",
+      "npm run owner:upgrade"
+    ],
+    "modules": [
+      {
+        "id": "job-registry",
+        "name": "JobRegistry",
+        "address": "0xA100000000000000000000000000000000000001",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "active",
+        "upgradeScript": "npm run owner:update-all",
+        "auditLagDays": 20,
+        "auditStale": false,
+        "notes": []
+      },
+      {
+        "id": "stake-manager",
+        "name": "StakeManager",
+        "address": "0xA100000000000000000000000000000000000002",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "active",
+        "upgradeScript": "npm run owner:parameters",
+        "auditLagDays": 28,
+        "auditStale": false,
+        "notes": []
+      },
+      {
+        "id": "validation-module",
+        "name": "ValidationModule",
+        "address": "0xA100000000000000000000000000000000000003",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "pending-upgrade",
+        "upgradeScript": "npm run owner:upgrade",
+        "auditLagDays": 48,
+        "auditStale": false,
+        "notes": [
+          "Pending upgrade"
+        ]
+      },
+      {
+        "id": "reputation-engine",
+        "name": "ReputationEngine",
+        "address": "0xA100000000000000000000000000000000000004",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "active",
+        "upgradeScript": "npm run owner:update-all",
+        "auditLagDays": 35,
+        "auditStale": false,
+        "notes": []
+      },
+      {
+        "id": "dispute-module",
+        "name": "DisputeModule",
+        "address": "0xA100000000000000000000000000000000000005",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "active",
+        "upgradeScript": "npm run owner:upgrade",
+        "auditLagDays": 23,
+        "auditStale": false,
+        "notes": []
+      },
+      {
+        "id": "certificate-nft",
+        "name": "CertificateNFT",
+        "address": "0xA100000000000000000000000000000000000006",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "active",
+        "upgradeScript": "npm run owner:update-all",
+        "auditLagDays": 30,
+        "auditStale": false,
+        "notes": []
+      }
+    ],
+    "alerts": [
+      {
+        "id": "coverage-gap",
+        "severity": "warning",
+        "summary": "Command coverage below 90% – script additional surfaces to reach full control.",
+        "details": [
+          "Coverage 22.7%",
+          "Add scripts for remaining modules, validators, or adapters to close the gap."
+        ]
+      },
+      {
+        "id": "pending-upgrade",
+        "severity": "info",
+        "summary": "Queued upgrades ready for 1 module(s).",
+        "details": [
+          "ValidationModule • Execute npm run owner:upgrade to promote"
+        ]
+      }
+    ]
   }
 }

--- a/demo/Economic-Power-v0/reports/owner-governance-ledger.json
+++ b/demo/Economic-Power-v0/reports/owner-governance-ledger.json
@@ -1,0 +1,113 @@
+{
+  "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+  "ownerSafe": "0xAGIJobsOperator00000000000000000000000000002",
+  "governanceSafe": "0xAGIJobsGovernor0000000000000000000000003",
+  "treasurySafe": "0xAGIJobsOwnerSafe0000000000000000000000001",
+  "threshold": 4,
+  "commandCoverage": 0.227,
+  "coverageNarrative": "Coverage below defensive target – prioritise scripting additional command hooks.",
+  "pauseScript": "npm run owner:system-pause",
+  "resumeScript": "npm run owner:update-all",
+  "scripts": [
+    "npm run owner:audit",
+    "npm run owner:parameters",
+    "npm run owner:system-pause",
+    "npm run owner:update-all",
+    "npm run owner:upgrade"
+  ],
+  "modules": [
+    {
+      "id": "job-registry",
+      "name": "JobRegistry",
+      "address": "0xA100000000000000000000000000000000000001",
+      "owner": "0xAGIJobsGovernor0000000000000000000000003",
+      "custody": "owner-controlled",
+      "status": "active",
+      "upgradeScript": "npm run owner:update-all",
+      "auditLagDays": 20,
+      "auditStale": false,
+      "notes": []
+    },
+    {
+      "id": "stake-manager",
+      "name": "StakeManager",
+      "address": "0xA100000000000000000000000000000000000002",
+      "owner": "0xAGIJobsGovernor0000000000000000000000003",
+      "custody": "owner-controlled",
+      "status": "active",
+      "upgradeScript": "npm run owner:parameters",
+      "auditLagDays": 28,
+      "auditStale": false,
+      "notes": []
+    },
+    {
+      "id": "validation-module",
+      "name": "ValidationModule",
+      "address": "0xA100000000000000000000000000000000000003",
+      "owner": "0xAGIJobsGovernor0000000000000000000000003",
+      "custody": "owner-controlled",
+      "status": "pending-upgrade",
+      "upgradeScript": "npm run owner:upgrade",
+      "auditLagDays": 48,
+      "auditStale": false,
+      "notes": [
+        "Pending upgrade"
+      ]
+    },
+    {
+      "id": "reputation-engine",
+      "name": "ReputationEngine",
+      "address": "0xA100000000000000000000000000000000000004",
+      "owner": "0xAGIJobsGovernor0000000000000000000000003",
+      "custody": "owner-controlled",
+      "status": "active",
+      "upgradeScript": "npm run owner:update-all",
+      "auditLagDays": 35,
+      "auditStale": false,
+      "notes": []
+    },
+    {
+      "id": "dispute-module",
+      "name": "DisputeModule",
+      "address": "0xA100000000000000000000000000000000000005",
+      "owner": "0xAGIJobsGovernor0000000000000000000000003",
+      "custody": "owner-controlled",
+      "status": "active",
+      "upgradeScript": "npm run owner:upgrade",
+      "auditLagDays": 23,
+      "auditStale": false,
+      "notes": []
+    },
+    {
+      "id": "certificate-nft",
+      "name": "CertificateNFT",
+      "address": "0xA100000000000000000000000000000000000006",
+      "owner": "0xAGIJobsGovernor0000000000000000000000003",
+      "custody": "owner-controlled",
+      "status": "active",
+      "upgradeScript": "npm run owner:update-all",
+      "auditLagDays": 30,
+      "auditStale": false,
+      "notes": []
+    }
+  ],
+  "alerts": [
+    {
+      "id": "coverage-gap",
+      "severity": "warning",
+      "summary": "Command coverage below 90% – script additional surfaces to reach full control.",
+      "details": [
+        "Coverage 22.7%",
+        "Add scripts for remaining modules, validators, or adapters to close the gap."
+      ]
+    },
+    {
+      "id": "pending-upgrade",
+      "severity": "info",
+      "summary": "Queued upgrades ready for 1 module(s).",
+      "details": [
+        "ValidationModule • Execute npm run owner:upgrade to promote"
+      ]
+    }
+  ]
+}

--- a/demo/Economic-Power-v0/scenario/baseline.json
+++ b/demo/Economic-Power-v0/scenario/baseline.json
@@ -3,6 +3,7 @@
   "scenarioId": "economic-power-v0-baseline",
   "title": "AGIJobs Economic Power Launch",
   "description": "Baseline configuration for the Economic Power demo showcasing modular orchestration, validator rigor, and treasury velocity.",
+  "analysisTimestamp": "2025-02-01T00:00:00.000Z",
   "network": {
     "name": "Ethereum Mainnet",
     "chainId": 1,

--- a/demo/Economic-Power-v0/test/economic_power_demo.test.ts
+++ b/demo/Economic-Power-v0/test/economic_power_demo.test.ts
@@ -94,5 +94,26 @@ test('economic power simulation produces deterministic metrics', async () => {
 
   assert(summary.deployment.modules.length > 0, 'Deployment modules should be catalogued');
   assert(summary.deployment.modules.every((module) => module.owner === summary.ownerControl.governanceSafe));
+
+  assert(summary.analysisTimestamp.length > 0, 'Analysis timestamp should be populated');
+  assert(summary.executionTimestamp.length > 0, 'Execution timestamp should be populated');
+  assert.equal(
+    summary.governanceLedger.modules.length,
+    scenario.modules.length,
+    'Governance ledger should mirror module catalogue',
+  );
+  assert.equal(
+    summary.governanceLedger.commandCoverage,
+    summary.metrics.ownerCommandCoverage,
+    'Ledger coverage should align with summary coverage metric',
+  );
+  assert.equal(
+    summary.governanceLedger.analysisTimestamp,
+    summary.analysisTimestamp,
+    'Ledger analysis timestamp should match summary analysis window',
+  );
+  assert(summary.governanceLedger.alerts.length >= 1, 'Ledger should expose actionable alerts');
+  const coverageAlert = summary.governanceLedger.alerts.find((alert) => alert.id === 'coverage-gap');
+  assert(coverageAlert, 'Coverage gap alert should be present for partial coverage scenarios');
 });
 

--- a/demo/Economic-Power-v0/ui/data/default-summary.json
+++ b/demo/Economic-Power-v0/ui/data/default-summary.json
@@ -1,7 +1,9 @@
 {
   "scenarioId": "economic-power-v0-baseline",
   "title": "AGIJobs Economic Power Launch",
-  "generatedAt": "2025-10-28T14:29:43.623Z",
+  "generatedAt": "2025-02-01T00:00:00.000Z",
+  "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+  "executionTimestamp": "2025-02-01T00:00:00.000Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -590,5 +592,118 @@
         "pagerduty://agi-critical"
       ]
     }
+  },
+  "governanceLedger": {
+    "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+    "ownerSafe": "0xAGIJobsOperator00000000000000000000000000002",
+    "governanceSafe": "0xAGIJobsGovernor0000000000000000000000003",
+    "treasurySafe": "0xAGIJobsOwnerSafe0000000000000000000000001",
+    "threshold": 4,
+    "commandCoverage": 0.227,
+    "coverageNarrative": "Coverage below defensive target – prioritise scripting additional command hooks.",
+    "pauseScript": "npm run owner:system-pause",
+    "resumeScript": "npm run owner:update-all",
+    "scripts": [
+      "npm run owner:audit",
+      "npm run owner:parameters",
+      "npm run owner:system-pause",
+      "npm run owner:update-all",
+      "npm run owner:upgrade"
+    ],
+    "modules": [
+      {
+        "id": "job-registry",
+        "name": "JobRegistry",
+        "address": "0xA100000000000000000000000000000000000001",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "active",
+        "upgradeScript": "npm run owner:update-all",
+        "auditLagDays": 20,
+        "auditStale": false,
+        "notes": []
+      },
+      {
+        "id": "stake-manager",
+        "name": "StakeManager",
+        "address": "0xA100000000000000000000000000000000000002",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "active",
+        "upgradeScript": "npm run owner:parameters",
+        "auditLagDays": 28,
+        "auditStale": false,
+        "notes": []
+      },
+      {
+        "id": "validation-module",
+        "name": "ValidationModule",
+        "address": "0xA100000000000000000000000000000000000003",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "pending-upgrade",
+        "upgradeScript": "npm run owner:upgrade",
+        "auditLagDays": 48,
+        "auditStale": false,
+        "notes": [
+          "Pending upgrade"
+        ]
+      },
+      {
+        "id": "reputation-engine",
+        "name": "ReputationEngine",
+        "address": "0xA100000000000000000000000000000000000004",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "active",
+        "upgradeScript": "npm run owner:update-all",
+        "auditLagDays": 35,
+        "auditStale": false,
+        "notes": []
+      },
+      {
+        "id": "dispute-module",
+        "name": "DisputeModule",
+        "address": "0xA100000000000000000000000000000000000005",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "active",
+        "upgradeScript": "npm run owner:upgrade",
+        "auditLagDays": 23,
+        "auditStale": false,
+        "notes": []
+      },
+      {
+        "id": "certificate-nft",
+        "name": "CertificateNFT",
+        "address": "0xA100000000000000000000000000000000000006",
+        "owner": "0xAGIJobsGovernor0000000000000000000000003",
+        "custody": "owner-controlled",
+        "status": "active",
+        "upgradeScript": "npm run owner:update-all",
+        "auditLagDays": 30,
+        "auditStale": false,
+        "notes": []
+      }
+    ],
+    "alerts": [
+      {
+        "id": "coverage-gap",
+        "severity": "warning",
+        "summary": "Command coverage below 90% – script additional surfaces to reach full control.",
+        "details": [
+          "Coverage 22.7%",
+          "Add scripts for remaining modules, validators, or adapters to close the gap."
+        ]
+      },
+      {
+        "id": "pending-upgrade",
+        "severity": "info",
+        "summary": "Queued upgrades ready for 1 module(s).",
+        "details": [
+          "ValidationModule • Execute npm run owner:upgrade to promote"
+        ]
+      }
+    ]
   }
 }

--- a/demo/Economic-Power-v0/ui/index.html
+++ b/demo/Economic-Power-v0/ui/index.html
@@ -103,6 +103,40 @@
         </div>
       </section>
 
+      <section class="panel" aria-labelledby="governance-ledger-heading">
+        <div class="panel-header">
+          <h2 id="governance-ledger-heading">Governance ledger</h2>
+          <p>Custody ledger, alert feed, and coverage diagnostics derived from <code>owner-governance-ledger.json</code>.</p>
+        </div>
+        <div class="governance-ledger-meta" role="group" aria-label="Governance ledger metadata">
+          <p><strong>Analysis timestamp:</strong> <span id="ledger-analysis"></span></p>
+          <p><strong>Execution timestamp:</strong> <span id="ledger-execution"></span></p>
+          <p><strong>Command coverage:</strong> <span id="ledger-coverage"></span></p>
+        </div>
+        <div class="panel-subheader">
+          <h3>Alerts</h3>
+        </div>
+        <ul id="ledger-alerts" class="alert-list" role="list"></ul>
+        <div class="panel-subheader">
+          <h3>Module custody</h3>
+        </div>
+        <div class="table-wrapper">
+          <table id="ledger-table">
+            <thead>
+              <tr>
+                <th>Module</th>
+                <th>Custody</th>
+                <th>Status</th>
+                <th>Audit lag</th>
+                <th>Upgrade command</th>
+                <th>Notes</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+
       <section class="panel" aria-labelledby="deployment-heading">
         <div class="panel-header">
           <h2 id="deployment-heading">On-chain control fabric</h2>

--- a/demo/Economic-Power-v0/ui/styles.css
+++ b/demo/Economic-Power-v0/ui/styles.css
@@ -444,6 +444,77 @@ tr:hover td {
   background: rgba(56, 189, 248, 0.07);
 }
 
+.governance-ledger-meta {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.governance-ledger-meta p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+}
+
+.alert-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.alert-pill {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.9rem 1.1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(15, 23, 42, 0.72);
+  box-shadow: 0 18px 32px rgba(4, 8, 20, 0.45);
+}
+
+.alert-pill strong {
+  font-size: 0.95rem;
+  color: var(--accent);
+}
+
+.alert-pill span {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.alert-critical {
+  border-color: rgba(248, 113, 113, 0.45);
+  background: rgba(64, 10, 22, 0.6);
+}
+
+.alert-warning {
+  border-color: rgba(250, 204, 21, 0.5);
+  background: rgba(82, 60, 7, 0.55);
+}
+
+.alert-info {
+  border-color: rgba(96, 165, 250, 0.45);
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.alert-success {
+  border-color: rgba(74, 222, 128, 0.45);
+  background: rgba(10, 36, 22, 0.55);
+}
+
+#ledger-table tbody tr:nth-child(odd) {
+  background: rgba(15, 25, 48, 0.45);
+}
+
+#ledger-table td {
+  vertical-align: top;
+}
+
 .mermaid {
   margin-top: 1.5rem;
   background: rgba(9, 14, 28, 0.9);


### PR DESCRIPTION
## Summary
- extend the Economic Power scenario schema and simulation to track analysis/execution timestamps and synthesise a governance ledger for the owner
- generate a deterministic owner-governance-ledger.json artifact and surface the ledger alerts inside the command playbook and test suite
- expand the UI with a governance ledger panel, updated default data, and refreshed documentation describing the new outputs

## Testing
- npm run test:economic-power

------
https://chatgpt.com/codex/tasks/task_e_6900d96e47e08333977fed643683065a