### PR TITLE
Ensure ENS ownership validation uses operator address

### DIFF
--- a/demo/AGI-Alpha-Node-v0/src/core/dashboard.ts
+++ b/demo/AGI-Alpha-Node-v0/src/core/dashboard.ts
@@ -53,6 +53,7 @@ export function startDashboard(options: DashboardOptions): void {
         res.writeHead(200);
         res.end(file);
       } catch (error) {
+        logger.warn({ error, filePath }, 'Failed to serve dashboard asset');
         res.statusCode = 404;
         res.end('Asset not found');
       }

--- a/demo/AGI-Alpha-Node-v0/src/index.ts
+++ b/demo/AGI-Alpha-Node-v0/src/index.ts
@@ -2,6 +2,8 @@
 import { Command } from 'commander';
 import { config as loadEnv } from 'dotenv';
 
+import { Wallet } from 'ethers';
+
 import { AntifragileShell } from './ai/antifragileShell.js';
 import { AgentRegistry } from './ai/agentRegistry.js';
 import { PlanningEngine } from './ai/planningEngine.js';
@@ -35,6 +37,8 @@ const config = loadConfig();
 
 async function main(): Promise<void> {
   const privateKey = ensurePrivateKey(options.privateKey ?? process.env.ALPHA_NODE_PRIVATE_KEY);
+  const operatorWallet = new Wallet(privateKey);
+  const operatorAddress = operatorWallet.address;
   const ensVerifier = new EnsVerifier({
     providerUrl: options.rpc ?? 'http://localhost:8545',
     ensRoot: config.ens.rootNode,
@@ -43,7 +47,7 @@ async function main(): Promise<void> {
 
   const fqdn = options.ens ?? `demo.${config.ens.rootNode}`;
   logger.info({ fqdn }, 'Validating ENS ownership');
-  const proof = await ensVerifier.buildOwnershipProof(fqdn);
+  const proof = await ensVerifier.buildOwnershipProof(fqdn, operatorAddress);
   if (!proof.isValid && !options.simulate) {
     throw new Error(`ENS ownership check failed for ${fqdn}`);
   }

--- a/demo/AGI-Alpha-Node-v0/src/utils/config.ts
+++ b/demo/AGI-Alpha-Node-v0/src/utils/config.ts
@@ -14,7 +14,6 @@ function mergeDeep<T extends Record<string, unknown>>(target: T, source: ConfigI
   for (const key of Object.keys(source)) {
     const sourceValue = source[key];
     if (sourceValue && typeof sourceValue === 'object' && !Array.isArray(sourceValue)) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const targetValue = (target as Record<string, unknown>)[key] ?? {};
       (target as Record<string, unknown>)[key] = mergeDeep(
         targetValue as Record<string, unknown>,

--- a/demo/AGI-Alpha-Node-v0/tsconfig.json
+++ b/demo/AGI-Alpha-Node-v0/tsconfig.json
@@ -11,7 +11,8 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "types": ["node"]
+    "types": ["node"],
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
   },
   "include": ["src/**/*.ts", "config/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- derive the operator address from the provided private key and supply it to the ENS ownership verification
- ensure the CLI rejects ENS names that are not owned by the staking operator
- add explicit type roots so the TypeScript compiler can resolve Node definitions during the build
- log failed dashboard asset reads and drop an unused lint suppression

## Testing
- npm run ci

------
https://chatgpt.com/codex/tasks/task_e_6900df5020908333a58a803bf32cde1d