### PR TITLE
feat(demo): empower owner reporting reconfiguration

### DIFF
--- a/demo/Planetary-Orchestrator-Fabric-v0/README.md
+++ b/demo/Planetary-Orchestrator-Fabric-v0/README.md
@@ -12,6 +12,7 @@ This demo packages **Planetary Orchestrator Fabric** as a runnable, checkpointab
 - 💾 **Crash-Proof Checkpointing** – A built-in recovery engine snapshots the entire fabric so runs resume exactly where they stopped.
 - 🛡️ **Owner Supreme Controls** – The owner can pause, update, reprioritize, or surgically reroute jobs at any moment via declarative commands.
 - 🧭 **Checkpoint Command Deck** – Owners retarget storage paths, tighten snapshot cadence, and trigger instant saves from the same schedule that drives pauses and reroutes.
+- 🗂️ **Adaptive Reporting** – Owners redirect artifact directories and default labels on demand, with changes persisting across checkpoints and resumes.
 - 📈 **CI-Certified** – Dedicated workflows and tests guarantee green checks on every PR and on `main`.
 - 🛰️ **Immersive UI** – Rich mermaid diagrams, dashboards, and walkthroughs translate complex topology into intuitive visuals.
 - 🎛️ **Owner Command Schedules** – Load declarative schedules that trigger pause/resume, shard tuning, and node lifecycle actions mid-run.

--- a/demo/Planetary-Orchestrator-Fabric-v0/config/owner-commands.example.json
+++ b/demo/Planetary-Orchestrator-Fabric-v0/config/owner-commands.example.json
@@ -67,6 +67,18 @@
       }
     },
     {
+      "tick": 270,
+      "note": "Retarget reporting outputs to governance archive",
+      "command": {
+        "type": "reporting.configure",
+        "reason": "Stream artifacts to dedicated governance bucket",
+        "update": {
+          "directory": "demo/Planetary-Orchestrator-Fabric-v0/reports/governance-archive",
+          "defaultLabel": "governance-drill"
+        }
+      }
+    },
+    {
       "tick": 280,
       "note": "Reroute urgent Mars manufacturing job to Helios",
       "command": {

--- a/demo/Planetary-Orchestrator-Fabric-v0/docs/owner-control.md
+++ b/demo/Planetary-Orchestrator-Fabric-v0/docs/owner-control.md
@@ -78,6 +78,24 @@ node scripts/v2/ownerControlSurface.ts \
 
 - The orchestrator immediately persists the new settings and records them under `ownerState.checkpoint` and the next `checkpoint.json` artifact.
 
+### Retarget Reporting Archives
+
+Direct reports to fresh destinations mid-run without redeploying tooling:
+
+```json
+{
+  "type": "reporting.configure",
+  "reason": "Route artifacts to governance bucket",
+  "update": {
+    "directory": "demo/Planetary-Orchestrator-Fabric-v0/reports/governance-archive",
+    "defaultLabel": "governance-drill"
+  }
+}
+```
+
+- `summary.json` updates `ownerState.reporting` so dashboards and auditors immediately see the new directory/label.
+- Checkpoints persist the new settings; subsequent resumes keep writing to the chosen archive without manual edits.
+
 ### Reroute Specific Jobs
 
 ```bash

--- a/demo/Planetary-Orchestrator-Fabric-v0/src/types.ts
+++ b/demo/Planetary-Orchestrator-Fabric-v0/src/types.ts
@@ -133,6 +133,7 @@ export interface CheckpointData {
   tick: number;
   systemPaused: boolean;
   pausedShards: ShardId[];
+  reporting?: FabricConfig['reporting'];
   shards: Record<ShardId, {
     queue: JobState[];
     inFlight: JobState[];
@@ -372,6 +373,11 @@ export type OwnerCommand =
       type: 'checkpoint.configure';
       update: { intervalTicks?: number; path?: string };
       reason?: string;
+    }
+  | {
+      type: 'reporting.configure';
+      update: { directory?: string; defaultLabel?: string };
+      reason?: string;
     };
 
 export interface OwnerCommandSchedule {
@@ -420,6 +426,7 @@ export interface FabricSummary {
     pausedShards: ShardId[];
     checkpoint: { path: string; intervalTicks: number };
     metrics: Pick<FabricMetrics, 'ownerInterventions' | 'systemPauses' | 'shardPauses'>;
+    reporting: FabricConfig['reporting'];
   };
   ownerCommands: OwnerCommandSummary;
   ledger: {


### PR DESCRIPTION
## Summary
- add an owner-level `reporting.configure` command so operators can retarget artifact directories and default labels mid-run
- persist reporting state through checkpoints/restores and surface it across summaries, dashboards, and owner state APIs
- extend documentation, example schedules, and regression tests to cover the new reporting controls

## Testing
- npm run lint:planetary-orchestrator-fabric
- npm run test:planetary-orchestrator-fabric
- npm run demo:planetary-orchestrator-fabric:ci
- npm run demo:planetary-orchestrator-fabric:acceptance -- --label reporting-retarget-2 --jobs-high-load 4000 --outage-node mars.gpu-helion --restart-stop-after 180


------
https://chatgpt.com/codex/tasks/task_e_6900e5fd3594833390a5485f66270b3a