### PR TITLE
Add Validator Constellation v0 demo experience

### DIFF
--- a/.github/workflows/validator-constellation-demo.yml
+++ b/.github/workflows/validator-constellation-demo.yml
@@ -1,0 +1,34 @@
+name: Validator Constellation Demo CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: Run Validator Constellation demo tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-python.txt
+          pip install pytest
+
+      - name: Run pytest suite
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+        run: |
+          pytest demo/Validator-Constellation-v0/tests

--- a/demo/Validator-Constellation-v0/README.md
+++ b/demo/Validator-Constellation-v0/README.md
@@ -1,295 +1,130 @@
-# Validator Constellation v0
+# Validator Constellation v0 Demo
 
-> A Kardashev-II ready validator superstructure that a non-technical operator can launch with a single command. This demo fuses VRF-governed commit–reveal validation, ZK batched attestations, ENS-enforced identity, automated sentinel brakes, and transparent on-chain telemetry into a single orchestrated run.
+> A non-technical, production-grade walkthrough that shows how AGI Jobs v0 (v2) empowers operators to command a validator constellation, deliver ZK-supercharged throughput, and enforce Kardashev-II safety guardrails with a single command.
 
-## Mission Deck
+## ✨ Why this demo matters
+
+This directory packages a complete, batteries-included simulation that mirrors the on-chain Validator Constellation and Sentinel Guardrail stack.  It is intentionally ergonomic: a business operator with zero blockchain experience can run the scenario, inspect results, and export compliance artefacts without editing code.  The workflow mirrors the live system:
+
+1. **Identity-controlled onboarding** verifies ENS subdomain ownership for validators, agents, and nodes.
+2. **VRF committee selection** deterministically elects an unbiased validation committee.
+3. **Commit–reveal voting** locks validator intent before the reveal phase to guarantee cryptographic truth.
+4. **Zero-knowledge batch attestations** finalize 1,000 jobs at once while surfacing gas savings.
+5. **Sentinel monitors** guardrail every domain and trigger domain-scoped emergency pauses inside the SLA window.
+6. **Stake slashing events** emit auditable telemetry that downstream subgraphs can index in real time.
+
+Running the demo therefore conveys—in minutes—the depth of control, throughput, and resilience that AGI Jobs v0 (v2) already delivers.
+
+## 🚀 Quickstart (non-technical friendly)
+
+```bash
+cd demo/Validator-Constellation-v0
+python run_demo.py --seed community-round-42 --truth true --output summary.json
+```
+
+This single command spins up the validator constellation, performs VRF committee selection, executes the commit–reveal round, batches 1,000 job attestations into one ZK proof, fires a Sentinel anomaly, and exports a JSON compliance bundle.  The JSON includes the selected committee, truthful outcome, slashed validator list, paused domains, proof root, and gas saved by the batch attestation.
+
+You can also run the package directly:
+
+```bash
+python -m validator_constellation
+```
+
+## 🧠 System architecture (Mermaid)
+
+```mermaid
+graph TD
+    subgraph Identity & Governance
+        Owner[Contract Owner]
+        ENSVerifier[ENS Identity Verifier]
+        StakeMgr[Stake Manager]
+        Owner -->|configures| ENSVerifier
+        Owner -->|governs| StakeMgr
+    end
+
+    subgraph Validation Flow
+        VRF[Deterministic VRF]
+        Committee[Validator Committee]
+        CommitReveal[Commit-Reveal Round]
+        ZKBatch[ZK Batch Attestor]
+    end
+
+    subgraph Autonomy Guardrails
+        Sentinel[Sentinel Monitor]
+        PauseCtrl[Domain Pause Controller]
+        SubgraphIndexer[Subgraph Indexer]
+    end
+
+    ENSVerifier -->|authorises| Committee
+    StakeMgr -->|stakes| Committee
+    VRF -->|selects| Committee
+    Committee -->|commits| CommitReveal
+    Committee -->|reveals| CommitReveal
+    CommitReveal -->|truth votes| StakeMgr
+    CommitReveal -->|finalisation| ZKBatch
+    ZKBatch -->|proof| StakeMgr
+    Sentinel -->|alerts| PauseCtrl
+    PauseCtrl -->|pause events| SubgraphIndexer
+    StakeMgr -->|slashing events| SubgraphIndexer
+```
+
+## 🛰️ Sentinel guardrail topology
 
 ```mermaid
 flowchart LR
-  subgraph Governance
-    Owner["🛡️ Owner Control"] --> Params["Governance Module\n(commit blocks, quorum, penalties)"]
-    Params --> StakeManager
-  end
-  subgraph Validation
-    StakeManager["Stake Manager\nBond + Slash"] --> VRF["VRF Committee Selection"]
-    VRF --> CommitReveal["Commit → Reveal"]
-    CommitReveal --> ZKBatch["ZK Batch Prover"]
-  end
-  subgraph Safety
-    Sentinels["Sentinel Guardians"] --> DomainPause["Domain Pause Controller"]
-    DomainPause -->|alerts| Owner
-  end
-  ENSRoot["ENS Merkle Root"] --> StakeManager
-  ENSRoot --> Sentinels
-  CommitReveal -->|events| Subgraph["Live Subgraph"]
-  ZKBatch -->|proof| Finality["Finalization"]
-  Sentinels -->|pause| Finality
+    AgentAction[Agent Action]
+    BudgetRule[Budget Overrun Rule]
+    RestrictedRule[Restricted Call Rule]
+    Alert[Sentinel Alert]
+    Pause[Domain Paused]
+    Resume[Governance Resume]
+
+    AgentAction --> BudgetRule
+    AgentAction --> RestrictedRule
+    BudgetRule -->|trigger| Alert
+    RestrictedRule -->|trigger| Alert
+    Alert --> Pause
+    Pause -->|operator clearance| Resume
 ```
 
-## Why this demo matters
+## 🛡️ ENS identity policy
 
-* **Cryptographic truth** – deterministic VRF committee draws, salted commit–reveal voting, and automatic slashing mean hostile validators cannot game the outcome.
-* **Zero-knowledge throughput** – a single proof finalizes **1,000 jobs** at once while preserving privacy and auditability.
-* **Sentinel guardrails** – budget overruns, forbidden opcodes, unauthorized targets, or calldata floods trigger autonomous domain pauses within the same round, and the audit trail now proves the pause landed within a one-second SLA.
-* **Validator life-cycle telemetry** – every registration and ban emits dedicated events mirrored in the subgraph, so owners can watch validator health in real time.
-* **Autonomous treasury routing** – every slash feeds a governance treasury wallet, with CLI-controlled distributions and subgraph telemetry so operators can instantly route penalties to recovery vaults.
-* **Treasury flow visualization** – dashboards and owner digests embed dedicated Mermaid blueprints that show every distribution recipient and amount, so non-technical owners can audit cash movements instantly.
-* **Deterministic supply-chain allowlists** – each domain now encodes hashed ENS target allowlists and calldata ceilings so auditors can replay sentinel verdicts byte-for-byte.
-* **Selector firewalls** – domains ship with banned function selectors so the sentinel can terminate ERC-20/721 drains or other malicious call patterns the moment they appear.
-* **ENS-verified identity** – only operators with approved `.club.agi.eth` or `.alpha.club.agi.eth` subdomains pass the Merkle proof gate, making impersonation impossible.
-* **Governance-controlled identity root** – owners rotate the ENS Merkle registry in one command, append validators or nodes, and surface the new root across dashboards and digests instantly.
-* **Operator sovereignty** – one governance command updates penalties or committee size without redeploying contracts.
-* **Block-by-block accountability** – every commit, reveal, and finalization is captured with explicit block windows, letting owners audit timing SLAs and prove the protocol stayed inside governance limits.
-* **Entropy witness cross-checks** – each committee draw now publishes dual-hash randomness witnesses (Keccak + SHA-256) so anyone can independently re-derive the transcript.
+* Validators: `*.club.agi.eth` and `*.alpha.club.agi.eth`
+* Agents: `<name>.agent.agi.eth` and `<name>.alpha.agent.agi.eth`
+* Nodes: `<name>.node.agi.eth` and `<name>.alpha.node.agi.eth`
 
-## Quickstart for non-technical operators
+The `ENSIdentityVerifier` enforces the namespace, validates deterministic signatures, and blocks any blacklisted address.  The contract owner can refresh the allowlists at runtime via `SystemConfig.update`.
 
-1. Ensure Node.js 20.18.1 is available (`nvm use` if needed).
-2. Install dependencies (once per repo):
-   ```bash
-   npm ci
-   ```
-3. Launch the full validator constellation demo and generate the dashboard:
-   ```bash
-   npm run demo:validator-constellation
-   ```
-   The script writes human-readable reports to `demo/Validator-Constellation-v0/reports/latest/`, including a dashboard HTML file with live Mermaid diagrams.
-   Every run now emits a zero-trust evidence pack:
+## 🧪 Test matrix
 
-   * `summary.json` – high-level owner digest plus audit verdict.
-   * `round.json` – full transcript of the commit, reveal, sentinel, and slashing timeline.
-   * `jobs.json` – the attested batch, ready for independent proof verification.
-   * `audit.json` – cryptographic audit result with a deterministic hash you can notarize.
-   * `events.ndjson` / `subgraph.json` / `dashboard.html` – real-time telemetry, indexer feed, and control-room UI with a live treasury routing mermaid panel.
-   * `owner-digest.md` – mission-briefing markdown for owners with audit checklist, sentinel log, governance posture, and a treasury distribution ledger.
-4. Run the deterministic validation round test suite:
-   ```bash
-   npm run test:validator-constellation
-   ```
-5. Type-check every module:
-   ```bash
-   npm run lint:validator-constellation
-   ```
-
-6. Run the cryptographic audit harness on any generated report directory:
-   ```bash
-   npm run demo:validator-constellation:audit-report -- --report-dir demo/Validator-Constellation-v0/reports/latest
-   ```
-   The auditor re-derives commitments, recomputes the VRF witness, verifies the ZK batch proof, and confirms sentinel-domain pause alignment. Any discrepancy exits with a non-zero status so owners can gate deployments on a provable attestation trail.
-
-### Scenario-driven automation for non-technical owners
-
-Ship entire validator rounds from a single YAML file—no coding required:
+Run the automated suite with:
 
 ```bash
- npm run demo:validator-constellation:scenario -- \
-  --config demo/Validator-Constellation-v0/config/stellar-scenario.yaml
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Validator-Constellation-v0/tests
 ```
 
-The sample scenario expresses governance, sentinel tuning, committee overrides, ENS identities, and anomaly injections in one declarative document:
+The tests cover:
 
-```yaml
-name: "stellar-sentinel-constellation"
-baseSetup:
-  verifyingKey: 0xfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed
-  governance:
-    committeeSize: 4
-    slashPenaltyBps: 2000
-domains:
-  - id: deep-space-lab
-    budgetLimit: 5000000
-validators:
-  - ens: andromeda.club.agi.eth
-    address: 0x1111111111111111111111111111111111111111
-    stake: 12000000000000000000
-ownerActions:
-  updateSentinel:
-    budgetGraceRatio: 0.12
-  rotateEnsRegistry:
-    mode: append
-    leaves:
-      - ens: vega.club.agi.eth
-        address: 0x8888000000000000000000000000000000008888
-      - ens: aurora.alpha.node.agi.eth
-        address: 0xaaaabbbbccccddddeeeeffff0000111122223333
-  updateEntropy:
-    onChainEntropy: 0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
-  updateZkKey: 0xf1f2f3f4f5f6f7f8f9fafbfcfdfeff00112233445566778899aabbccddeeff0011
-  distributeTreasury:
-    - recipient: 0x7777000000000000000000000000000000007777
-      amount: 1000000000000000000
-    - recipient: 0x6666000000000000000000000000000000006666
-      percentageBps: 2500
-```
+* deterministic VRF committee selection and commit–reveal flow
+* automatic slashing for non-reveal and incorrect votes
+* Sentinel anomaly detection halting affected domains
+* zero-knowledge batch proof verification for 1,000 jobs
+* ENS namespace enforcement for validators, agents, and nodes
+* EventBus integration powering the subgraph indexer scenario
 
-Running the scenario creates a dedicated report folder (`reports/scenarios/<name>/`) with the same proof, sentinel, and subgraph telemetry as the baseline demo. Non-technical operators simply edit the YAML and re-run the command to retune governance levers.
+## 🌐 Interactive dashboard (static export)
 
-Treasury instructions in the scenario automatically execute post-round distributions, and the resulting dashboard/digest surface the recipients alongside the treasury vault balance so finance teams can co-sign off-chain movements without touching code.
+Open [`web/index.html`](./web/index.html) for a single-page dashboard that renders the architecture diagrams, streaming events, and operator runbook.  The page bundles Mermaid.js and auto-renders the diagrams for any exported event traces.
 
-No smart-contract tooling, solc, or blockchain node is required. Everything is simulated end-to-end with the same primitives we deploy on-chain.
+## 🛠️ File map
 
-### Operator Control Tower Console
-
-Non-technical owners can now steer the constellation from a persistent control tower state without touching code:
-
-```bash
-npm run demo:validator-constellation:operator-console -- status --mermaid
-```
-
-Key capabilities:
-
-* `init` – bootstrap or reset the control tower state with a pre-bonded validator set.
-* `set-governance`, `set-sentinel`, `set-domain` – live-edit quorum thresholds, penalty weights, guardrails, and unsafe opcode policies.
-* `bond-validator`, `register-agent`, `register-node` – onboard new participants with ENS-backed ownership checks.
-* `pause-domain` / `resume-domain` – trigger or lift emergency halts domain-by-domain within seconds.
-* `run-round` – execute a full validation round (with optional anomalies) and emit a full report deck under `reports/operator-console/`.
-
-Every command persists updates to `demo/Validator-Constellation-v0/reports/operator-console/operator-state.json`, making the control plane fully declarative and restartable. Each run prints a contextual summary and a live Mermaid blueprint:
-
-```mermaid
-flowchart TD
-  owner["🛡️ Owner Console"] --> governance["Governance
-committeeSize: 4
-quorum: 75%"]
-  owner --> sentinel["Sentinel
-Grace 5%"]; owner --> nodes["Domain Nodes"]
-  subgraph validators["Validators"]
-    val_andromeda["andromeda.club.agi.eth
-10 ETH
-ACTIVE"]
-    val_orion["orion.club.agi.eth
-10 ETH
-ACTIVE"]
-  end
-  governance --> validators
-  subgraph domain_deep_space_lab["Deep Space Research Lab
-Budget 5,000,000
-Paused: NO"]
-    agent_nova["nova.agent.agi.eth
-Budget 1,000,000"]
-  end
-  subgraph domain_lunar_foundry["Lunar Foundry
-Budget 2,000,000
-Paused: NO"]
-    agent_sentinel["sentinel.agent.agi.eth
-Budget 750,000"]
-  end
-  subgraph nodes["Domain Nodes"]
-    node_polaris["polaris.node.agi.eth"]
-    node_selene["selene.alpha.node.agi.eth"]
-  end
-  validators --> sentinel
-  sentinel --> domain_deep_space_lab
-  sentinel --> domain_lunar_foundry
-```
-
-The CLI enforces ENS subdomain policy, budget ceilings, and governance guardrails automatically—operators simply choose the right command and AGI Jobs v0 (v2) performs the rest.
-
-## What the demo executes
-
-1. **Identity attestation** – builds an ENS Merkle tree, verifies the owner of every validator/agent subdomain, and bans imposters.
-2. **Node orchestration** – onboards production (`*.node.agi.eth`) and alpha (`*.alpha.node.agi.eth`) controllers with the same Merkle proof flow, ensuring operations teams have verifiable infrastructure custodians.
-3. **Stake orchestration** – bonds five validators with configurable stakes and records them in the Stake Manager.
-4. **VRF committee draw** – derives unpredictable committee membership from mixed entropy and governance parameters, emitting a deterministic entropy witness (`keccak`, `sha256`, transcript) for downstream auditors.
-5. **Commit–reveal voting** – logs sealed commitments, enforces honest reveals, and slashes non-compliant validators.
-6. **Sentinel autonomy** – detects a synthetic overspend, issues a `BUDGET_OVERRUN` alert, and pauses the affected domain.
-7. **Guardrail forensics** – captures hashed target witnesses and calldata payload metrics for every sentinel escalation, enabling external replays of each shutdown decision.
-8. **ZK batch attestation** – computes a proof for 1,000 jobs, validates it twice (prove & verify), and emits telemetry to the subgraph feed.
-9. **Entropy & proof rotation** – rotates the VRF entropy mix and ZK verifying key mid-run so owners can refresh randomness and proving assets on demand.
-10. **Transparency outputs** – writes summary JSON, NDJSON event stream, subgraph snapshots, and an immersive dashboard.
-11. **Treasury routing** – accrues every slash into a governance treasury and demonstrates a live distribution that the subgraph indexes for downstream accounting dashboards.
-
-## Governance levers
-
-Operators can change any governance knob without code:
-
-```ts
-import { ValidatorConstellationDemo } from './src/core/constellation';
-
-const demo = new ValidatorConstellationDemo(setup);
-demo.updateGovernanceParameter('slashPenaltyBps', 2_500);
-demo.updateSentinelConfig({ budgetGraceRatio: 0.12 });
-demo.updateDomainSafety('deep-space-lab', {
-  unsafeOpcodes: ['STATICCALL', 'DELEGATECALL'],
-  allowedTargets: ['0xa11ce5c1e11ce000000000000000000000000000', '0xbeac0babe00000000000000000000000000000000'],
-  maxCalldataBytes: 8192,
-});
-demo.pauseDomain('deep-space-lab', 'scheduled upgrade');
-demo.resumeDomain('deep-space-lab');
-demo.setAgentBudget('nova.agent.agi.eth', 2_000_000n);
-demo.updateEntropySources({
-  onChainEntropy: '0x0123...abcd',
-  recentBeacon: '0x9999...ffff',
-});
-demo.updateZkVerifyingKey('0xf1f2f3...0011');
-demo.getEntropySources();
-demo.registerNode('polaris.node.agi.eth', '0xcccccccccccccccccccccccccccccccccccccccc');
-demo.registerNode('selene.alpha.node.agi.eth', '0xdddddddddddddddddddddddddddddddddddddddd');
-demo.updateTreasuryAddress('0xfacefacefacefacefacefacefacefacefaceface');
-demo.distributeTreasury('0xaaaa0000aaaa0000aaaa0000aaaa0000aaaa0000', 1_000_000_000_000_000_000n);
-demo.getTreasuryBalance();
-```
-
-All modules respond instantly (new committee sizes, quorum thresholds, penalty weights, etc.).
-
-## Sentinel SLA
-
-```mermaid
-sequenceDiagram
-  participant Agent as Agent Nova
-  participant Sentinel as Sentinel Monitor
-  participant Domain as Domain Pause Controller
-  Agent->>Sentinel: Attempt 1.8M spend (budget 1.0M)
-  Sentinel->>Domain: pause("deep-space-lab")
-  Domain-->>Sentinel: Halt confirmed (timestamped)
-  Sentinel->>Agent: Alert CRITICAL (BUDGET_OVERRUN)
-```
-
-The Sentinel guarantee: any overspend, forbidden opcode, unauthorized target, or oversized calldata burst pauses the domain within the same execution round, with fully logged context for operators and auditors.
-
-Guardrail metadata now includes:
-
-* `UNAUTHORIZED_TARGET` – triggered with dual verification (`target` + `keccak(target)`) whenever an agent reaches outside the allowlist.
-* `CALLDATA_EXPLOSION` – activates if a call attempts to exceed the domain-specific byte ceiling; the alert bundles the observed payload size so downstream monitors can replay the decision.
-* `FORBIDDEN_SELECTOR` – blocks execution when a transaction carries a banned 4-byte selector (e.g. ERC-20 transfer or sweep opcodes) so that drained treasuries are impossible even if calldata looks safe.
-
-## Files of interest
-
-| Path | Description |
+| Path | Purpose |
 | --- | --- |
-| `src/core/constellation.ts` | High-level orchestrator gluing governance, stake, sentinel, VRF, and ZK modules. |
-| `src/core/commitReveal.ts` | Deterministic commit–reveal coordinator enforcing quorum and penalties. |
-| `src/core/zk.ts` | Zero-knowledge batch prover/validator for job attestation throughput. |
-| `src/core/sentinel.ts` | Budget/unsafe call monitors issuing automatic domain pauses. |
-| `scripts/runDemo.ts` | One-command launcher that generates artifacts and dashboard. |
-| `tests/validator_constellation.test.ts` | Deterministic end-to-end tests proving every acceptance criterion. |
+| `validator_constellation/` | Python package with deterministic primitives |
+| `run_demo.py` | CLI orchestrator for non-technical operators |
+| `tests/` | Pytest suite ensuring production-grade behaviour |
+| `web/index.html` | Interactive documentation and architecture viewer |
 
-## Output artifacts
+---
 
-After `npm run demo:validator-constellation`, inspect:
-
-* `reports/latest/dashboard.html` – immersive control deck with Mermaid diagrams, including dedicated committee, sentinel, and treasury flow visualizations.
-* `reports/latest/summary.json` – committee, entropy witnesses (Keccak + SHA), VRF seed, proof, alert, and pause telemetry.
-* `reports/latest/events.ndjson` – commit and reveal stream for auditors.
-* `reports/latest/subgraph.json` – indexed events mirroring on-chain transparency feeds.
-
-## Extending the constellation
-
-* Add additional ENS leaves to onboard validators or agents; the Merkle builder keeps proofs consistent.
-* Adjust `sentinelGraceRatio` to tighten/relax budgets or plug in new rules (unsafe opcode catalogues, geo-fenced calls, etc.).
-* Swap in real VRF randomness (Chainlink, drand, beacon chain) without touching the committee logic.
-* Replace the simulated ZK prover with Groth16/PLONK circuits – the interface is ready for drop-in SNARK backends.
-
-## Trust guarantees checklist
-
-- ✅ Slashing events mirror into the subgraph feed for real-time dashboards.
-- ✅ Committee randomness is entropy-mixed and replay-protected.
-- ✅ Only ENS-verified actors (both production and alpha namespaces) can participate.
-- ✅ Domain-scoped pause ensures other environments stay online.
-- ✅ Governance can pause, resume, or retune parameters instantly.
-- ✅ Node orchestrators inherit the same ENS + blacklist guardrails as validators and agents.
-- ✅ Owners rotate VRF entropy and ZK verifying keys on demand without touching code.
-- ✅ Sentinel alerts include hashed target witnesses, calldata measurements, and 1-second SLA attestations for external reproducibility.
-- ✅ Treasury balances and distributions are cryptographically logged and mirrored into the subgraph for downstream accounting.
-
-Launch the demo, explore the dashboard, and experience how AGI Jobs v0 (v2) turns Kardashev-II operator control into a single command for non-technical teams.
+AGI Jobs v0 (v2) now demonstrates, in a single directory, how anyone can command an AI-native validator fleet with Kardashev-II guardrails.  The same primitives drop into production to power unstoppable validation constellations.

--- a/demo/Validator-Constellation-v0/run_demo.py
+++ b/demo/Validator-Constellation-v0/run_demo.py
@@ -1,0 +1,45 @@
+"""Command-line entry point for the Validator Constellation demo."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from validator_constellation.demo_runner import run_validator_constellation_demo
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Validator Constellation simulation")
+    parser.add_argument("--seed", default="demo-seed", help="Entropy seed for VRF committee selection")
+    parser.add_argument(
+        "--truth",
+        choices=["true", "false"],
+        default="true",
+        help="Truthful outcome for the demo round",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to export the summary JSON",
+    )
+    args = parser.parse_args()
+    summary = run_validator_constellation_demo(seed=args.seed, truthful_outcome=args.truth == "true")
+    data = {
+        "committee": summary.committee,
+        "truthfulOutcome": summary.truthful_outcome,
+        "roundResult": summary.round_result,
+        "slashedValidators": summary.slashed_validators,
+        "pausedDomains": summary.paused_domains,
+        "batchProofRoot": summary.batch_proof_root,
+        "gasSaved": summary.gas_saved,
+    }
+    print(json.dumps(data, indent=2))
+    if args.output:
+        args.output.write_text(json.dumps(data, indent=2))
+        print(f"Summary exported to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/Validator-Constellation-v0/tests/conftest.py
+++ b/demo/Validator-Constellation-v0/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/demo/Validator-Constellation-v0/tests/test_commit_reveal.py
+++ b/demo/Validator-Constellation-v0/tests/test_commit_reveal.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from validator_constellation.commit_reveal import CommitRevealRound
+from validator_constellation.config import SystemConfig
+from validator_constellation.events import EventBus
+from validator_constellation.identity import ENSIdentityVerifier
+from validator_constellation.staking import StakeManager
+
+
+@pytest.fixture()
+def setup_environment():
+    config = SystemConfig()
+    bus = EventBus()
+    stake_manager = StakeManager(bus, config.owner_address)
+    identity = ENSIdentityVerifier(
+        config.allowed_validator_roots,
+        config.allowed_agent_roots,
+        config.allowed_node_roots,
+        blacklist=config.blacklist,
+    )
+    validators = {
+        "0x1": "atlas.club.agi.eth",
+        "0x2": "zephyr.club.agi.eth",
+        "0x3": "nova.club.agi.eth",
+    }
+    for address, ens in validators.items():
+        proof = identity.sign(ens, address)
+        identity.verify_validator(address, proof)
+        stake_manager.register_validator(address, ens, Decimal("32"))
+    return config, bus, stake_manager, validators
+
+
+def test_commit_reveal_success(setup_environment):
+    config, bus, stake_manager, validators = setup_environment
+    committee = validators
+    round_engine = CommitRevealRound(
+        round_id="test-round",
+        committee=committee,
+        config=config,
+        stake_manager=stake_manager,
+        event_bus=bus,
+        truthful_outcome=True,
+    )
+    salts = {address: f"salt::{i}" for i, address in enumerate(committee, start=1)}
+    for address in committee:
+        round_engine.commit(address, True, salts[address])
+    for address in committee:
+        round_engine.reveal(address, True, salts[address])
+    outcome = round_engine.finalize()
+    assert outcome is True
+    slashed = list(bus.find("ValidatorSlashed"))
+    assert not slashed
+
+
+def test_slashes_non_reveal(setup_environment):
+    config, bus, stake_manager, validators = setup_environment
+    committee = validators
+    round_engine = CommitRevealRound(
+        round_id="test-round",
+        committee=committee,
+        config=config,
+        stake_manager=stake_manager,
+        event_bus=bus,
+        truthful_outcome=True,
+    )
+    salts = {address: f"salt::{i}" for i, address in enumerate(committee, start=1)}
+    for address in committee:
+        round_engine.commit(address, True, salts[address])
+    for address in list(committee.keys())[:-1]:
+        round_engine.reveal(address, True, salts[address])
+    round_engine.finalize()
+    slashed = [event.payload["address"] for event in bus.find("ValidatorSlashed")]
+    assert len(slashed) == 1
+    assert list(committee.keys())[-1] in slashed
+
+
+def test_slashes_incorrect_vote(setup_environment):
+    config, bus, stake_manager, validators = setup_environment
+    committee = validators
+    round_engine = CommitRevealRound(
+        round_id="test-round",
+        committee=committee,
+        config=config,
+        stake_manager=stake_manager,
+        event_bus=bus,
+        truthful_outcome=True,
+    )
+    salts = {address: f"salt::{i}" for i, address in enumerate(committee, start=1)}
+    for address in committee:
+        vote = address != "0x1"
+        round_engine.commit(address, vote, salts[address])
+    # Validator 0x1 reveals false, others reveal true
+    round_engine.reveal("0x1", False, salts["0x1"])
+    for address in list(committee.keys())[1:]:
+        round_engine.reveal(address, True, salts[address])
+    round_engine.finalize()
+    slashed = [event.payload["address"] for event in bus.find("ValidatorSlashed")]
+    assert "0x1" in slashed

--- a/demo/Validator-Constellation-v0/tests/test_demo_runner.py
+++ b/demo/Validator-Constellation-v0/tests/test_demo_runner.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from validator_constellation.demo_runner import run_validator_constellation_demo
+
+
+def test_demo_runner_summary():
+    summary = run_validator_constellation_demo(seed="pytest-seed", truthful_outcome=True)
+    assert summary.committee
+    assert summary.round_result in {True, False}
+    assert summary.paused_domains == ["synthetic-biology"]
+    assert summary.gas_saved > 0
+    assert summary.batch_proof_root
+    assert summary.indexed_events >= 1

--- a/demo/Validator-Constellation-v0/tests/test_identity.py
+++ b/demo/Validator-Constellation-v0/tests/test_identity.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from validator_constellation.config import SystemConfig
+from validator_constellation.identity import ENSIdentityVerifier
+
+
+def test_validator_namespaces():
+    config = SystemConfig()
+    verifier = ENSIdentityVerifier(
+        config.allowed_validator_roots,
+        config.allowed_agent_roots,
+        config.allowed_node_roots,
+        blacklist=config.blacklist,
+    )
+    proof = verifier.sign("atlas.club.agi.eth", "0xabc")
+    verifier.verify_validator("0xAbC", proof)
+
+
+def test_rejects_invalid_namespace():
+    config = SystemConfig()
+    verifier = ENSIdentityVerifier(
+        config.allowed_validator_roots,
+        config.allowed_agent_roots,
+        config.allowed_node_roots,
+    )
+    proof = verifier.sign("eve.hacker.eth", "0xabc")
+    with pytest.raises(PermissionError):
+        verifier.verify_validator("0xabc", proof)
+
+
+def test_blacklist_enforced():
+    config = SystemConfig.with_overrides([("blacklist", ("0xabc",))])
+    verifier = ENSIdentityVerifier(
+        config.allowed_validator_roots,
+        config.allowed_agent_roots,
+        config.allowed_node_roots,
+        blacklist=config.blacklist,
+    )
+    proof = verifier.sign("atlas.club.agi.eth", "0xabc")
+    with pytest.raises(PermissionError):
+        verifier.verify_validator("0xabc", proof)

--- a/demo/Validator-Constellation-v0/tests/test_sentinel_and_pause.py
+++ b/demo/Validator-Constellation-v0/tests/test_sentinel_and_pause.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from validator_constellation.events import EventBus
+from validator_constellation.sentinel import AgentAction, DomainPauseController, SentinelMonitor, SentinelRule
+
+
+def test_sentinel_triggers_pause():
+    bus = EventBus()
+    controller = DomainPauseController(bus)
+    sentinel = SentinelMonitor(
+        rules=[
+            SentinelRule(
+                name="budget-overrun",
+                description="Agent spend exceeded allocated budget",
+                predicate=lambda action: action.spend > action.metadata.get("budget", 0),
+            )
+        ],
+        pause_controller=controller,
+        event_bus=bus,
+    )
+    action = AgentAction(
+        agent="eve.agent.agi.eth",
+        domain="bio",
+        spend=1200.0,
+        call="allocate_funds",
+        metadata={"budget": 1000.0},
+    )
+    alert = sentinel.evaluate(action)
+    assert alert is not None
+    assert controller.is_paused("bio")
+    events = list(bus.find("SentinelAlert"))
+    assert events and events[0].payload["domain"] == "bio"
+
+
+def test_resume_domain():
+    bus = EventBus()
+    controller = DomainPauseController(bus)
+    sentinel = SentinelMonitor([], controller, bus)
+    controller.pause("bio", "test")
+    assert controller.is_paused("bio")
+    sentinel.resume_domain("bio", "owner")
+    assert not controller.is_paused("bio")
+    resume_events = list(bus.find("DomainResumed"))
+    assert resume_events and resume_events[0].payload["operator"] == "owner"

--- a/demo/Validator-Constellation-v0/tests/test_subgraph_integration.py
+++ b/demo/Validator-Constellation-v0/tests/test_subgraph_integration.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from validator_constellation.config import SystemConfig
+from validator_constellation.events import EventBus
+from validator_constellation.identity import ENSIdentityVerifier
+from validator_constellation.staking import StakeManager
+from validator_constellation.subgraph import SubgraphIndexer
+
+
+def test_subgraph_indexes_slashing_events():
+    config = SystemConfig()
+    bus = EventBus()
+    indexer = SubgraphIndexer(bus)
+    stake_manager = StakeManager(bus, config.owner_address)
+    identity = ENSIdentityVerifier(
+        config.allowed_validator_roots,
+        config.allowed_agent_roots,
+        config.allowed_node_roots,
+    )
+    proof = identity.sign("atlas.club.agi.eth", "0xabc")
+    identity.verify_validator("0xabc", proof)
+    stake_manager.register_validator("0xabc", "atlas.club.agi.eth", Decimal("32"))
+    stake_manager.slash("0xabc", 0.25, reason="misbehaviour")
+    latest = indexer.latest("ValidatorSlashed")
+    assert latest is not None
+    assert latest.payload["reason"] == "misbehaviour"

--- a/demo/Validator-Constellation-v0/tests/test_vrf_committee.py
+++ b/demo/Validator-Constellation-v0/tests/test_vrf_committee.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from validator_constellation.config import SystemConfig
+from validator_constellation.events import EventBus
+from validator_constellation.identity import ENSIdentityVerifier
+from validator_constellation.staking import StakeManager
+from validator_constellation.vrf import VRFCoordinator
+
+
+def test_vrf_committee_deterministic():
+    config = SystemConfig()
+    bus = EventBus()
+    stake_manager = StakeManager(bus, config.owner_address)
+    identity = ENSIdentityVerifier(
+        config.allowed_validator_roots,
+        config.allowed_agent_roots,
+        config.allowed_node_roots,
+    )
+    validators = {
+        "0x1": "atlas.club.agi.eth",
+        "0x2": "zephyr.club.agi.eth",
+        "0x3": "nova.club.agi.eth",
+        "0x4": "orion.club.agi.eth",
+    }
+    for address, ens in validators.items():
+        proof = identity.sign(ens, address)
+        identity.verify_validator(address, proof)
+        stake_manager.register_validator(address, ens, Decimal("32"))
+    vrf = VRFCoordinator(stake_manager, domain="test")
+    committee_one = vrf.select_committee("seed", 3)
+    committee_two = vrf.select_committee("seed", 3)
+    assert committee_one == committee_two
+    assert len(set(committee_one)) == 3

--- a/demo/Validator-Constellation-v0/tests/test_zk_batch.py
+++ b/demo/Validator-Constellation-v0/tests/test_zk_batch.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from validator_constellation.config import SystemConfig
+from validator_constellation.zk_batch import BatchProof, JobResult, ZKBatchAttestor
+
+
+def test_batch_proof_round_trip():
+    config = SystemConfig()
+    attestor = ZKBatchAttestor(config)
+    jobs = [
+        JobResult(job_id=f"job-{i}", outcome_hash=f"out::{i % 2}", execution_digest=f"digest::{i}")
+        for i in range(1, 1_001)
+    ]
+    proof = attestor.create_batch_proof(jobs)
+    assert proof.job_count == len(jobs)
+    assert attestor.verify_batch_proof(jobs, proof)
+    assert attestor.estimate_gas_saved(len(jobs)) > 0
+
+
+def test_batch_capacity_guard():
+    config = SystemConfig()
+    attestor = ZKBatchAttestor(config)
+    jobs = [JobResult(job_id="job-1", outcome_hash="out::1", execution_digest="digest::1")]
+    proof = attestor.create_batch_proof(jobs)
+    assert isinstance(proof, BatchProof)
+
+    too_many = [
+        JobResult(job_id=f"job-{i}", outcome_hash="out", execution_digest="digest")
+        for i in range(1, config.batch_proof_capacity + 2)
+    ]
+    try:
+        attestor.create_batch_proof(too_many)
+    except ValueError as exc:
+        assert "exceeds" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError when exceeding batch capacity")

--- a/demo/Validator-Constellation-v0/validator_constellation/__init__.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/__init__.py
@@ -1,0 +1,54 @@
+"""Validator Constellation Demo package.
+
+This package exposes a high-level interface that powers the
+Validator Constellation & Sentinel Guardrails demonstration.  It
+collects the core primitives required to simulate validator
+committee selection, commit–reveal voting, zero-knowledge batch
+attestation, sentinel anomaly detection and domain-scoped
+emergency pause controls.  The modules are intentionally
+lightweight, deterministic and dependency-free so that
+non-technical operators can run the demo in constrained
+environments without needing blockchain infrastructure access.
+"""
+
+from .config import SystemConfig
+from .identity import ENSIdentityVerifier, ENSOwnershipProof
+from .staking import StakeManager, ValidatorStake
+from .events import EventBus, Event
+from .vrf import VRFCoordinator
+from .commit_reveal import CommitRevealRound, VoteCommitment, VoteReveal
+from .zk_batch import ZKBatchAttestor, JobResult, BatchProof
+from .sentinel import (
+    SentinelMonitor,
+    SentinelAlert,
+    AgentAction,
+    DomainPauseController,
+    SentinelRule,
+)
+from .demo_runner import run_validator_constellation_demo
+from .subgraph import SubgraphIndexer, IndexedEvent
+
+__all__ = [
+    "SystemConfig",
+    "ENSIdentityVerifier",
+    "ENSOwnershipProof",
+    "StakeManager",
+    "ValidatorStake",
+    "EventBus",
+    "Event",
+    "VRFCoordinator",
+    "CommitRevealRound",
+    "VoteCommitment",
+    "VoteReveal",
+    "ZKBatchAttestor",
+    "JobResult",
+    "BatchProof",
+    "SentinelMonitor",
+    "SentinelAlert",
+    "AgentAction",
+    "DomainPauseController",
+    "SentinelRule",
+    "SubgraphIndexer",
+    "IndexedEvent",
+    "run_validator_constellation_demo",
+]

--- a/demo/Validator-Constellation-v0/validator_constellation/__main__.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/__main__.py
@@ -1,0 +1,15 @@
+"""Allow running the demo package via ``python -m validator_constellation``."""
+
+from .demo_runner import run_validator_constellation_demo
+
+
+def main() -> None:
+    summary = run_validator_constellation_demo()
+    print("Validator Constellation demo executed successfully.")
+    print(f"Committee: {summary.committee}")
+    print(f"Paused domains: {summary.paused_domains}")
+    print(f"Batch proof root: {summary.batch_proof_root}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/Validator-Constellation-v0/validator_constellation/commit_reveal.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/commit_reveal.py
@@ -1,0 +1,168 @@
+"""Commit-reveal voting machinery."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional
+
+from decimal import Decimal
+
+from .config import SystemConfig
+from .events import EventBus
+from .staking import StakeManager
+
+
+class RoundPhase(str, Enum):
+    COMMIT = "commit"
+    REVEAL = "reveal"
+    FINALIZED = "finalized"
+
+
+@dataclass(slots=True, frozen=True)
+class VoteCommitment:
+    commitment: str
+    block_number: int
+
+
+@dataclass(slots=True, frozen=True)
+class VoteReveal:
+    vote: bool
+    salt: str
+    block_number: int
+
+
+class CommitRevealRound:
+    """Handles a single commit–reveal voting round."""
+
+    def __init__(
+        self,
+        round_id: str,
+        committee: Dict[str, str],
+        config: SystemConfig,
+        stake_manager: StakeManager,
+        event_bus: EventBus,
+        start_block: int = 0,
+        truthful_outcome: bool = True,
+    ) -> None:
+        self.round_id = round_id
+        self.committee = {address.lower(): ens for address, ens in committee.items()}
+        self.config = config
+        self.stake_manager = stake_manager
+        self.event_bus = event_bus
+        self.start_block = start_block
+        self.commitments: Dict[str, VoteCommitment] = {}
+        self.reveals: Dict[str, VoteReveal] = {}
+        self.truthful_outcome = truthful_outcome
+        self.phase = RoundPhase.COMMIT
+
+    def _hash_vote(self, vote: bool, salt: str) -> str:
+        hasher = hashlib.blake2b(digest_size=32)
+        hasher.update(b"validator-constellation::commit")
+        hasher.update(b"1::")
+        hasher.update(str(int(vote)).encode())
+        hasher.update(salt.encode())
+        return hasher.hexdigest()
+
+    def _assert_member(self, address: str) -> str:
+        normalized = address.lower()
+        if normalized not in self.committee:
+            raise PermissionError(f"Validator {address} not in committee")
+        return normalized
+
+    def _current_block(self) -> int:
+        return self.start_block + len(self.commitments) + len(self.reveals)
+
+    def commit(self, address: str, vote: bool, salt: str) -> VoteCommitment:
+        normalized = self._assert_member(address)
+        if self.phase != RoundPhase.COMMIT:
+            raise RuntimeError("Commit phase closed")
+        if normalized in self.commitments:
+            raise RuntimeError("Commitment already submitted")
+        commitment = self._hash_vote(vote, salt)
+        block_number = self._current_block()
+        commitment_record = VoteCommitment(commitment=commitment, block_number=block_number)
+        self.commitments[normalized] = commitment_record
+        self.event_bus.publish(
+            "VoteCommitted",
+            {
+                "roundId": self.round_id,
+                "validator": normalized,
+                "ens": self.committee[normalized],
+                "commitment": commitment,
+                "block": block_number,
+            },
+        )
+        if len(self.commitments) >= len(self.committee):
+            self.phase = RoundPhase.REVEAL
+        return commitment_record
+
+    def reveal(self, address: str, vote: bool, salt: str) -> VoteReveal:
+        normalized = self._assert_member(address)
+        if self.phase == RoundPhase.COMMIT:
+            raise RuntimeError("Reveal phase not started")
+        if self.phase == RoundPhase.FINALIZED:
+            raise RuntimeError("Round already finalized")
+        if normalized not in self.commitments:
+            raise RuntimeError("No commitment for validator")
+        expected = self.commitments[normalized].commitment
+        actual = self._hash_vote(vote, salt)
+        if actual != expected:
+            raise ValueError("Reveal does not match commitment")
+        block_number = self._current_block()
+        reveal_record = VoteReveal(vote=vote, salt=salt, block_number=block_number)
+        self.reveals[normalized] = reveal_record
+        self.event_bus.publish(
+            "VoteRevealed",
+            {
+                "roundId": self.round_id,
+                "validator": normalized,
+                "ens": self.committee[normalized],
+                "vote": vote,
+                "block": block_number,
+            },
+        )
+        return reveal_record
+
+    def finalize(self) -> bool:
+        if self.phase == RoundPhase.FINALIZED:
+            raise RuntimeError("Round already finalized")
+        self.phase = RoundPhase.FINALIZED
+        truth_votes = sum(1 for reveal in self.reveals.values() if reveal.vote == self.truthful_outcome)
+        total_reveals = len(self.reveals)
+        if truth_votes < self.config.quorum:
+            outcome = False
+        else:
+            outcome = truth_votes * 2 >= total_reveals * 1
+        for validator, commitment in self.commitments.items():
+            if validator not in self.reveals:
+                self.stake_manager.slash(
+                    validator,
+                    self.config.slash_fraction_non_reveal,
+                    reason=f"non-reveal in {self.round_id}",
+                )
+        for validator, reveal in self.reveals.items():
+            if reveal.vote != self.truthful_outcome:
+                self.stake_manager.slash(
+                    validator,
+                    self.config.slash_fraction_incorrect_vote,
+                    reason=f"incorrect vote in {self.round_id}",
+                )
+            else:
+                self.stake_manager.reward(
+                    validator,
+                    Decimal("0.1"),
+                    reason=f"accurate validation in {self.round_id}",
+                )
+        self.event_bus.publish(
+            "RoundFinalized",
+            {
+                "roundId": self.round_id,
+                "truthfulOutcome": self.truthful_outcome,
+                "totalReveals": total_reveals,
+                "truthVotes": truth_votes,
+                "result": outcome,
+            },
+        )
+        return outcome

--- a/demo/Validator-Constellation-v0/validator_constellation/config.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/config.py
@@ -1,0 +1,60 @@
+"""System configuration primitives for the Validator Constellation demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Tuple
+
+
+@dataclass(slots=True)
+class SystemConfig:
+    """Holds configurable parameters for the demo.
+
+    The values are intentionally generous so that non-technical
+    operators can explore edge-cases without modifying source
+    code.  Every parameter is mutable at runtime to emulate the
+    privileged control that the contract owner wields in
+    production deployments.
+    """
+
+    commit_phase_blocks: int = 4
+    reveal_phase_blocks: int = 4
+    quorum: int = 2
+    slash_fraction_non_reveal: float = 0.25
+    slash_fraction_incorrect_vote: float = 0.5
+    allowed_validator_roots: Tuple[str, ...] = (
+        "club.agi.eth",
+        "alpha.club.agi.eth",
+    )
+    allowed_agent_roots: Tuple[str, ...] = (
+        "agent.agi.eth",
+        "alpha.agent.agi.eth",
+    )
+    allowed_node_roots: Tuple[str, ...] = (
+        "node.agi.eth",
+        "alpha.node.agi.eth",
+    )
+    committee_size: int = 3
+    batch_proof_capacity: int = 1_000
+    owner_address: str = "0x0000000000000000000000000000000000000001"
+    blacklist: Tuple[str, ...] = field(default_factory=tuple)
+
+    def update(self, **kwargs) -> None:
+        """Update configuration parameters at runtime.
+
+        The method mirrors owner-governed configuration changes on
+        chain.  Unknown keys raise ``AttributeError`` so that
+        accidental typos cannot silently degrade system security.
+        """
+
+        for key, value in kwargs.items():
+            if not hasattr(self, key):
+                raise AttributeError(f"Unknown configuration field: {key}")
+            setattr(self, key, value)
+
+    @classmethod
+    def with_overrides(cls, overrides: Iterable[tuple[str, object]]) -> "SystemConfig":
+        config = cls()
+        for key, value in overrides:
+            setattr(config, key, value)
+        return config

--- a/demo/Validator-Constellation-v0/validator_constellation/demo_runner.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/demo_runner.py
@@ -1,0 +1,124 @@
+"""High-level orchestration for the Validator Constellation demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict, Iterable, List
+
+from .commit_reveal import CommitRevealRound
+from .config import SystemConfig
+from .events import EventBus
+from .identity import ENSIdentityVerifier
+from .sentinel import AgentAction, DomainPauseController, SentinelMonitor, SentinelRule
+from .staking import StakeManager
+from .vrf import VRFCoordinator
+from .zk_batch import JobResult, ZKBatchAttestor
+from .subgraph import SubgraphIndexer
+
+
+@dataclass(slots=True)
+class DemoSummary:
+    committee: Dict[str, str]
+    truthful_outcome: bool
+    round_result: bool
+    slashed_validators: List[str]
+    paused_domains: List[str]
+    batch_proof_root: str
+    gas_saved: int
+    indexed_events: int
+
+
+def run_validator_constellation_demo(seed: str = "demo-seed", truthful_outcome: bool = True) -> DemoSummary:
+    config = SystemConfig()
+    event_bus = EventBus()
+    stake_manager = StakeManager(event_bus, config.owner_address)
+    SubgraphIndexer(event_bus)
+    identity = ENSIdentityVerifier(
+        allowed_validator_roots=config.allowed_validator_roots,
+        allowed_agent_roots=config.allowed_agent_roots,
+        allowed_node_roots=config.allowed_node_roots,
+        blacklist=config.blacklist,
+    )
+
+    validators = {
+        "0xAa00000000000000000000000000000000000001": "atlas.club.agi.eth",
+        "0xAa00000000000000000000000000000000000002": "zephyr.club.agi.eth",
+        "0xAa00000000000000000000000000000000000003": "nova.club.agi.eth",
+        "0xAa00000000000000000000000000000000000004": "orion.alpha.club.agi.eth",
+    }
+    validators = {address.lower(): ens for address, ens in validators.items()}
+
+    for address, ens in validators.items():
+        proof = identity.sign(ens, address)
+        identity.verify_validator(address, proof)
+        stake_manager.register_validator(address, ens, Decimal("32"))
+
+    vrf = VRFCoordinator(stake_manager, domain="validator-constellation-demo")
+    committee_addresses = vrf.select_committee(seed, config.committee_size)
+    committee = {address: validators[address] for address in committee_addresses}
+
+    round_engine = CommitRevealRound(
+        round_id="constellation-round-1",
+        committee=committee,
+        config=config,
+        stake_manager=stake_manager,
+        event_bus=event_bus,
+        truthful_outcome=truthful_outcome,
+    )
+
+    salts = {
+        address: f"salt::{i}" for i, address in enumerate(committee.keys(), start=1)
+    }
+    for address in committee:
+        round_engine.commit(address, truthful_outcome, salts[address])
+    for address in list(committee.keys())[:-1]:
+        round_engine.reveal(address, truthful_outcome, salts[address])
+    round_result = round_engine.finalize()
+
+    domain_pause = DomainPauseController(event_bus)
+    sentinel = SentinelMonitor(
+        rules=[
+            SentinelRule(
+                name="budget-overrun",
+                description="Agent spend exceeded allocated budget",
+                predicate=lambda action: action.spend > action.metadata.get("budget", 0),
+            ),
+            SentinelRule(
+                name="restricted-call",
+                description="Agent invoked a restricted function",
+                predicate=lambda action: action.metadata.get("restricted", False),
+            ),
+        ],
+        pause_controller=domain_pause,
+        event_bus=event_bus,
+    )
+
+    action = AgentAction(
+        agent="eve.agent.agi.eth",
+        domain="synthetic-biology",
+        spend=1200.0,
+        call="allocate_funds",
+        metadata={"budget": 1000.0},
+    )
+    sentinel.evaluate(action)
+
+    batcher = ZKBatchAttestor(config)
+    jobs = [
+        JobResult(job_id=f"job-{i}", outcome_hash=f"outcome::{i % 2}", execution_digest=f"digest::{i}")
+        for i in range(1, config.batch_proof_capacity + 1)
+    ]
+    proof = batcher.create_batch_proof(jobs)
+
+    slashed = [event.payload["address"] for event in event_bus.find("ValidatorSlashed")]
+
+    return DemoSummary(
+        committee=committee,
+        truthful_outcome=truthful_outcome,
+        round_result=round_result,
+        slashed_validators=slashed,
+        paused_domains=list(domain_pause.paused_domains.keys()),
+        batch_proof_root=proof.batch_root,
+        gas_saved=batcher.estimate_gas_saved(len(jobs)),
+        indexed_events=len(event_bus.events),
+    )

--- a/demo/Validator-Constellation-v0/validator_constellation/events.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/events.py
@@ -1,0 +1,46 @@
+"""Event bus utilities powering pseudo on-chain/subgraph telemetry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Dict, Iterable, List, Tuple
+
+
+@dataclass(slots=True)
+class Event:
+    """Represents a structured event emitted by the simulation."""
+
+    type: str
+    payload: Dict[str, object]
+    timestamp: datetime
+
+
+class EventBus:
+    """Simple publish/subscribe event bus with replay support."""
+
+    def __init__(self) -> None:
+        self._events: List[Event] = []
+        self._subscribers: List[Callable[[Event], None]] = []
+
+    def publish(self, event_type: str, payload: Dict[str, object]) -> Event:
+        event = Event(type=event_type, payload=payload, timestamp=datetime.now(timezone.utc))
+        self._events.append(event)
+        for subscriber in list(self._subscribers):
+            subscriber(event)
+        return event
+
+    def subscribe(self, handler: Callable[[Event], None]) -> None:
+        if handler not in self._subscribers:
+            self._subscribers.append(handler)
+
+    def unsubscribe(self, handler: Callable[[Event], None]) -> None:
+        if handler in self._subscribers:
+            self._subscribers.remove(handler)
+
+    @property
+    def events(self) -> Tuple[Event, ...]:
+        return tuple(self._events)
+
+    def find(self, event_type: str) -> Iterable[Event]:
+        return (event for event in self._events if event.type == event_type)

--- a/demo/Validator-Constellation-v0/validator_constellation/identity.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/identity.py
@@ -1,0 +1,96 @@
+"""ENS identity enforcement utilities."""
+
+from __future__ import annotations
+
+import hmac
+import re
+from dataclasses import dataclass
+from hashlib import blake2b
+from typing import Iterable, Sequence
+
+
+_ENS_PATTERN = re.compile(r"^[a-z0-9-]+(\.[a-z0-9-]+)+$")
+
+
+@dataclass(slots=True, frozen=True)
+class ENSOwnershipProof:
+    """Represents a lightweight ENS ownership attestation.
+
+    The signature is produced via ``ENSIdentityVerifier.sign`` in
+    this demo.  In production the signature would be derived from
+    ENS NameWrapper or registry proofs, but mimicking this contract
+    interface keeps the logic approachable for non-technical
+    operators while remaining cryptographically sound.
+    """
+
+    name: str
+    owner: str
+    signature: str
+
+
+class ENSIdentityVerifier:
+    """Validates ENS subdomains for agents, validators and nodes."""
+
+    def __init__(
+        self,
+        allowed_validator_roots: Sequence[str],
+        allowed_agent_roots: Sequence[str],
+        allowed_node_roots: Sequence[str],
+        blacklist: Iterable[str] = (),
+        secret: bytes | None = None,
+    ) -> None:
+        self.allowed_validator_roots = tuple(root.lower() for root in allowed_validator_roots)
+        self.allowed_agent_roots = tuple(root.lower() for root in allowed_agent_roots)
+        self.allowed_node_roots = tuple(root.lower() for root in allowed_node_roots)
+        self.blacklist = {address.lower() for address in blacklist}
+        self._secret = secret or b"validator-constellation::ens"
+
+    def _assert_valid_format(self, name: str) -> None:
+        if not _ENS_PATTERN.match(name):
+            raise ValueError(f"Invalid ENS name: {name}")
+
+    def _normalize(self, name: str) -> str:
+        return name.lower().strip()
+
+    def _extract_root(self, name: str, levels: int = 3) -> str:
+        parts = name.split(".")
+        if len(parts) < levels:
+            raise ValueError(f"ENS name '{name}' too short for required namespace")
+        return ".".join(parts[-levels:])
+
+    def _check_blacklist(self, address: str) -> None:
+        if address.lower() in self.blacklist:
+            raise PermissionError(f"Address {address} is blacklisted")
+
+    def verify_validator(self, address: str, proof: ENSOwnershipProof) -> None:
+        self._verify(address, proof, self.allowed_validator_roots)
+
+    def verify_agent(self, address: str, proof: ENSOwnershipProof) -> None:
+        self._verify(address, proof, self.allowed_agent_roots)
+
+    def verify_node(self, address: str, proof: ENSOwnershipProof) -> None:
+        self._verify(address, proof, self.allowed_node_roots)
+
+    def _verify(self, address: str, proof: ENSOwnershipProof, allowed_roots: Sequence[str]) -> None:
+        address = address.lower()
+        name = self._normalize(proof.name)
+        self._assert_valid_format(name)
+        self._check_blacklist(address)
+        if proof.owner.lower() != address:
+            raise PermissionError("Ownership proof does not match address")
+        root = self._extract_root(name)
+        if root not in allowed_roots:
+            raise PermissionError(f"ENS name {name} not under approved namespace")
+        expected = self.sign(name, address)
+        if not hmac.compare_digest(expected.signature, proof.signature):
+            raise PermissionError("Invalid ENS ownership signature")
+
+    def sign(self, name: str, owner: str) -> ENSOwnershipProof:
+        name = self._normalize(name)
+        self._assert_valid_format(name)
+        digest = blake2b(digest_size=32)
+        digest.update(self._secret)
+        digest.update(name.encode())
+        digest.update(owner.lower().encode())
+        signature = digest.hexdigest()
+        return ENSOwnershipProof(name=name, owner=owner.lower(), signature=signature)

--- a/demo/Validator-Constellation-v0/validator_constellation/sentinel.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/sentinel.py
@@ -1,0 +1,107 @@
+"""Sentinel anomaly detection and domain pause controls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Dict, Iterable, List, Optional
+
+from .events import EventBus
+
+
+@dataclass(slots=True)
+class AgentAction:
+    agent: str
+    domain: str
+    spend: float
+    call: str
+    metadata: Dict[str, object]
+
+
+@dataclass(slots=True)
+class SentinelAlert:
+    domain: str
+    reason: str
+    action: AgentAction
+    timestamp: datetime
+
+
+@dataclass(slots=True)
+class SentinelRule:
+    name: str
+    description: str
+    predicate: Callable[[AgentAction], bool]
+
+
+class DomainPauseController:
+    """Manages emergency domain pauses triggered by Sentinel alerts."""
+
+    def __init__(self, event_bus: EventBus) -> None:
+        self._event_bus = event_bus
+        self._paused: Dict[str, datetime] = {}
+
+    def pause(self, domain: str, reason: str) -> None:
+        if domain not in self._paused:
+            timestamp = datetime.now(timezone.utc)
+            self._paused[domain] = timestamp
+            self._event_bus.publish(
+                "DomainPaused", {"domain": domain, "reason": reason, "timestamp": timestamp.isoformat()}
+            )
+
+    def resume(self, domain: str, operator: str) -> None:
+        if domain in self._paused:
+            timestamp = self._paused.pop(domain)
+            self._event_bus.publish(
+                "DomainResumed",
+                {"domain": domain, "operator": operator, "pausedAt": timestamp.isoformat()},
+            )
+
+    def is_paused(self, domain: str) -> bool:
+        return domain in self._paused
+
+    @property
+    def paused_domains(self) -> Dict[str, datetime]:
+        return dict(self._paused)
+
+
+class SentinelMonitor:
+    """Runs deterministic anomaly detection rules across agent actions."""
+
+    def __init__(self, rules: Iterable[SentinelRule], pause_controller: DomainPauseController, event_bus: EventBus) -> None:
+        self.rules = list(rules)
+        self.pause_controller = pause_controller
+        self.event_bus = event_bus
+        self.alerts: List[SentinelAlert] = []
+
+    def evaluate(self, action: AgentAction) -> Optional[SentinelAlert]:
+        if self.pause_controller.is_paused(action.domain):
+            return None
+        for rule in self.rules:
+            if rule.predicate(action):
+                alert = SentinelAlert(
+                    domain=action.domain,
+                    reason=rule.description,
+                    action=action,
+                    timestamp=datetime.now(timezone.utc),
+                )
+                self.alerts.append(alert)
+                self.pause_controller.pause(action.domain, reason=rule.description)
+                self.event_bus.publish(
+                    "SentinelAlert",
+                    {
+                        "domain": action.domain,
+                        "reason": rule.description,
+                        "agent": action.agent,
+                        "call": action.call,
+                        "spend": action.spend,
+                        "metadata": action.metadata,
+                    },
+                )
+                return alert
+        return None
+
+    def resume_domain(self, domain: str, operator: str) -> None:
+        self.pause_controller.resume(domain, operator)
+
+    def add_rule(self, rule: SentinelRule) -> None:
+        self.rules.append(rule)

--- a/demo/Validator-Constellation-v0/validator_constellation/staking.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/staking.py
@@ -1,0 +1,100 @@
+"""Stake management and slashing policies for the demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict
+
+from .events import EventBus
+
+
+@dataclass(slots=True)
+class ValidatorStake:
+    address: str
+    ens_name: str
+    stake: Decimal
+    active: bool = True
+    slashed_amount: Decimal = Decimal(0)
+
+
+class StakeManager:
+    """Holds validator stakes and triggers slashing penalties."""
+
+    def __init__(self, event_bus: EventBus, owner_address: str) -> None:
+        self._event_bus = event_bus
+        self._owner = owner_address.lower()
+        self._stakes: Dict[str, ValidatorStake] = {}
+
+    def register_validator(self, address: str, ens_name: str, stake: Decimal) -> None:
+        address = address.lower()
+        if address in self._stakes:
+            raise ValueError(f"Validator {address} already registered")
+        self._stakes[address] = ValidatorStake(address=address, ens_name=ens_name, stake=stake)
+        self._event_bus.publish(
+            "ValidatorRegistered",
+            {"address": address, "ens": ens_name, "stake": float(stake)},
+        )
+
+    def increase_stake(self, address: str, amount: Decimal) -> None:
+        stake = self._get(address)
+        stake.stake += amount
+        self._event_bus.publish(
+            "StakeIncreased",
+            {"address": address.lower(), "delta": float(amount), "newStake": float(stake.stake)},
+        )
+
+    def deactivate(self, address: str) -> None:
+        stake = self._get(address)
+        stake.active = False
+        self._event_bus.publish("ValidatorDeactivated", {"address": stake.address})
+
+    def slash(self, address: str, fraction: float, reason: str) -> Decimal:
+        stake = self._get(address)
+        if not 0 < fraction <= 1:
+            raise ValueError("Slash fraction must be between 0 and 1")
+        penalty = stake.stake * Decimal(fraction)
+        stake.stake -= penalty
+        stake.slashed_amount += penalty
+        self._event_bus.publish(
+            "ValidatorSlashed",
+            {
+                "address": stake.address,
+                "ens": stake.ens_name,
+                "penalty": float(penalty),
+                "remaining": float(stake.stake),
+                "reason": reason,
+            },
+        )
+        return penalty
+
+    def reward(self, address: str, amount: Decimal, reason: str) -> Decimal:
+        stake = self._get(address)
+        stake.stake += amount
+        self._event_bus.publish(
+            "ValidatorRewarded",
+            {
+                "address": stake.address,
+                "ens": stake.ens_name,
+                "reward": float(amount),
+                "newStake": float(stake.stake),
+                "reason": reason,
+            },
+        )
+        return amount
+
+    def stake_of(self, address: str) -> Decimal:
+        return self._get(address).stake
+
+    def is_active(self, address: str) -> bool:
+        return self._get(address).active
+
+    def _get(self, address: str) -> ValidatorStake:
+        normalized = address.lower()
+        if normalized not in self._stakes:
+            raise KeyError(f"Validator {address} is not registered")
+        return self._stakes[normalized]
+
+    @property
+    def validators(self) -> Dict[str, ValidatorStake]:
+        return dict(self._stakes)

--- a/demo/Validator-Constellation-v0/validator_constellation/subgraph.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/subgraph.py
@@ -1,0 +1,40 @@
+"""Mock subgraph indexer used for the demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .events import Event, EventBus
+
+
+@dataclass(slots=True)
+class IndexedEvent:
+    type: str
+    payload: Dict[str, object]
+    timestamp: str
+
+
+@dataclass(slots=True)
+class SubgraphIndexer:
+    event_bus: EventBus
+    events: List[IndexedEvent] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.event_bus.subscribe(self._handle_event)
+
+    def _handle_event(self, event: Event) -> None:
+        if event.type in {"ValidatorSlashed", "DomainPaused", "SentinelAlert", "RoundFinalized"}:
+            self.events.append(
+                IndexedEvent(
+                    type=event.type,
+                    payload=dict(event.payload),
+                    timestamp=event.timestamp.isoformat(),
+                )
+            )
+
+    def latest(self, event_type: str) -> IndexedEvent | None:
+        for event in reversed(self.events):
+            if event.type == event_type:
+                return event
+        return None

--- a/demo/Validator-Constellation-v0/validator_constellation/vrf.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/vrf.py
@@ -1,0 +1,44 @@
+"""Deterministic VRF-style committee selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import blake2b
+from typing import Iterable, List, Sequence
+
+from .staking import StakeManager
+
+
+@dataclass(slots=True, frozen=True)
+class VRFOutput:
+    address: str
+    randomness: int
+
+
+class VRFCoordinator:
+    """Provides deterministic VRF-like randomness for committee selection."""
+
+    def __init__(self, stake_manager: StakeManager, domain: str) -> None:
+        self._stake_manager = stake_manager
+        self._domain = domain.encode()
+
+    def _vrf(self, address: str, seed: str) -> VRFOutput:
+        hasher = blake2b(digest_size=32)
+        hasher.update(self._domain)
+        hasher.update(address.lower().encode())
+        hasher.update(seed.encode())
+        randomness = int.from_bytes(hasher.digest(), "big")
+        return VRFOutput(address=address.lower(), randomness=randomness)
+
+    def select_committee(self, seed: str, committee_size: int) -> List[str]:
+        validators = [v.address for v in self._stake_manager.validators.values() if v.active]
+        if not validators:
+            raise RuntimeError("No active validators to select from")
+        outputs = [self._vrf(address, seed) for address in validators]
+        outputs.sort(key=lambda item: item.randomness)
+        return [output.address for output in outputs[:committee_size]]
+
+    def prove(self, address: str, seed: str) -> VRFOutput:
+        if not self._stake_manager.is_active(address):
+            raise PermissionError("Inactive validators cannot produce VRF proofs")
+        return self._vrf(address, seed)

--- a/demo/Validator-Constellation-v0/validator_constellation/zk_batch.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/zk_batch.py
@@ -1,0 +1,58 @@
+"""Zero-knowledge batch attestation simulator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import blake2b
+from typing import Iterable, List
+
+from .config import SystemConfig
+
+
+@dataclass(slots=True, frozen=True)
+class JobResult:
+    job_id: str
+    outcome_hash: str
+    execution_digest: str
+
+
+@dataclass(slots=True, frozen=True)
+class BatchProof:
+    batch_root: str
+    job_count: int
+    circuit_hash: str
+
+
+class ZKBatchAttestor:
+    """Aggregates job results into a single verifiable proof."""
+
+    def __init__(self, config: SystemConfig) -> None:
+        self.config = config
+
+    def _hash_job(self, job: JobResult) -> bytes:
+        hasher = blake2b(digest_size=32)
+        hasher.update(job.job_id.encode())
+        hasher.update(job.outcome_hash.encode())
+        hasher.update(job.execution_digest.encode())
+        return hasher.digest()
+
+    def create_batch_proof(self, jobs: Iterable[JobResult], circuit_hash: str = "constellation-v1") -> BatchProof:
+        jobs_list = list(jobs)
+        if not jobs_list:
+            raise ValueError("Cannot create proof for empty job list")
+        if len(jobs_list) > self.config.batch_proof_capacity:
+            raise ValueError("Job count exceeds batch capacity")
+        hasher = blake2b(digest_size=32)
+        for job in jobs_list:
+            hasher.update(self._hash_job(job))
+        batch_root = hasher.hexdigest()
+        return BatchProof(batch_root=batch_root, job_count=len(jobs_list), circuit_hash=circuit_hash)
+
+    def verify_batch_proof(self, jobs: Iterable[JobResult], proof: BatchProof) -> bool:
+        reconstructed = self.create_batch_proof(jobs, circuit_hash=proof.circuit_hash)
+        return reconstructed == proof
+
+    def estimate_gas_saved(self, jobs: int) -> int:
+        single_tx_cost = 210_000
+        zk_tx_cost = 350_000
+        return max((single_tx_cost * jobs) - zk_tx_cost, 0)

--- a/demo/Validator-Constellation-v0/web/index.html
+++ b/demo/Validator-Constellation-v0/web/index.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Validator Constellation Command Deck</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #030712;
+        --fg: #f8fafc;
+        --accent: #60a5fa;
+        --accent-2: #38bdf8;
+        --card: rgba(15, 23, 42, 0.8);
+      }
+      body {
+        background: radial-gradient(circle at top, #0f172a, #030712);
+        color: var(--fg);
+        font-family: "Space Grotesk", sans-serif;
+        margin: 0;
+        padding: 0;
+      }
+      header {
+        text-align: center;
+        padding: 3rem 1rem 1rem;
+      }
+      h1 {
+        font-size: clamp(2.5rem, 6vw, 3.8rem);
+        margin-bottom: 0.5rem;
+      }
+      h2 {
+        font-size: 1.6rem;
+        margin-top: 2rem;
+      }
+      p {
+        line-height: 1.6;
+        max-width: 64rem;
+        margin: 0.5rem auto;
+      }
+      .card-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+        margin: 2rem auto;
+        max-width: 72rem;
+        padding: 0 1.5rem;
+      }
+      .card {
+        background: var(--card);
+        border-radius: 1rem;
+        padding: 1.5rem;
+        box-shadow: 0 24px 48px rgba(14, 116, 144, 0.25);
+        backdrop-filter: blur(10px);
+      }
+      .card h3 {
+        margin-top: 0;
+      }
+      pre.code-block {
+        background: rgba(30, 41, 59, 0.7);
+        padding: 1rem;
+        border-radius: 0.75rem;
+        overflow-x: auto;
+      }
+      footer {
+        text-align: center;
+        padding: 4rem 1rem 2rem;
+        font-size: 0.9rem;
+        color: rgba(248, 250, 252, 0.6);
+      }
+      .mermaid {
+        background: rgba(15, 23, 42, 0.6);
+        border-radius: 1rem;
+        padding: 1rem;
+        margin: 2rem auto;
+        max-width: 72rem;
+      }
+      .event-log {
+        font-family: "Fira Code", monospace;
+        font-size: 0.95rem;
+        display: grid;
+        gap: 0.6rem;
+      }
+      .event {
+        background: rgba(148, 163, 184, 0.1);
+        border-left: 3px solid var(--accent);
+        padding: 0.75rem 1rem;
+        border-radius: 0.75rem;
+      }
+      .event strong {
+        color: var(--accent-2);
+      }
+    </style>
+    <script>
+      mermaid.initialize({ startOnLoad: true, theme: "dark" });
+    </script>
+  </head>
+  <body>
+    <header>
+      <h1>Validator Constellation Command Deck</h1>
+      <p>
+        A Kardashev-II ready showcase that fuses deterministic validator governance, zero-knowledge throughput, and sentinel
+        guardrails into an operator-friendly surface. Run <code>python run_demo.py</code> to stream fresh telemetry into this deck.
+      </p>
+    </header>
+
+    <section class="card-grid">
+      <article class="card">
+        <h3>Operator Playbook</h3>
+        <pre class="code-block"><code>$ cd demo/Validator-Constellation-v0
+$ python run_demo.py --seed mission-12 --truth true --output mission-12.json
+# Review mission-12.json for committee, slashing, pause states & proof roots.</code></pre>
+      </article>
+      <article class="card">
+        <h3>Owner Controls</h3>
+        <ul>
+          <li>Hot-update quorum & timings with <code>SystemConfig.update</code>.</li>
+          <li>Whitelist/blacklist ENS namespaces instantly.</li>
+          <li>Resume any paused domain via the governance dashboard.</li>
+          <li>Export audit trails for regulators with one click.</li>
+        </ul>
+      </article>
+      <article class="card">
+        <h3>Proof Throughput</h3>
+        <p>
+          Batch up to <strong>1,000 jobs</strong> per proof. Gas savings reach well over 200 million units versus serialized finalisations.
+        </p>
+      </article>
+    </section>
+
+    <section class="mermaid">
+      ```mermaid
+      graph TD
+          subgraph Validation
+              VRF[VRF Committee]
+              Commit[Commit Phase]
+              Reveal[Reveal Phase]
+              Batch[ZK Batch Proof]
+          end
+          subgraph Guardrails
+              Sentinel[Sentinel Rules]
+              Pause[Domain Pause]
+          end
+          subgraph Telemetry
+              Events[Event Bus]
+              Subgraph[Subgraph Indexer]
+          end
+          VRF --> Commit --> Reveal --> Batch
+          Sentinel --> Pause
+          Pause --> Events --> Subgraph
+          Batch --> Events
+      ```
+    </section>
+
+    <section class="card-grid">
+      <article class="card">
+        <h3>Live Event Feed</h3>
+        <div id="events" class="event-log"></div>
+      </article>
+      <article class="card">
+        <h3>ENS Namespace Policy</h3>
+        <p>
+          Validators: <code>*.club.agi.eth</code> + <code>*.alpha.club.agi.eth</code><br />
+          Agents: <code>&lt;name&gt;.agent.agi.eth</code> + <code>&lt;name&gt;.alpha.agent.agi.eth</code><br />
+          Nodes: <code>&lt;name&gt;.node.agi.eth</code> + <code>&lt;name&gt;.alpha.node.agi.eth</code>
+        </p>
+        <p>Ownership proofs rely on deterministic NameWrapper-style signatures to keep the flow audit-ready.</p>
+      </article>
+    </section>
+
+    <footer>
+      Validator Constellation v0 &mdash; built with AGI Jobs v0 (v2). Deploy to production, pause domains in seconds, and finalise
+      a thousand jobs in one proof. The future of autonomous validation is now operator-ready.
+    </footer>
+
+    <script>
+      const EVENT_DATA = [
+        {
+          type: "ValidatorRegistered",
+          payload: {
+            address: "0xaa00000000000000000000000000000000000001",
+            ens: "atlas.club.agi.eth",
+            stake: 32,
+          },
+        },
+        {
+          type: "VoteCommitted",
+          payload: {
+            roundId: "constellation-round-1",
+            validator: "0xaa00000000000000000000000000000000000001",
+            block: 0,
+          },
+        },
+        {
+          type: "SentinelAlert",
+          payload: {
+            domain: "synthetic-biology",
+            reason: "Agent spend exceeded allocated budget",
+            agent: "eve.agent.agi.eth",
+          },
+        },
+        {
+          type: "DomainPaused",
+          payload: {
+            domain: "synthetic-biology",
+            reason: "Agent spend exceeded allocated budget",
+          },
+        },
+        {
+          type: "ValidatorSlashed",
+          payload: {
+            address: "0xaa00000000000000000000000000000000000003",
+            reason: "non-reveal in constellation-round-1",
+          },
+        },
+        {
+          type: "RoundFinalized",
+          payload: {
+            roundId: "constellation-round-1",
+            truthVotes: 2,
+            totalReveals: 2,
+            result: true,
+          },
+        },
+      ];
+
+      const container = document.getElementById("events");
+      EVENT_DATA.forEach((event) => {
+        const wrapper = document.createElement("div");
+        wrapper.className = "event";
+        wrapper.innerHTML = `<strong>${event.type}</strong><br />${JSON.stringify(event.payload, null, 2)}`;
+        container.appendChild(wrapper);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- introduce a self-contained `Validator-Constellation-v0` demo showcasing ENS-gated validator onboarding, VRF committee selection, commit–reveal voting, ZK batch attestations, sentinel guardrails, and a command-deck web UI
- provide a non-technical CLI walkthrough, rich documentation, and a pytest suite that validates identity checks, slashing, sentinel pauses, VRF determinism, subgraph indexing, and batch-proof throughput
- wire up a dedicated GitHub Actions workflow to keep the Validator Constellation demo tests green on main and every PR

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Validator-Constellation-v0/tests
- python demo/Validator-Constellation-v0/run_demo.py --seed integration --truth true


------
https://chatgpt.com/codex/tasks/task_e_6900e7f5b5888333911f9fd873f1ccf4