### PR TITLE
Add Meta-Agentic α-AGI Jobs demo v3

### DIFF
--- a/.github/workflows/demo-meta-agentic-alpha-agi-jobs.yml
+++ b/.github/workflows/demo-meta-agentic-alpha-agi-jobs.yml
@@ -55,6 +55,13 @@ jobs:
         run: |
           python demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_demo_v2.py --timeout 60
 
+      - name: Execute demo CLI V3
+        env:
+          META_AGENTIC_DEMO_V3_TIMEOUT: '210'
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: '1'
+        run: |
+          python demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_demo_v3.py --timeout 75
+
       - name: Upload artefacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -63,7 +70,10 @@ jobs:
           path: |
             demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/latest_run.json
             demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/latest_run_v2.json
+            demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/latest_run_v3.json
             demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/orchestrator/scoreboard.json
+            demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/orchestrator_v3/scoreboard.json
             demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/alpha_deck.md
             demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v2/reports/generated/alpha_masterplan_run.md
+            demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/reports/generated/meta_synthesis.md
             demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/ui/

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/README.md
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/README.md
@@ -49,6 +49,7 @@ demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/
    ```bash
    python demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_demo.py
    python demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_demo_v2.py
+   python demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_demo_v3.py
    ```
    The V2 CLI prints direct links to the freshly generated owner console and masterplan report.
 3. **Open the console**:
@@ -60,6 +61,7 @@ demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/
    - `demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/latest_run.json`
    - `demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/latest_run_v2.json`
    - `demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v2/reports/generated/alpha_masterplan_run.md`
+   - `demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/reports/generated/meta_synthesis.md`
    - `demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/orchestrator/scoreboard.json`
    - `demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/reports/alpha_deck.md`
 
@@ -121,11 +123,11 @@ sequenceDiagram
 
 ## 🛡️ Governance & Safety Guarantees
 
-- **Owner Supremacy:** Owners, guardians, approvals, and pause controls are configured directly via `governance.set` orchestration step. Contract owners can update every tunable parameter (stake floors, reward splits, validators, circuit breakers) on-demand.
-- **Timelock & Guardian Hooks:** High-impact operations (e.g., treasury reallocations) honour timelock & guardian thresholds from the scenario YAML.
+- **Owner Supremacy:** Owners, guardians, approvals, and pause controls are configured directly via `governance.set` orchestration step. Contract owners can update every tunable parameter (stake floors, reward splits, validators, circuit breakers) on-demand, including the new V3 mission dials surfaced in `meta_agentic_alpha_v3`.
+- **Timelock & Guardian Hooks:** High-impact operations (e.g., treasury reallocations) honour timelock & guardian thresholds from the scenario YAML and the V3 tri-sentinel guardian mesh.
 - **Dry-Run First:** All execution steps run in simulated mode by default, leveraging `ORCHESTRATOR_BRIDGE_MODE=python` and `eth_call` semantics.
 - **Checkpointing:** Crash-safe checkpointing ensures runs can be resumed mid-flight.
-- **Antifragile Monitoring:** Generated dashboards highlight stress scenarios and automatically update the alpha probability metric.
+- **Antifragile Monitoring:** Generated dashboards highlight stress scenarios and automatically update the alpha probability metric, now with a compounding index in the V3 console.
 
 ---
 
@@ -183,7 +185,9 @@ The regenerated `storage/ui/index.html` console now:
 - Exposes one-click artefact links (summary JSON, investor masterplan, console sources) for downstream teams.
 - Highlights owner levers updated via `owner_controls.py` so stakeholders instantly see configuration deltas.
 
-Serve it statically or drop it into any CDN – the bundle is pure HTML/CSS/JS with Mermaid handled via CDN.
+Serve it statically or drop it into any CDN – the bundle is pure HTML/CSS/JS with Mermaid handled via CDN. The
+V3 console lives under `storage/ui/v3` and adds alpha compounding telemetry, unstoppable mesh summaries, and
+guardian confirmation feeds.
 
 ---
 

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/README.md
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/README.md
@@ -1,0 +1,81 @@
+# Meta-Agentic α-AGI Jobs Demo V3 — Meta-Sovereign Alpha Fabric 👁️✨
+
+The **V3 Meta-Agentic α-AGI Jobs Demo** demonstrates how a non-technical owner can wield
+AGI Jobs v0 (v2) to spin up an autonomous alpha factory that senses opportunities, self-improves,
+architects ventures, calibrates governance, and dispatches gasless executions under guardian
+oversight. Every control – treasury, circuit breakers, approvals, antifragility buffers – is dialled
+via human-friendly YAML and surfaced in a beautiful console.
+
+## 🚀 Quickstart
+
+```bash
+cd demo/Meta-Agentic-ALPHA-AGI-Jobs-v0
+python meta_agentic_demo_v3.py --timeout 90
+```
+
+The command:
+1. Bootstraps orchestrator storage, guardians, and antifragility monitors.
+2. Registers all V3 agents with stakes, multisig controls, and ethics oversight.
+3. Builds a meta-plan spanning Identify → Learn → Think → Design → Strategise → Govern → Execute → Feedback.
+4. Simulates and executes the plan with dry-run safety before committing on-chain payloads.
+5. Emits artefacts:
+   - `storage/latest_run_v3.json` — canonical ledger of the autonomous mission.
+   - `meta_agentic_alpha_v3/reports/generated/meta_synthesis.md` — investor-ready report with Mermaid timelines.
+   - `storage/ui/v3/index.html` — grandiose owner console pre-populated with live metrics.
+
+## 🛡️ Owner Empowerment
+
+- **Full parameter control:** update budgets, rewards, risk limits, approvals through
+  `scripts/owner_controls.py --config meta_agentic_alpha_v3/config/scenario.yaml`.
+- **Guardian oversight:** three-guardian tri-sentinel circuit must co-sign high-impact actions.
+- **Emergency pause:** instant pause switch plus antifragility oracle triggers on drawdowns or variance spikes.
+- **Gasless UX:** account abstraction bundler & paymaster configured out of the box.
+
+## 🧭 Architecture Flow
+
+```mermaid
+flowchart TD
+    A[Owner Trigger] --> B{Meta-Agentic Planner V3}
+    B -->|Identify| C[Hypergraph Signal Mesh]
+    B -->|Learn| D[MuZero AlphaFusion III]
+    B -->|Think| E[Meta-Strategist Tree]
+    B -->|Design| F[Creative Alpha Forge]
+    B -->|Strategise| G[Treasury Autopilot]
+    B -->|Govern| H[Guardian & Owner Console]
+    B -->|Execute| I[Gasless On-Chain Bundle]
+    I --> J[Treasury Ledger]
+    J --> K[Feedback Alpha Ledger]
+    K --> B
+```
+
+## 📊 Dashboard Preview
+
+The static UI in `ui/` renders:
+- Live alpha readiness, compounding index, and antifragility posture.
+- Phase telemetry tables with completion heatmaps.
+- Mermaid execution timelines + guardian approvals.
+- Artefact links (summary JSON, investor deck, console assets).
+
+Serve locally:
+```bash
+python -m http.server --directory demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/ui/v3 9001
+```
+Visit `http://localhost:9001` to experience the console.
+
+## ✅ Testing
+
+Run the regression suite:
+```bash
+pytest demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/tests/test_meta_agentic_alpha_v3.py -q
+```
+
+## ✨ What makes it superlative?
+
+- **Meta-agentic federation:** 7-agent quorum via the A2A meta-priority protocol.
+- **Owner-first design:** all parameters adjustable via YAML or helper CLI. Summary JSON surfaces the exact command
+  owners should run for edits.
+- **Production ready:** storage is idempotent, JSON/Markdown artefacts are reproducible, and CI ensures every PR keeps
+  the demo green.
+- **Educational:** narrative-first reporting explains how each phase contributes to compounding alpha.
+
+Unleash autonomous wealth engines – no engineering team required.

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/config/scenario.yaml
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/config/scenario.yaml
@@ -1,0 +1,285 @@
+scenario:
+  id: "meta-agentic-alpha-v3"
+  title: "Meta-Agentic α-AGI Jobs Demo — Meta-Sovereign Alpha Fabric"
+  narrative: |
+    A non-technical owner commands AGI Jobs v0 (v2) to summon an autonomous
+    meta-agentic enterprise that continuously senses latent alpha, architects
+    execution blueprints, calibrates governance, and dispatches capital on-chain
+    with full gas abstraction and guardian failsafes. Every lever — treasury,
+    approvals, pauses, antifragility buffers — is configurable from the console.
+  owner:
+    address: "0xA1FAce00000000000000000000000000C0NTROL"
+    guardians:
+      - "0xBEEf0000000000000000000000000000DEF1ACE"
+      - "0xACED0000000000000000000000000000FEEDC0"
+      - "0x0Mn1SOvERE1GN000000000000000000001"
+    approvals_required: 3
+    emergency_pause: true
+    can_delegate_parameters: true
+    mission_charter: "meta-agentic-alpha"
+  treasury:
+    token: "AGIALPHA"
+    initial_balance: "5000000"
+    risk_limits:
+      max_drawdown_percent: 6.5
+      var_percent: 3.2
+      antifragility_buffer_percent: 22
+      circuit_breaker_percent: 8.5
+    streaming_allocation:
+      identify_mesh: 0.21
+      simulation_foundry: 0.18
+      strategy_lab: 0.27
+      reserve_garrison: 0.34
+  gasless:
+    enabled: true
+    bundler: "meta-agentic-bundler"
+    paymaster: "account-abstraction/alpha-meta-paymaster.json"
+    session_keys:
+      - "guardian-grid-validator"
+      - "alpha-portfolio-autopilot"
+  dashboards:
+    - title: "Meta-Agentic Mission Deck"
+      file: "meta_agentic_alpha_v3/reports/meta_mission_deck.md"
+    - title: "Meta-Agentic Console V3"
+      file: "meta_agentic_alpha_v3/ui/index.html"
+  attachments:
+    - "meta_agentic_alpha_v3/reports/meta_mission_deck.md"
+
+mission:
+  alpha_goal: "compound-global-alpha"
+  ica_score_target: 0.94
+  antifragility_focus: "black-swan-enrichment"
+  sovereign_controls:
+    pause_switch: true
+    treasury_dials:
+      liquidity_buffer_percent: 18
+      reinvestment_percent: 42
+      emergency_diversion_percent: 9
+    guardian_circuit: "tri-sentinel"
+  opportunity_domains:
+    - finance/liquidity-arbitrage
+    - climate/carbon-bridging
+    - biotech/protein-design
+    - infrastructure/resilient-energy
+
+unstoppable:
+  hypergraph_state: "omniscient"
+  multi_agent_mesh:
+    quorum: 7
+    coordination_protocol: "A2A-meta-priority"
+    sentinel_agents:
+      - "guardian-grid-validator"
+      - "alpha-portfolio-autopilot"
+      - "omni-risk-auditor"
+      - "sovereign-governor"
+      - "treasury-allocator"
+      - "ethics-proctor"
+      - "mission-chronicle"
+  safety_net:
+    antifragility_oracle: "omega-delta-observatory"
+    halt_conditions:
+      - "variance>3σ"
+      - "losses>circuit_breaker"
+      - "guardian-veto"
+    restart_policy: "adaptive-warm-start"
+
+agents:
+  - agent_id: "guardian-grid-validator"
+    owner: "Tri-Sentinel Guardian Syndicate"
+    region: "omni"
+    capabilities:
+      - execution
+      - validation
+      - oversight
+    stake_amount: "48000"
+    slashable: true
+    requires_kyc: true
+    operator_secret: "guardian-alpha"
+  - agent_id: "alpha-portfolio-autopilot"
+    owner: "Treasury Autopilot"
+    region: "global"
+    capabilities:
+      - strategy
+      - analytics
+      - router
+    stake_amount: "88000"
+    slashable: true
+    operator_secret: "autopilot-secret"
+  - agent_id: "ethics-proctor"
+    owner: "Omni Ethics Council"
+    region: "planetary"
+    capabilities:
+      - oversight
+      - analysis
+    stake_amount: "25000"
+    slashable: false
+    operator_secret: "ethics-sentinel"
+
+phases:
+  - id: "identify"
+    label: "Identify"
+    description: "Fuse multi-domain alpha anomalies into a living opportunity graph."
+    weight: 1.6
+    success_metric: "signal_resonance"
+    step:
+      kind: "plan"
+      tool: "identify.meta-mesh"
+      params:
+        sensors:
+          finance: "data/finance/opportunity_signals.json"
+          research: "data/research/breakthroughs.json"
+          policy: "data/policy/regulatory_radar.json"
+        hypergraph_export: "storage/alpha_hypergraph.json"
+        anomaly_threshold: 0.9
+        escalation_channel: "console"
+  - id: "learn"
+    label: "Out-Learn"
+    description: "Evolve open-ended curricula with MuZero-grade world modeling."
+    weight: 1.7
+    success_metric: "world_model_sufficiency"
+    step:
+      kind: "plan"
+      tool: "learn.self-architect"
+      params:
+        curriculum: "AlphaFactory/MetaSeason"
+        simulation_engine: "MiniWorld-POET-XL"
+        world_model: "MuZero-AlphaFusion-III"
+        policy_distillation: true
+        antifragility_oracle: "omega-delta-observatory"
+  - id: "think"
+    label: "Out-Think"
+    description: "Meta-planner decomposes strategies with guardian critique loops."
+    weight: 2.2
+    success_metric: "meta_plan_strength"
+    step:
+      kind: "plan"
+      tool: "plan.meta-strategist"
+      params:
+        branching_factor: 11
+        evaluation_policy: "risk-adjusted-NPV"
+        coordination_protocol: "A2A-meta-priority"
+        guardian_veto: true
+        oversight_agent: "ethics-proctor"
+  - id: "design"
+    label: "Out-Design"
+    description: "Creative synthesis of actionable ventures with simulation feedback."
+    weight: 1.5
+    success_metric: "design_efficacy"
+    step:
+      kind: "plan"
+      tool: "design.alpha-forge"
+      params:
+        designer_agent: "aether-designer-v19"
+        deliverables:
+          - "Omni-sector liquidity vault"
+          - "Resilient energy micro-grid rollout"
+          - "Protein sequence supply mesh"
+        simulation_feedback: true
+        antifragility_backtesting: true
+  - id: "strategise"
+    label: "Out-Strategise"
+    description: "Portfolio strategist allocates capital with antifragility levers."
+    weight: 1.9
+    success_metric: "risk_adjusted_alpha"
+    step:
+      kind: "plan"
+      tool: "strategy.meta"
+      params:
+        treasury_token: "AGIALPHA"
+        capital_allocation:
+          liquidity_vault: 0.29
+          energy_microgrid: 0.26
+          protein_mesh: 0.23
+          innovation_reserve: 0.22
+        antifragility_checks:
+          - "simulate_black_swan"
+          - "stress_var@99"
+          - "guardian_resilience_playback"
+  - id: "govern"
+    label: "Out-Govern"
+    description: "Owner-controlled governance dial adjustments and circuit validation."
+    weight: 1.4
+    success_metric: "governance_integrity"
+    step:
+      kind: "plan"
+      tool: "governance.meta"
+      params:
+        approvals_required: 3
+        guardian_multisig: true
+        pause_switch: true
+        adjustable_parameters:
+          - "plan.budget.max"
+          - "phases[execute-onchain].step.params.job.reward"
+          - "treasury.risk_limits.circuit_breaker_percent"
+        timelock_seconds: 86400
+        human_console: "storage/ui/index.html"
+  - id: "execute-onchain"
+    label: "Out-Execute"
+    description: "Account abstraction & treasury autopilot commit the job bundle on-chain."
+    weight: 2.4
+    success_metric: "execution_integrity"
+    step:
+      kind: "chain"
+      tool: "job.bundle"
+      params:
+        job:
+          title: "Meta-Agentic Sovereign Liquidity Mesh"
+          description: |
+            Deploy a cross-domain alpha machine that arbitrages global liquidity
+            gaps, funds resilient energy, and accelerates biotech manufacturing.
+          reward: "225000"
+          deadline_days: 21
+          attachments:
+            - "meta_agentic_alpha_v3/reports/meta_mission_deck.md"
+          treasury_account: "0xA1FAce00000000000000000000000000C0NTROL"
+          fee_bps: 38
+          validator: "guardian-grid-validator"
+        staking:
+          validator: "guardian-grid-validator"
+          amount: "48000"
+          token: "AGIALPHA"
+          slash_guardian: "0x0Mn1SOvERE1GN000000000000000000001"
+        validation_commit:
+          agent: "guardian-grid-validator"
+          tx_summary: "Simulated validation commit for sovereign liquidity mesh"
+          expected_profit: "540000"
+          dry_run: true
+        treasury_update:
+          analyst_agent: "alpha-portfolio-autopilot"
+          post_execution_buffer_percent: 19
+        governance_ping:
+          route: "timelock"
+          confirmation_window_minutes: 120
+  - id: "feedback"
+    label: "Out-Learn-Again"
+    description: "Autonomous feedback ingestion closes the loop into future runs."
+    weight: 1.1
+    success_metric: "learning_loop_gain"
+    step:
+      kind: "plan"
+      tool: "feedback.alpha-ledger"
+      params:
+        ledger: "storage/latest_run_v3.json"
+        update_scoreboard: true
+        reinforce_agents:
+          - "alpha-portfolio-autopilot"
+          - "guardian-grid-validator"
+        spawn_new_agents: 2
+        antifragility_memory: "storage/antifragility.log"
+
+plan:
+  approvals:
+    - "council/alpha"
+    - "owner/multisig"
+    - "guardian/tri-sentinel"
+  budget:
+    max: "900000"
+    currency: "AGIALPHA"
+  antifragility:
+    circuit_breaker_threshold_percent: 6.0
+    pause_on_drawdown_percent: 7.5
+    reinvestment_buffer_percent: 25
+  confirmations:
+    - "Confirm liquidity mesh deployment parameters"
+    - "Guardian tri-sentinel approval recorded"
+    - "Owner verified mission charter update"

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/reports/meta_mission_deck.md
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/reports/meta_mission_deck.md
@@ -1,0 +1,18 @@
+# Meta-Agentic α-AGI Jobs Demo V3 — Mission Deck
+
+This deck is rendered for investors, guardians, and owners. It is templated and refreshed by the
+V3 orchestrator run. After each run, `meta_agentic_alpha_v3/reports/generated/meta_synthesis.md`
+contains the live metrics.
+
+```mermaid
+graph TD
+  Identify --> Learn --> Think --> Design --> Strategise --> Govern --> Execute --> Feedback --> Identify
+```
+
+Key modules:
+- Hypergraph alpha detection across finance, climate, biotech, infrastructure.
+- MuZero AlphaFusion III world model for resilient foresight.
+- Tri-sentinel guardian circuit with timelock approvals.
+- Gasless execution bundler with paymaster safety nets.
+
+Use the generated report for detailed KPIs and instructions.

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/ui/dashboard.js
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/ui/dashboard.js
@@ -1,0 +1,129 @@
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";
+
+const DATA_PATH = "dashboard-data.json";
+
+function fmtPercent(value) {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return "—";
+  }
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function fmtList(entries) {
+  if (!entries || !entries.length) return "—";
+  return entries.join(", ");
+}
+
+function setField(name, value) {
+  const el = document.querySelector(`[data-field="${name}"]`);
+  if (el) {
+    el.textContent = value ?? "—";
+  }
+}
+
+function setLink(name, value) {
+  const link = document.querySelector(`[data-link="${name}"]`);
+  if (link && value) {
+    link.href = value;
+  }
+}
+
+function populatePhaseTable(phaseScores) {
+  const tbody = document.querySelector("[data-phase-table]");
+  if (!tbody) return;
+  tbody.innerHTML = "";
+  (phaseScores || []).forEach((phase) => {
+    const tr = document.createElement("tr");
+    const stateClass = `state-${phase.state || "pending"}`;
+    tr.innerHTML = `
+      <td>${phase.label}</td>
+      <td class="${stateClass}">${phase.state?.toUpperCase() ?? "PENDING"}</td>
+      <td>${(phase.completion * 100).toFixed(0)}%</td>
+      <td>${phase.weight.toFixed(2)}</td>
+      <td>${phase.metric}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function populateConfirmations(confirmations) {
+  const list = document.querySelector("[data-list=\"confirmations\"]");
+  if (!list) return;
+  list.innerHTML = "";
+  (confirmations || []).forEach((item) => {
+    const li = document.createElement("li");
+    li.textContent = item;
+    list.appendChild(li);
+  });
+}
+
+function renderTimeline(mermaidSource) {
+  const target = document.querySelector("[data-field=\"timeline\"]");
+  if (!target) return;
+  target.textContent = mermaidSource;
+  mermaid.initialize({ startOnLoad: true, theme: "dark" });
+  mermaid.run({ nodes: [target] });
+}
+
+async function loadDashboard() {
+  try {
+    const response = await fetch(`${DATA_PATH}?t=${Date.now()}`);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const payload = await response.json();
+
+    setField("scenario-title", payload.scenario?.title ?? "Meta-Agentic α-AGI Jobs Demo V3");
+    setField("scenario-narrative", payload.scenario?.narrative ?? "");
+    setField("run-id", payload.runId);
+    setField("run-state", payload.state);
+    setField("alpha-readiness", fmtPercent(payload.alphaReadiness));
+    setField("alpha-compounding", fmtPercent(payload.alphaCompoundingIndex));
+    setField("owner-address", payload.owner?.address ?? "—");
+    setField("owner-guardians", fmtList(payload.owner?.guardians ?? []));
+    setField("owner-approvals", String(payload.owner?.approvals_required ?? "—"));
+    setField("owner-pause", payload.owner?.emergency_pause ? "Enabled" : "Disabled");
+    setField("owner-delegation", payload.owner?.can_delegate_parameters ? "Enabled" : "Disabled");
+    setField("owner-charter", payload.owner?.mission_charter ?? "—");
+    setField("treasury-token", payload.treasury?.token ?? "—");
+    setField("treasury-balance", payload.treasury?.initial_balance ?? "—");
+    setField("treasury-max-drawdown", `${payload.treasury?.risk_limits?.max_drawdown_percent ?? "—"}%`);
+    setField("treasury-var", `${payload.treasury?.risk_limits?.var_percent ?? "—"}%`);
+    setField(
+      "treasury-buffer",
+      `${payload.treasury?.risk_limits?.antifragility_buffer_percent ?? "—"}%`
+    );
+    setField(
+      "treasury-circuit",
+      `${payload.treasury?.risk_limits?.circuit_breaker_percent ?? payload.plan?.antifragility?.circuit_breaker_threshold_percent ?? "—"}%`
+    );
+    setField("gasless-bundler", payload.gasless?.bundler ?? "—");
+    setField("gasless-paymaster", payload.gasless?.paymaster ?? "—");
+    setField("hypergraph-state", payload.unstoppable?.hypergraph_state ?? "—");
+    setField("mesh-quorum", String(payload.unstoppable?.multi_agent_mesh?.quorum ?? "—"));
+    setField("mesh-protocol", payload.unstoppable?.multi_agent_mesh?.coordination_protocol ?? "—");
+    setField(
+      "mesh-sentinels",
+      fmtList(payload.unstoppable?.multi_agent_mesh?.sentinel_agents ?? [])
+    );
+    setField("safety-oracle", payload.unstoppable?.safety_net?.antifragility_oracle ?? "—");
+    setField(
+      "halt-conditions",
+      fmtList(payload.unstoppable?.safety_net?.halt_conditions ?? [])
+    );
+
+    populatePhaseTable(payload.phaseScores || []);
+    populateConfirmations(payload.confirmations || []);
+    const logs = Array.isArray(payload.logs) ? payload.logs.join("\n") : payload.logs;
+    setField("run-logs", logs || "No logs available.");
+
+    if (payload.timeline) {
+      renderTimeline(payload.timeline);
+    }
+
+    setLink("summary", payload.links?.summary);
+    setLink("report", payload.links?.report);
+    setLink("dashboard", payload.links?.dashboard);
+  } catch (error) {
+    console.error("Unable to load dashboard data", error);
+  }
+}
+
+window.addEventListener("DOMContentLoaded", loadDashboard);

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/ui/index.html
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/ui/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Meta-Agentic α-AGI Jobs Demo V3 Command Console</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div>
+        <h1 data-field="scenario-title">Meta-Agentic α-AGI Jobs Demo V3</h1>
+        <p class="lead" data-field="scenario-narrative">
+          Command the sovereign alpha fabric: sense, strategise, govern, and execute multi-trillion missions with a single click.
+        </p>
+      </div>
+      <div class="metrics">
+        <div class="metric">
+          <span>Run ID</span>
+          <strong data-field="run-id">—</strong>
+        </div>
+        <div class="metric">
+          <span>State</span>
+          <strong data-field="run-state">—</strong>
+        </div>
+        <div class="metric">
+          <span>Alpha Readiness</span>
+          <strong data-field="alpha-readiness">—</strong>
+        </div>
+        <div class="metric">
+          <span>Compounding Index</span>
+          <strong data-field="alpha-compounding">—</strong>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="grid">
+        <article class="card">
+          <h2>Owner Controls</h2>
+          <dl class="definition-grid">
+            <div><dt>Owner</dt><dd data-field="owner-address">—</dd></div>
+            <div><dt>Guardians</dt><dd data-field="owner-guardians">—</dd></div>
+            <div><dt>Approvals Required</dt><dd data-field="owner-approvals">—</dd></div>
+            <div><dt>Emergency Pause</dt><dd data-field="owner-pause">—</dd></div>
+            <div><dt>Delegation</dt><dd data-field="owner-delegation">—</dd></div>
+            <div><dt>Mission Charter</dt><dd data-field="owner-charter">—</dd></div>
+          </dl>
+          <p class="hint">
+            Adjust parameters instantly:
+            <code>python demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/scripts/owner_controls.py --config meta_agentic_alpha_v3/config/scenario.yaml</code>
+          </p>
+        </article>
+
+        <article class="card">
+          <h2>Treasury & Antifragility</h2>
+          <dl class="definition-grid">
+            <div><dt>Token</dt><dd data-field="treasury-token">—</dd></div>
+            <div><dt>Balance</dt><dd data-field="treasury-balance">—</dd></div>
+            <div><dt>Max Drawdown</dt><dd data-field="treasury-max-drawdown">—</dd></div>
+            <div><dt>VaR</dt><dd data-field="treasury-var">—</dd></div>
+            <div><dt>Antifragility Buffer</dt><dd data-field="treasury-buffer">—</dd></div>
+            <div><dt>Circuit Breaker</dt><dd data-field="treasury-circuit">—</dd></div>
+            <div><dt>Gasless Bundler</dt><dd data-field="gasless-bundler">—</dd></div>
+            <div><dt>Paymaster</dt><dd data-field="gasless-paymaster">—</dd></div>
+          </dl>
+        </article>
+
+        <article class="card">
+          <h2>Unstoppable Mesh</h2>
+          <dl class="definition-grid">
+            <div><dt>Hypergraph State</dt><dd data-field="hypergraph-state">—</dd></div>
+            <div><dt>Quorum</dt><dd data-field="mesh-quorum">—</dd></div>
+            <div><dt>Protocol</dt><dd data-field="mesh-protocol">—</dd></div>
+            <div><dt>Sentinel Agents</dt><dd data-field="mesh-sentinels">—</dd></div>
+            <div><dt>Safety Oracle</dt><dd data-field="safety-oracle">—</dd></div>
+            <div><dt>Halt Conditions</dt><dd data-field="halt-conditions">—</dd></div>
+          </dl>
+        </article>
+      </section>
+
+      <section class="card">
+        <h2>Phase Telemetry</h2>
+        <table class="phase-table">
+          <thead>
+            <tr>
+              <th>Phase</th>
+              <th>State</th>
+              <th>Completion</th>
+              <th>Weight</th>
+              <th>Metric</th>
+            </tr>
+          </thead>
+          <tbody data-phase-table></tbody>
+        </table>
+      </section>
+
+      <section class="card">
+        <h2>Alpha Timeline</h2>
+        <pre class="mermaid" data-field="timeline">gantt
+  dateFormat  X
+  title Awaiting orchestration results
+        </pre>
+      </section>
+
+      <section class="card">
+        <h2>Guardian Confirmations</h2>
+        <ol data-list="confirmations">
+          <li>Awaiting telemetry…</li>
+        </ol>
+      </section>
+
+      <section class="card artefacts">
+        <h2>Execution Artefacts</h2>
+        <ul>
+          <li>
+            <a data-link="summary" href="#" target="_blank" rel="noopener">Summary JSON</a>
+            <span>Canonical ledger for auditors and investors.</span>
+          </li>
+          <li>
+            <a data-link="report" href="#" target="_blank" rel="noopener">Meta Synthesis Deck</a>
+            <span>Auto-generated Mermaid-rich mission report.</span>
+          </li>
+          <li>
+            <a data-link="dashboard" href="#" target="_blank" rel="noopener">Console Source</a>
+            <span>Self-contained assets for redeployment.</span>
+          </li>
+        </ul>
+      </section>
+
+      <section class="card logs">
+        <h2>Run Logs</h2>
+        <details open>
+          <summary>Latest orchestrator events</summary>
+          <pre data-field="run-logs">Awaiting orchestration output…</pre>
+        </details>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        Crafted with <strong>AGI Jobs v0 (v2)</strong>. Meta-agentic autonomy ready for
+        production-scale alpha factories.
+      </p>
+    </footer>
+
+    <script type="module" src="dashboard.js"></script>
+  </body>
+</html>

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/ui/styles.css
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v3/ui/styles.css
@@ -1,0 +1,207 @@
+:root {
+  color-scheme: dark;
+  --bg: #04070f;
+  --card: #0c1424;
+  --border: rgba(255, 255, 255, 0.1);
+  --accent: #6df0ff;
+  --accent-2: #ffe27a;
+  --text: rgba(255, 255, 255, 0.92);
+  --muted: rgba(255, 255, 255, 0.6);
+  --font-display: "Space Grotesk", system-ui, sans-serif;
+  --font-body: "Inter", system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #11233d, var(--bg) 55%);
+  color: var(--text);
+  font-family: var(--font-body);
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.hero {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.hero h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 5vw, 3rem);
+  margin: 0;
+}
+
+.lead {
+  margin-top: 0.75rem;
+  max-width: 640px;
+  font-size: 1.05rem;
+  color: var(--muted);
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.metric {
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: linear-gradient(135deg, rgba(109, 240, 255, 0.16), rgba(255, 255, 255, 0.05));
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.75rem;
+}
+
+.metric strong {
+  display: block;
+  font-size: 1.1rem;
+  margin-top: 0.4rem;
+  color: var(--accent);
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  background: rgba(12, 20, 36, 0.85);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(10px);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+}
+
+.definition-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem 1.25rem;
+  margin: 1rem 0 0;
+}
+
+.definition-grid dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.definition-grid dd {
+  margin: 0.2rem 0 0;
+  font-size: 1rem;
+}
+
+.hint {
+  margin-top: 1.2rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.hint code {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.4rem;
+  display: inline-block;
+}
+
+.phase-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.phase-table th,
+.phase-table td {
+  padding: 0.75rem 0.9rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.phase-table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.phase-table td.state-completed {
+  color: #7ef59a;
+}
+
+.phase-table td.state-running {
+  color: #ffe27a;
+}
+
+.phase-table td.state-failed {
+  color: #ff8b8b;
+}
+
+.phase-table td.state-pending {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.artefacts ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.artefacts a {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.logs pre {
+  max-height: 320px;
+  overflow: auto;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  font-size: 0.85rem;
+}
+
+footer {
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1.5rem 1rem 3rem;
+  }
+  .hero {
+    align-items: flex-start;
+  }
+}

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_demo_v3.py
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_demo_v3.py
@@ -1,0 +1,68 @@
+"""Command-line interface for the Meta-Agentic α-AGI Jobs Demo V3."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _ensure_python_path() -> None:
+    base_dir = Path(__file__).resolve().parent
+    python_dir = base_dir / "python"
+    if python_dir.exists() and str(python_dir) not in sys.path:
+        sys.path.insert(0, str(python_dir))
+    repo_root = base_dir.parent.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+
+_ensure_python_path()
+
+from meta_agentic_alpha_demo.v3 import load_configuration, run_demo  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def _default_config_path() -> Path:
+    return Path(__file__).resolve().parent / "meta_agentic_alpha_v3" / "config" / "scenario.yaml"
+
+
+def run_cli(args: argparse.Namespace) -> int:
+    config_path = Path(args.config).resolve() if args.config else _default_config_path()
+    outcome = run_demo(load_configuration(config_path), timeout=args.timeout)
+    alpha_metrics = outcome.metadata if isinstance(outcome.metadata, dict) else {}
+    payload = {
+        "runId": outcome.run_id,
+        "state": outcome.status.run.state,
+        "alphaReadiness": alpha_metrics.get("alphaReadiness"),
+        "alphaCompoundingIndex": alpha_metrics.get("alphaCompoundingIndex"),
+        "summary": str(outcome.summary_path),
+        "scoreboard": outcome.scoreboard_snapshot,
+        "dashboard": str(outcome.dashboard_path) if outcome.dashboard_path else None,
+        "report": str(outcome.report_path) if outcome.report_path else None,
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Launch the Meta-Agentic α-AGI Jobs Demo V3 orchestration run.")
+    parser.add_argument("--config", help="Path to the V3 scenario YAML configuration file.")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("META_AGENTIC_DEMO_V3_TIMEOUT", "150")),
+        help="Maximum seconds to wait for orchestration completion.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return run_cli(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/python/meta_agentic_alpha_demo/v3/__init__.py
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/python/meta_agentic_alpha_demo/v3/__init__.py
@@ -1,0 +1,11 @@
+"""Meta-Agentic α-AGI Jobs Demo V3 helpers."""
+
+from .configuration import MetaAgenticV3Configuration, load_configuration
+from .engine import MetaAgenticV3Outcome, run_demo
+
+__all__ = [
+    "MetaAgenticV3Configuration",
+    "MetaAgenticV3Outcome",
+    "load_configuration",
+    "run_demo",
+]

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/python/meta_agentic_alpha_demo/v3/configuration.py
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/python/meta_agentic_alpha_demo/v3/configuration.py
@@ -1,0 +1,131 @@
+"""Structured configuration loader for the Meta-Agentic α-AGI Jobs V3 demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from meta_agentic_alpha_demo.v2.configuration import (
+    AgentConfiguration,
+    MetaAgenticV2Configuration,
+    PhaseDefinition,
+    PlanSettings,
+    ScenarioMetadata,
+    load_configuration as load_v2_configuration,
+)
+
+
+@dataclass(frozen=True)
+class MissionProfile:
+    """High-level mission directives that guide compounding alpha."""
+
+    alpha_goal: str
+    ica_score_target: float
+    antifragility_focus: str
+    sovereign_controls: Mapping[str, Any]
+    opportunity_domains: Sequence[str]
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> "MissionProfile":
+        alpha_goal = str(payload.get("alpha_goal", "compound-alpha"))
+        ica_score_target = float(payload.get("ica_score_target", 0.0))
+        antifragility_focus = str(payload.get("antifragility_focus", "antifragility"))
+        sovereign_controls = dict(payload.get("sovereign_controls", {}))
+        opportunity_domains = tuple(str(entry) for entry in payload.get("opportunity_domains", []) or [])
+        return cls(
+            alpha_goal=alpha_goal,
+            ica_score_target=ica_score_target,
+            antifragility_focus=antifragility_focus,
+            sovereign_controls=sovereign_controls,
+            opportunity_domains=opportunity_domains,
+        )
+
+
+@dataclass(frozen=True)
+class MetaAgenticV3Configuration:
+    """Aggregated view of the V3 scenario YAML."""
+
+    base: MetaAgenticV2Configuration
+    mission: MissionProfile
+    unstoppable: Mapping[str, Any]
+
+    @property
+    def path(self) -> Path:  # pragma: no cover - passthrough
+        return self.base.path
+
+    @property
+    def payload(self) -> Mapping[str, Any]:  # pragma: no cover - passthrough
+        return self.base.payload
+
+    @property
+    def scenario(self) -> ScenarioMetadata:
+        return self.base.scenario
+
+    @property
+    def agents(self) -> Sequence[AgentConfiguration]:  # pragma: no cover - passthrough
+        return self.base.agents
+
+    @property
+    def phases(self) -> Sequence[PhaseDefinition]:  # pragma: no cover - passthrough
+        return self.base.phases
+
+    @property
+    def plan(self) -> PlanSettings:  # pragma: no cover - passthrough
+        return self.base.plan
+
+    @property
+    def base_dir(self) -> Path:
+        return self.base.base_dir
+
+    @property
+    def attachments(self) -> Sequence[str]:
+        return tuple(self.base.attachments)
+
+    @property
+    def dashboards(self) -> Sequence[Mapping[str, Any]]:  # pragma: no cover - passthrough
+        return self.base.dashboards
+
+    @property
+    def owner(self) -> Mapping[str, Any]:  # pragma: no cover - passthrough
+        return self.base.owner
+
+    @property
+    def treasury(self) -> Mapping[str, Any]:  # pragma: no cover - passthrough
+        return self.base.treasury
+
+    @property
+    def gasless(self) -> Mapping[str, Any]:  # pragma: no cover - passthrough
+        return self.base.gasless
+
+    @property
+    def approvals(self) -> Sequence[str]:  # pragma: no cover - passthrough
+        return self.base.approvals
+
+    @property
+    def confirmations(self) -> Sequence[str]:  # pragma: no cover - passthrough
+        return self.base.confirmations
+
+    def phase_map(self) -> Mapping[str, PhaseDefinition]:  # pragma: no cover - passthrough
+        return self.base.phase_map()
+
+
+def load_configuration(path: str | Path) -> MetaAgenticV3Configuration:
+    """Load and enrich the scenario configuration for the V3 demo."""
+
+    base = load_v2_configuration(path)
+    payload = base.payload
+    mission = MissionProfile.from_mapping(payload.get("mission", {}))
+    unstoppable = dict(payload.get("unstoppable", {}))
+    return MetaAgenticV3Configuration(base=base, mission=mission, unstoppable=unstoppable)
+
+
+__all__ = [
+    "AgentConfiguration",
+    "MetaAgenticV3Configuration",
+    "MissionProfile",
+    "PhaseDefinition",
+    "PlanSettings",
+    "ScenarioMetadata",
+    "load_configuration",
+]

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/python/meta_agentic_alpha_demo/v3/engine.py
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/python/meta_agentic_alpha_demo/v3/engine.py
@@ -1,0 +1,529 @@
+"""Execution harness for the Meta-Agentic α-AGI Jobs Demo V3."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Sequence
+
+import shutil
+from textwrap import dedent
+
+from orchestrator.agents import AgentRegistryError, get_registry
+from orchestrator.models import (
+    AgentCapability,
+    AgentRegistrationIn,
+    AgentSecurityControls,
+    AgentStake,
+    Attachment,
+    JobIntent,
+    OrchestrationPlan,
+    Step,
+)
+
+from .configuration import MetaAgenticV3Configuration, MissionProfile
+
+
+_CAPABILITY_MAP: Mapping[str, AgentCapability] = {
+    "execution": AgentCapability.EXECUTION,
+    "validation": AgentCapability.VALIDATION,
+    "analysis": AgentCapability.ANALYSIS,
+    "analytics": AgentCapability.ANALYSIS,
+    "strategy": AgentCapability.ANALYSIS,
+    "oversight": AgentCapability.SUPPORT,
+    "support": AgentCapability.SUPPORT,
+    "router": AgentCapability.ROUTER,
+}
+
+
+@dataclass
+class PhaseScore:
+    """Runtime evaluation of a scenario phase."""
+
+    phase_id: str
+    label: str
+    weight: float
+    success_metric: str
+    state: str
+    completion: float
+
+
+@dataclass
+class MetaAgenticV3Outcome:
+    """Aggregate artefacts emitted by :func:`run_demo`."""
+
+    run_id: str
+    plan: OrchestrationPlan
+    status: Any
+    summary_path: Path
+    phase_scores: Sequence[PhaseScore]
+    scoreboard_snapshot: Mapping[str, Any]
+    dashboard_path: Path | None = None
+    report_path: Path | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+def _ensure_environment(base_dir: Path) -> Dict[str, Path]:
+    storage_root = base_dir / "storage" / "orchestrator_v3"
+    storage_root.mkdir(parents=True, exist_ok=True)
+    (storage_root / "agents").mkdir(parents=True, exist_ok=True)
+    (storage_root / "runs").mkdir(parents=True, exist_ok=True)
+    (base_dir / "reports").mkdir(parents=True, exist_ok=True)
+    (base_dir / "storage" / "ui" / "v3").mkdir(parents=True, exist_ok=True)
+
+    defaults = {
+        "ORCHESTRATOR_BRIDGE_MODE": "python",
+        "ORCHESTRATOR_SCOREBOARD_PATH": storage_root / "scoreboard.json",
+        "ORCHESTRATOR_CHECKPOINT_PATH": storage_root / "checkpoint.json",
+        "ORCHESTRATOR_CHECKPOINT_LEVELDB": storage_root / "checkpoint.db",
+        "ORCHESTRATOR_GOVERNANCE_PATH": storage_root / "governance.json",
+        "ORCHESTRATOR_STATE_DIR": storage_root / "runs",
+        "AGENT_REGISTRY_PATH": storage_root / "agents" / "registry.json",
+    }
+
+    for key, value in defaults.items():
+        os.environ.setdefault(key, str(value))
+
+    paths = {key: Path(str(value)) for key, value in defaults.items()}
+    scoreboard_path = paths["ORCHESTRATOR_SCOREBOARD_PATH"]
+    scoreboard_path.parent.mkdir(parents=True, exist_ok=True)
+    scoreboard_path.touch(exist_ok=True)
+    return paths
+
+
+def _map_capabilities(entries: Iterable[str]) -> List[AgentCapability]:
+    capabilities: List[AgentCapability] = []
+    for entry in entries:
+        capability = _CAPABILITY_MAP.get(entry.lower())
+        if capability:
+            capabilities.append(capability)
+    if not capabilities:
+        capabilities.append(AgentCapability.EXECUTION)
+    return capabilities
+
+
+def _register_agents(config: MetaAgenticV3Configuration) -> List[str]:
+    registry = get_registry()
+    onboarded: List[str] = []
+    existing = {agent.agent_id for agent in registry.list().agents}
+    for agent_cfg in config.agents:
+        payload = dict(agent_cfg.payload)
+        agent_id = agent_cfg.agent_id
+        if agent_id in existing:
+            onboarded.append(agent_id)
+            continue
+        stake_amount = Decimal(str(payload.get("stake_amount", "0")))
+        registration = AgentRegistrationIn(
+            agent_id=agent_id,
+            owner=str(payload.get("owner", "Meta-Agentic Demo Owner")),
+            region=str(payload.get("region", "global")),
+            capabilities=_map_capabilities(payload.get("capabilities", []) or []),
+            stake=AgentStake(amount=stake_amount, slashable=bool(payload.get("slashable", True))),
+            security=AgentSecurityControls(
+                requires_kyc=bool(payload.get("requires_kyc", False)),
+                multisig=bool(payload.get("multisig", True)),
+                notes=str(payload.get("notes", "Meta-Agentic V3 demo auto-registration")),
+            ),
+            router=None,
+            operator_secret=str(payload.get("operator_secret", f"{agent_id}-secret")),
+        )
+        try:
+            registry.register(registration)
+            onboarded.append(agent_id)
+        except AgentRegistryError as exc:  # pragma: no cover - extremely unlikely in CI
+            raise RuntimeError(f"Unable to register demo agent `{agent_id}`: {exc}") from exc
+    return onboarded
+
+
+def _build_attachments(config: MetaAgenticV3Configuration) -> List[Attachment]:
+    attachments: List[Attachment] = []
+    for resource in config.attachments:
+        path = Path(resource)
+        attachments.append(Attachment(name=path.name, cid=None, size=None))
+    return attachments
+
+
+def _build_plan(config: MetaAgenticV3Configuration, attachments: Sequence[Attachment]) -> OrchestrationPlan:
+    intent = JobIntent(
+        kind="custom",
+        title=config.scenario.title,
+        description=config.scenario.narrative,
+        attachments=list(attachments),
+    )
+
+    phase_meta: List[Mapping[str, Any]] = []
+    steps: List[Step] = []
+    for phase in config.phases:
+        step_payload: MutableMapping[str, Any] = dict(phase.step_payload)
+        step_payload.setdefault("id", phase.identifier)
+        step_payload.setdefault("name", phase.label)
+        step_payload.setdefault("kind", "plan")
+        metadata = {
+            "phase": phase.identifier,
+            "label": phase.label,
+            "weight": phase.weight,
+            "success_metric": phase.success_metric,
+        }
+        phase_meta.append(metadata)
+        step = Step.model_validate(step_payload)
+        steps.append(step)
+
+    plan = OrchestrationPlan.from_intent(
+        intent,
+        steps=steps,
+        budget_max=str(config.plan.budget.get("max", "0")),
+    )
+    plan.metadata.update(
+        {
+            "scenario": {
+                "id": config.scenario.identifier,
+                "title": config.scenario.title,
+                "owner": config.owner,
+                "treasury": config.treasury,
+                "gasless": config.gasless,
+            },
+            "mission": {
+                "alpha_goal": config.mission.alpha_goal,
+                "ica_target": config.mission.ica_score_target,
+                "antifragility_focus": config.mission.antifragility_focus,
+                "opportunity_domains": list(config.mission.opportunity_domains),
+            },
+            "unstoppable": config.unstoppable,
+            "phases": phase_meta,
+            "approvals": list(config.approvals),
+            "confirmations": list(config.confirmations),
+            "generatedAt": time.time(),
+        }
+    )
+    if config.plan.antifragility:
+        plan.metadata["antifragility"] = dict(config.plan.antifragility)
+    return plan
+
+
+def _phase_scores(config: MetaAgenticV3Configuration, status: Any) -> List[PhaseScore]:
+    state_by_id = {step.id: step.state for step in status.steps}
+    scores: List[PhaseScore] = []
+    for phase in config.phases:
+        state = state_by_id.get(phase.identifier, "pending")
+        if state == "completed":
+            ratio = 1.0
+        elif state == "failed":
+            ratio = 0.0
+        elif state == "running":
+            ratio = 0.75
+        else:
+            ratio = 0.25
+        scores.append(
+            PhaseScore(
+                phase_id=phase.identifier,
+                label=phase.label,
+                weight=phase.weight,
+                success_metric=phase.success_metric,
+                state=state,
+                completion=ratio,
+            )
+        )
+    return scores
+
+
+def _alpha_readiness(scores: Sequence[PhaseScore]) -> float:
+    total_weight = sum(score.weight for score in scores) or 1.0
+    weighted = sum(score.weight * score.completion for score in scores)
+    readiness = min(0.999, max(0.0, weighted / total_weight))
+    return readiness
+
+
+def _alpha_compounding_index(scores: Sequence[PhaseScore], mission: MissionProfile) -> float:
+    readiness = _alpha_readiness(scores)
+    mission_factor = min(1.0, max(0.0, mission.ica_score_target))
+    antifragility_bias = 0.05 if "antifragility" in mission.antifragility_focus.lower() else 0.0
+    return min(0.999, readiness * 0.7 + mission_factor * 0.25 + antifragility_bias)
+
+
+def _render_phase_table(phase_scores: Sequence[PhaseScore]) -> str:
+    rows = ["| Phase | State | Completion | Weight | Metric |", "|-------|-------|------------|--------|--------|"]
+    for score in phase_scores:
+        rows.append(
+            f"| {score.label} | {score.state.title()} | {score.completion:.0%} | {score.weight:.2f} | {score.success_metric} |"
+        )
+    return "\n".join(rows)
+
+
+def _render_mermaid_timeline(phase_scores: Sequence[PhaseScore]) -> str:
+    lines = ["gantt", "    dateFormat  X", "    title Meta-Agentic α-AGI Jobs V3 Execution"]
+    for index, score in enumerate(phase_scores, start=1):
+        status = "done" if score.state == "completed" else "crit" if score.state == "failed" else "active"
+        lines.append(f"    section {score.label}")
+        lines.append(f"    {score.success_metric} :{status}, {score.phase_id}, {index}, {max(1, int(score.weight))}")
+    return "\n".join(lines)
+
+
+def _render_mermaid_operating_system(config: MetaAgenticV3Configuration) -> str:
+    sentinels = config.unstoppable.get("multi_agent_mesh", {}).get("sentinel_agents", [])
+    guardian_nodes = "\n            ".join(sentinels) if sentinels else "Guardian"
+    return dedent(
+        f"""
+        graph TD
+          Owner --> Planner
+          Planner --> Identify
+          Planner --> Learn
+          Planner --> Think
+          Planner --> Design
+          Planner --> Strategise
+          Planner --> Govern
+          Planner --> Execute
+          Execute --> Treasury
+          Treasury --> Feedback
+          Feedback --> Planner
+          subgraph GuardianQuorum
+            {guardian_nodes}
+          end
+          Govern --> GuardianQuorum
+        """
+    ).strip()
+
+
+def _build_summary_payload(
+    config: MetaAgenticV3Configuration,
+    status: Any,
+    plan: OrchestrationPlan,
+    phase_scores: Sequence[PhaseScore],
+    onboarded_agents: Sequence[str],
+) -> Dict[str, Any]:
+    from orchestrator.scoreboard import get_scoreboard
+
+    alpha_readiness = _alpha_readiness(phase_scores)
+    alpha_compounding = _alpha_compounding_index(phase_scores, config.mission)
+    scoreboard_snapshot = get_scoreboard().snapshot()
+    timeline = _render_mermaid_timeline(phase_scores)
+    operating_system = _render_mermaid_operating_system(config)
+
+    payload: Dict[str, Any] = {
+        "runId": status.run.id,
+        "state": status.run.state,
+        "alphaReadiness": alpha_readiness,
+        "alphaCompoundingIndex": alpha_compounding,
+        "phaseScores": [
+            {
+                "phase": score.phase_id,
+                "label": score.label,
+                "state": score.state,
+                "weight": score.weight,
+                "metric": score.success_metric,
+                "completion": score.completion,
+            }
+            for score in phase_scores
+        ],
+        "approvals": list(config.approvals),
+        "confirmations": list(config.confirmations),
+        "owner": config.owner,
+        "treasury": config.treasury,
+        "gasless": config.gasless,
+        "mission": {
+            "alpha_goal": config.mission.alpha_goal,
+            "ica_score_target": config.mission.ica_score_target,
+            "antifragility_focus": config.mission.antifragility_focus,
+            "opportunity_domains": list(config.mission.opportunity_domains),
+        },
+        "unstoppable": config.unstoppable,
+        "agents": list(onboarded_agents),
+        "scoreboard": scoreboard_snapshot,
+        "steps": [step.model_dump(mode="json") for step in plan.steps],
+        "logs": status.logs,
+        "timeline": timeline,
+        "operatingSystem": operating_system,
+    }
+    payload["scenario"] = {
+        "id": config.scenario.identifier,
+        "title": config.scenario.title,
+        "narrative": config.scenario.narrative,
+    }
+    payload["plan"] = {
+        "approvals": list(config.approvals),
+        "budget": config.plan.budget,
+        "antifragility": config.plan.antifragility,
+    }
+    return payload
+
+
+def _write_summary(config: MetaAgenticV3Configuration, payload: Mapping[str, Any]) -> Path:
+    summary_path = config.base_dir / "storage" / "latest_run_v3.json"
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return summary_path
+
+
+def _sync_console_assets(config: MetaAgenticV3Configuration) -> Path:
+    source_dir = config.base_dir / "meta_agentic_alpha_v3" / "ui"
+    destination_dir = config.base_dir / "storage" / "ui" / "v3"
+    destination_dir.mkdir(parents=True, exist_ok=True)
+
+    for existing in destination_dir.glob("*"):
+        if existing.is_file():
+            existing.unlink()
+        elif existing.is_dir():
+            shutil.rmtree(existing)
+
+    for entry in source_dir.glob("**/*"):
+        if entry.is_dir():
+            continue
+        relative = entry.relative_to(source_dir)
+        target = destination_dir / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(entry, target)
+
+    return destination_dir / "index.html"
+
+
+def _write_dashboard_data(config: MetaAgenticV3Configuration, payload: Mapping[str, Any]) -> Path:
+    dashboard_path = config.base_dir / "storage" / "ui" / "v3" / "dashboard-data.json"
+    dashboard_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return dashboard_path
+
+
+def _write_meta_report(
+    config: MetaAgenticV3Configuration,
+    payload: Mapping[str, Any],
+    phase_scores: Sequence[PhaseScore],
+) -> Path:
+    report_dir = config.base_dir / "meta_agentic_alpha_v3" / "reports" / "generated"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / "meta_synthesis.md"
+
+    owner = config.owner
+    guardians = ", ".join(owner.get("guardians", [])) or "—"
+    treasury = config.treasury
+    gasless = config.gasless
+    phase_table = _render_phase_table(phase_scores)
+    mermaid_timeline = payload.get("timeline", "")
+    operating_system = payload.get("operatingSystem", "")
+
+    content = dedent(
+        f"""
+        # Meta-Agentic α-AGI Jobs Demo V3 — Live Mission Synthesis
+
+        ## Governance Posture
+
+        - **Owner:** {owner.get("address", "n/a")}
+        - **Guardians:** {guardians}
+        - **Approvals Required:** {owner.get("approvals_required", "n/a")}
+        - **Emergency Pause:** {"Enabled" if owner.get("emergency_pause") else "Disabled"}
+        - **Delegation:** {"Enabled" if owner.get("can_delegate_parameters") else "Disabled"}
+
+        ## Treasury & Antifragility
+
+        - **Token:** {treasury.get("token", "AGIALPHA")}
+        - **Initial Balance:** {treasury.get("initial_balance", "n/a")}
+        - **Risk Limits:** Max drawdown {treasury.get("risk_limits", {}).get("max_drawdown_percent", "?")}%,
+          VaR {treasury.get("risk_limits", {}).get("var_percent", "?")}%,
+          Antifragility buffer {treasury.get("risk_limits", {}).get("antifragility_buffer_percent", "?")}%,
+          Circuit breaker {treasury.get("risk_limits", {}).get("circuit_breaker_percent", "?")}%
+        - **Gasless Bundler:** {gasless.get("bundler", "n/a")}
+        - **Paymaster:** {gasless.get("paymaster", "n/a")}
+
+        ## Alpha Readiness
+
+        - **Run ID:** {payload.get("runId")}
+        - **State:** {payload.get("state")}
+        - **Alpha Readiness Score:** {payload.get("alphaReadiness"):.2%}
+        - **Compounding Index:** {payload.get("alphaCompoundingIndex"):.2%}
+        - **Participating Agents:** {", ".join(payload.get("agents", [])) or "—"}
+
+        ## Phase Telemetry
+
+        {phase_table}
+
+        ```mermaid
+        {mermaid_timeline}
+        ```
+
+        ## Operating System View
+
+        ```mermaid
+        {operating_system}
+        ```
+
+        ## Pending Confirmations
+
+        {os.linesep.join(f"- {confirmation}" for confirmation in payload.get('confirmations', [])) or "- None"}
+
+        ## Execution Steps
+
+        ```json
+        {json.dumps(payload.get("steps", []), ensure_ascii=False, indent=2)}
+        ```
+        """
+    ).strip()
+
+    report_path.write_text(content, encoding="utf-8")
+    return report_path
+
+
+def run_demo(config: MetaAgenticV3Configuration, *, timeout: float = 150.0) -> MetaAgenticV3Outcome:
+    """Execute the Meta-Agentic V3 demo end-to-end."""
+
+    _ensure_environment(config.base_dir)
+    attachments = _build_attachments(config)
+    onboarded_agents = _register_agents(config)
+    plan = _build_plan(config, attachments)
+
+    from orchestrator.runner import start_run
+
+    run_info = start_run(plan, approvals=list(config.approvals))
+
+    from orchestrator.runner import get_status
+
+    deadline = time.time() + timeout
+    status = get_status(run_info.id)
+    while status.run.state not in {"succeeded", "failed"}:
+        if time.time() > deadline:
+            raise TimeoutError(f"Run {run_info.id} did not complete within {timeout} seconds")
+        time.sleep(0.25)
+        status = get_status(run_info.id)
+
+    scores = _phase_scores(config, status)
+    summary_payload = _build_summary_payload(config, status, plan, scores, onboarded_agents)
+    dashboard_entry_path = _sync_console_assets(config)
+    report_path = _write_meta_report(config, summary_payload, scores)
+    summary_payload["links"] = {
+        "summary": str((config.base_dir / "storage" / "latest_run_v3.json").relative_to(config.base_dir)),
+        "report": str(report_path.relative_to(config.base_dir)),
+        "dashboard": str(dashboard_entry_path.relative_to(config.base_dir)),
+    }
+    summary_payload["__reportPath"] = summary_payload["links"]["report"]
+    summary_payload["__dashboardPath"] = summary_payload["links"]["dashboard"]
+    summary_payload["__sourceSummaryPath"] = "storage/latest_run_v3.json"
+    summary_path = _write_summary(config, summary_payload)
+    dashboard_data_path = _write_dashboard_data(config, summary_payload)
+
+    from orchestrator.scoreboard import get_scoreboard
+
+    outcome = MetaAgenticV3Outcome(
+        run_id=run_info.id,
+        plan=plan,
+        status=status,
+        summary_path=summary_path,
+        phase_scores=tuple(scores),
+        scoreboard_snapshot=get_scoreboard().snapshot(),
+        dashboard_path=dashboard_entry_path,
+        report_path=report_path,
+        metadata={
+            "attachments": [attachment.model_dump() for attachment in attachments],
+            "onboarded_agents": list(onboarded_agents),
+            "dashboardDataPath": str(dashboard_data_path),
+            "alphaReadiness": summary_payload.get("alphaReadiness"),
+            "alphaCompoundingIndex": summary_payload.get("alphaCompoundingIndex"),
+        },
+    )
+    return outcome
+
+
+__all__ = [
+    "MetaAgenticV3Outcome",
+    "PhaseScore",
+    "run_demo",
+]

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/tests/test_meta_agentic_alpha_v3.py
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/tests/test_meta_agentic_alpha_v3.py
@@ -1,0 +1,104 @@
+"""Regression tests for the Meta-Agentic α-AGI Jobs Demo V3."""
+
+from __future__ import annotations
+
+import json
+import sys
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+
+def _ensure_paths() -> None:
+    tests_dir = Path(__file__).resolve().parent
+    demo_root = tests_dir.parent
+    python_dir = demo_root / "python"
+    scripts_dir = demo_root / "scripts"
+    repo_root = demo_root.parent.parent
+    for candidate in (python_dir, repo_root, scripts_dir):
+        if str(candidate) not in sys.path:
+            sys.path.insert(0, str(candidate))
+
+
+_ensure_paths()
+
+from meta_agentic_alpha_demo.v3 import load_configuration, run_demo  # noqa: E402  pylint: disable=wrong-import-position
+
+owner_controls = import_module("owner_controls")
+
+
+@pytest.fixture()
+def v3_config_path() -> Path:
+    return (
+        Path(__file__)
+        .resolve()
+        .parent
+        .parent
+        / "meta_agentic_alpha_v3"
+        / "config"
+        / "scenario.yaml"
+    )
+
+
+def test_load_configuration_v3_shape(v3_config_path: Path) -> None:
+    config = load_configuration(v3_config_path)
+    assert config.scenario.title.startswith("Meta-Agentic α-AGI Jobs Demo")
+    assert config.mission.alpha_goal == "compound-global-alpha"
+    halt_conditions = config.unstoppable.get("safety_net", {}).get("halt_conditions", [])
+    assert any("guardian" in condition for condition in halt_conditions)
+    assert len(config.phases) >= 7
+    assert {phase.identifier for phase in config.phases} >= {
+        "identify",
+        "learn",
+        "think",
+        "design",
+        "strategise",
+        "govern",
+        "execute-onchain",
+        "feedback",
+    }
+    assert "meta_mission_deck.md" in next(iter(config.attachments))
+
+
+def test_run_demo_v3_creates_summary(tmp_path: Path, v3_config_path: Path) -> None:
+    config = load_configuration(v3_config_path)
+    outcome = run_demo(config, timeout=40)
+    summary_path = Path(outcome.summary_path)
+    assert summary_path.exists()
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert payload["state"] in {"succeeded", "failed"}
+    assert 0.0 <= float(payload["alphaReadiness"]) <= 1.0
+    assert 0.0 <= float(payload["alphaCompoundingIndex"]) <= 1.0
+    assert len(payload["phaseScores"]) == len(config.phases)
+    assert payload["mission"]["alpha_goal"] == config.mission.alpha_goal
+    assert payload["unstoppable"]["multi_agent_mesh"]["quorum"] == 7
+    assert Path(outcome.report_path).exists()
+    assert Path(outcome.dashboard_path).exists()
+    assert Path(outcome.metadata["dashboardDataPath"]).exists()
+
+
+def test_owner_controls_v3_updates(tmp_path: Path, v3_config_path: Path) -> None:
+    payload = owner_controls.load_yaml(v3_config_path)
+    owner_controls.apply_assignment(payload, "plan.budget.max", 1200000)
+    owner_controls.apply_assignment(
+        payload,
+        "phases[execute-onchain].step.params.job.reward",
+        333000,
+    )
+    owner_controls.apply_assignment(
+        payload,
+        "mission.ica_score_target",
+        0.97,
+    )
+    rendered = owner_controls.dump_yaml(payload)
+    assert "max: 1200000" in rendered
+    assert "reward: 333000" in rendered
+    assert "ica_score_target: 0.97" in rendered
+    assert owner_controls.main(
+        [
+            "--config",
+            str(v3_config_path),
+            "--show",
+        ]
+    ) == 0


### PR DESCRIPTION
## Summary
- add the Meta-Agentic α-AGI Jobs Demo V3 assets including scenario configuration, documentation, UI, and CLI entrypoint so non-technical owners can launch the meta-sovereign alpha fabric
- implement a new orchestration engine that extends the v2 harness with mission telemetry, compounding metrics, unstoppable mesh insights, and generated reports/dashboards, and wire the workflow to execute the V3 run
- add regression tests and update documentation to cover the new mission controls and CI expectations

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/tests -q
- python demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_demo_v3.py --timeout 60
- python -m compileall demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/python/meta_agentic_alpha_demo/v3


------
https://chatgpt.com/codex/tasks/task_e_6900f2bc73c4833394d42d0103d15e9f