### PR TITLE
Enhance Economic Power command coverage reporting

### DIFF
--- a/demo/Economic-Power-v0/README.md
+++ b/demo/Economic-Power-v0/README.md
@@ -29,6 +29,7 @@ Outputs land in `demo/Economic-Power-v0/reports/`:
 - `deployment-map.json` – mainnet-ready custody catalogue listing each v2 module, owner, upgrade command, and audit freshness.
 - `owner-command.mmd` – owner command mermaid graph linking pause/resume authority, parameter scripts, and module custody.
 - `owner-command-plan.md` – markdown playbook summarising quick actions, scripted upgrades, circuit breakers, and capital checkpoints in plain language.
+- `owner-command-checklist.json` – machine-auditable coverage ledger detailing per-surface command coverage percentages for jobs, validators, adapters, modules, treasury, pause/resume, and orchestrator surfaces.
 - `owner-governance-ledger.json` – deterministic custody ledger detailing module ownership, audit freshness, scripts, and alertable coverage gaps for governance dashboards.
 - `treasury-trajectory.json` – treasury state, yield, validator confidence, and automation lift captured after each job.
 - `assertions.json` – machine-readable verification ledger covering owner dominance, custody, validator strength, and treasury solvency.
@@ -103,6 +104,7 @@ The UI inside `demo/Economic-Power-v0/ui/` offers:
 - Metric cards covering ROI, net yield, validator confidence, throughput, and treasury position.
 - Economic power verification grid surfacing every assertion outcome, severity badge, and supporting evidence.
 - Expanded metrics for **Stability Index** and **Owner Command Coverage** quantifying how completely the multi-sig governs the stack.
+- Command coverage detail table translating `owner-command-checklist.json` into per-surface readiness so non-technical operators can see exactly which levers are scripted.
 - Sovereign control gauge mirroring the custody score produced in CI alongside a live on-chain module inventory.
 - Interactive job-to-agent tables to inspect assignments and validator stakes.
 - Capital trajectory tracker visualising treasury strength, validator confidence, and automation lift after every job.

--- a/demo/Economic-Power-v0/reports/baseline-summary.json
+++ b/demo/Economic-Power-v0/reports/baseline-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T15:43:12.044Z",
+  "executionTimestamp": "2025-10-28T16:59:49.680Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -632,7 +632,18 @@
       }
     ],
     "commandCoverage": 1,
-    "coverageNarrative": "Owner multi-sig holds deterministic runbooks for every critical surface."
+    "coverageNarrative": "Owner multi-sig holds deterministic runbooks for every critical surface.",
+    "coverageDetail": {
+      "jobs": 1,
+      "validators": 1,
+      "stablecoinAdapters": 1,
+      "modules": 1,
+      "parameters": 1,
+      "pause": 1,
+      "resume": 1,
+      "treasury": 1,
+      "orchestrator": 1
+    }
   },
   "assertions": [
     {

--- a/demo/Economic-Power-v0/reports/owner-command-checklist.json
+++ b/demo/Economic-Power-v0/reports/owner-command-checklist.json
@@ -1,0 +1,16 @@
+{
+  "generatedAt": "2025-02-01T00:00:00.000Z",
+  "coverage": 1,
+  "coverageNarrative": "Owner multi-sig holds deterministic runbooks for every critical surface.",
+  "surfaces": {
+    "jobs": 1,
+    "validators": 1,
+    "stablecoinAdapters": 1,
+    "modules": 1,
+    "parameters": 1,
+    "pause": 1,
+    "resume": 1,
+    "treasury": 1,
+    "orchestrator": 1
+  }
+}

--- a/demo/Economic-Power-v0/reports/owner-command-plan.md
+++ b/demo/Economic-Power-v0/reports/owner-command-plan.md
@@ -1,8 +1,20 @@
 # Owner Command Playbook
 
-Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/28/2025, 3:43:28 PM (UTC)
+Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/28/2025, 5:00:29 PM (UTC)
 
 Command coverage: 100.0% — Owner multi-sig holds deterministic runbooks for every critical surface.
+
+## Coverage detail
+
+- Job programs: 100.0% coverage
+- Validator programs: 100.0% coverage
+- Stablecoin adapters: 100.0% coverage
+- Protocol modules: 100.0% coverage
+- Parameter overrides: 100.0% coverage
+- Emergency pause: 100.0% coverage
+- Resume procedure: 100.0% coverage
+- Treasury playbooks: 100.0% coverage
+- Orchestrator mesh: 100.0% coverage
 
 ## Quick actions
 

--- a/demo/Economic-Power-v0/reports/summary.json
+++ b/demo/Economic-Power-v0/reports/summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T15:43:28.396Z",
+  "executionTimestamp": "2025-10-28T17:00:29.486Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -632,7 +632,18 @@
       }
     ],
     "commandCoverage": 1,
-    "coverageNarrative": "Owner multi-sig holds deterministic runbooks for every critical surface."
+    "coverageNarrative": "Owner multi-sig holds deterministic runbooks for every critical surface.",
+    "coverageDetail": {
+      "jobs": 1,
+      "validators": 1,
+      "stablecoinAdapters": 1,
+      "modules": 1,
+      "parameters": 1,
+      "pause": 1,
+      "resume": 1,
+      "treasury": 1,
+      "orchestrator": 1
+    }
   },
   "assertions": [
     {

--- a/demo/Economic-Power-v0/test/economic_power_demo.test.ts
+++ b/demo/Economic-Power-v0/test/economic_power_demo.test.ts
@@ -22,6 +22,27 @@ test('economic power simulation produces deterministic metrics', async () => {
     1,
     'Owner command coverage should confirm total command supremacy',
   );
+  const coverageDetail = summary.ownerCommandPlan.coverageDetail;
+  assert(coverageDetail, 'Coverage detail should be present');
+  const coverageSurfaces = [
+    'jobs',
+    'validators',
+    'stablecoinAdapters',
+    'modules',
+    'parameters',
+    'pause',
+    'resume',
+    'treasury',
+    'orchestrator',
+  ];
+  for (const surface of coverageSurfaces) {
+    assert(surface in coverageDetail, `Coverage detail should include ${surface}`);
+    assert.equal(
+      coverageDetail[surface as keyof typeof coverageDetail],
+      1,
+      `Coverage for ${surface} should be complete`,
+    );
+  }
   assert(summary.metrics.sovereignControlScore >= 0.9, 'Sovereign control score should confirm custody');
   assert.equal(
     summary.metrics.assertionPassRate,

--- a/demo/Economic-Power-v0/ui/data/default-summary.json
+++ b/demo/Economic-Power-v0/ui/data/default-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T15:43:00.875Z",
+  "executionTimestamp": "2025-10-28T16:59:49.680Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -632,7 +632,18 @@
       }
     ],
     "commandCoverage": 1,
-    "coverageNarrative": "Owner multi-sig holds deterministic runbooks for every critical surface."
+    "coverageNarrative": "Owner multi-sig holds deterministic runbooks for every critical surface.",
+    "coverageDetail": {
+      "jobs": 1,
+      "validators": 1,
+      "stablecoinAdapters": 1,
+      "modules": 1,
+      "parameters": 1,
+      "pause": 1,
+      "resume": 1,
+      "treasury": 1,
+      "orchestrator": 1
+    }
   },
   "assertions": [
     {

--- a/demo/Economic-Power-v0/ui/index.html
+++ b/demo/Economic-Power-v0/ui/index.html
@@ -165,6 +165,17 @@
               <span id="coverage-percent"></span>
             </p>
             <p id="coverage-narrative" class="narrative"></p>
+            <div class="table-wrapper">
+              <table id="coverage-table" aria-label="Command coverage detail">
+                <thead>
+                  <tr>
+                    <th>Surface</th>
+                    <th>Coverage</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
             <h4>Emergency contacts</h4>
             <ul id="emergency-contacts"></ul>
           </article>

--- a/demo/Economic-Power-v0/ui/script.js
+++ b/demo/Economic-Power-v0/ui/script.js
@@ -189,6 +189,33 @@ function renderSovereignty(summary) {
     coverageNarrative.textContent = summary.ownerCommandPlan.coverageNarrative;
   }
 
+  const coverageTable = document.querySelector('#coverage-table tbody');
+  if (coverageTable) {
+    coverageTable.innerHTML = '';
+    const detail = summary.ownerCommandPlan.coverageDetail || {};
+    const labelMap = {
+      jobs: 'Job programs',
+      validators: 'Validator programs',
+      stablecoinAdapters: 'Stablecoin adapters',
+      modules: 'Protocol modules',
+      parameters: 'Parameter overrides',
+      pause: 'Emergency pause',
+      resume: 'Resume procedure',
+      treasury: 'Treasury playbooks',
+      orchestrator: 'Orchestrator mesh',
+    };
+    for (const [surface, ratio] of Object.entries(detail)) {
+      const row = document.createElement('tr');
+      const label = labelMap[surface] || surface;
+      const percent = typeof ratio === 'number' ? (ratio * 100).toFixed(1) : '—';
+      row.innerHTML = `
+        <td>${label}</td>
+        <td>${percent}%</td>
+      `;
+      coverageTable.append(row);
+    }
+  }
+
   const emergencyList = document.getElementById('emergency-contacts');
   emergencyList.innerHTML = '';
   for (const contact of summary.ownerSovereignty.emergencyContacts) {
@@ -502,6 +529,7 @@ async function bootstrap(dataPath = defaultDataPath) {
   const summary = await loadSummary(dataPath);
   renderMetricCards(summary);
   renderOwnerTable(summary);
+  renderCommandCatalog(summary);
   renderAssignments(summary);
   renderSovereignty(summary);
   renderGovernanceLedger(summary);

--- a/demo/Economic-Power-v0/ui/styles.css
+++ b/demo/Economic-Power-v0/ui/styles.css
@@ -427,6 +427,21 @@ main {
   margin-top: 1rem;
 }
 
+#coverage-table {
+  min-width: 320px;
+  margin-top: 0.75rem;
+}
+
+#coverage-table th,
+#coverage-table td {
+  text-align: left;
+}
+
+#coverage-table td:last-child {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 #deployment-table code {
   background: rgba(56, 189, 248, 0.12);
   padding: 0.15rem 0.35rem;


### PR DESCRIPTION
## Summary
- add per-surface owner command coverage accounting and export the new checklist report
- surface the coverage breakdown in the UI and render command catalog data on initial load
- refresh deterministic fixtures (summary, baseline, owner plan) and extend tests to lock the coverage matrix

## Testing
- npm run demo:economic-power
- npm run demo:economic-power:ci
- npm run test:economic-power

------
https://chatgpt.com/codex/tasks/task_e_6900f46f15308333abc1bcca1590bb93