### PR TITLE
Strengthen planetary fabric acceptance guardrails

### DIFF
--- a/demo/Planetary-Orchestrator-Fabric-v0/src/router.ts
+++ b/demo/Planetary-Orchestrator-Fabric-v0/src/router.ts
@@ -148,6 +148,10 @@ export class ShardRouterService {
     this.config.spilloverTargets = [...targets];
   }
 
+  getSpilloverTargets(): ShardId[] {
+    return [...this.config.spilloverTargets];
+  }
+
   private sortPolicies(policies: SpilloverPolicy[]): SpilloverPolicy[] {
     return [...policies].sort((a, b) => {
       const thresholdDelta = a.threshold - b.threshold;


### PR DESCRIPTION
## Summary
- scale acceptance configurations from job volume so shards and nodes have the capacity to keep drop rates under 2%
- route spillovers only toward shards with live capacity and extend the simulator headroom so long runs complete after outages
- tighten the planetary fabric test harness to enforce <2% drop, active-shard balance, and longer recovery loops

## Testing
- `npm run test:planetary-orchestrator-fabric`


------
https://chatgpt.com/codex/tasks/task_e_6900f7efd57883339903ff5deef1e04b