### PR TITLE
Add automated reinvestment loop for AGI Alpha Node demo

### DIFF
--- a/demo/AGI-Alpha-Node-v0/README.md
+++ b/demo/AGI-Alpha-Node-v0/README.md
@@ -7,6 +7,7 @@ The **AGI Alpha Node Demo** showcases how a non-technical owner can command the 
 - ✅ **Owner sovereignty** – the node operator controls every configurable parameter, may pause the platform instantly, and can rotate governance safely.
 - 🔐 **Identity assurance** – ENS subdomain ownership is verified on-chain before any capability is granted.
 - 🪙 **$AGIALPHA-native economy** – staking, rewards, slashing, and reinvestment loops are enforced through the canonical V2 contracts.
+- 🪙 **$AGIALPHA-native economy** – staking, rewards, slashing, and automatic reinvestment loops are enforced through the canonical V2 contracts.
 - 🧠 **Swarm intelligence** – a MuZero-inspired planner, economic self-optimizer, and domain specialist mesh coordinate to deliver provable alpha on every job.
 - 🚀 **One-command deployment** – Dockerised runtime, Prometheus-compatible metrics, and a self-documenting operator console drop straight into institutional stacks.
 
@@ -77,6 +78,35 @@ flowchart TD
 
 ---
 
+## Treasury Autopilot
+
+```mermaid
+sequenceDiagram
+  participant Operator
+  participant AlphaNode
+  participant FeePool
+  participant StakeManager
+  participant Metrics
+
+  Operator->>AlphaNode: treasury reinvest (optional amount)
+  AlphaNode->>FeePool: claimRewards()
+  FeePool-->>AlphaNode: Pending $AGIALPHA released
+  AlphaNode->>StakeManager: depositStake(PlatformRole, amount)
+  StakeManager-->>AlphaNode: Stake receipt + event log
+  AlphaNode->>Metrics: updateReinvestment(report)
+  Metrics-->>Operator: Prometheus dashboard + console summary
+```
+
+The reinvestment policy operates continuously:
+
+- The **dashboard heartbeat** performs a dry-run reinvestment and displays the recommended action.
+- The **`treasury reinvest` CLI** claims and restakes $AGIALPHA in one command, auto-handling token approvals.
+- **Metrics** expose the reinvest ratio (`agi_alpha_node_reinvest_readiness`) so institutional monitors can enforce policy SLAs.
+
+Every transaction honours `SystemPause` guardrails and emits structured notes so non-technical operators can audit the entire loop.
+
+---
+
 ## Directory Layout
 
 | Path | Purpose |
@@ -116,6 +146,11 @@ flowchart TD
    npm run demo:agi-alpha-node -- dashboard --config my-alpha-node.json
    ```
    The earnings view streams live $AGIALPHA inflows, slashing risk, and reinvestment recommendations.
+6. **Trigger a treasury reinvestment (dry run first)**
+   ```bash
+   npm run demo:agi-alpha-node -- treasury reinvest --dry-run --config my-alpha-node.json
+   ```
+   Remove `--dry-run` to claim and restake rewards when you are satisfied with the preview. Use `--amount 3500` to override the automatic threshold in $AGIALPHA.
 
 > **Safety rails:** All scripts honour the `SystemPause` contract. If any invariants fail (stake shortfall, ENS mismatch, validator dispute), the node pauses itself and guides the operator through remediation.
 

--- a/demo/AGI-Alpha-Node-v0/src/blockchain/reinvest.ts
+++ b/demo/AGI-Alpha-Node-v0/src/blockchain/reinvest.ts
@@ -1,0 +1,199 @@
+import { formatUnits, Wallet } from 'ethers';
+import { NormalisedAlphaNodeConfig } from '../config';
+import {
+  connectFeePool,
+  connectStakeManager,
+  connectToken,
+  FeePoolContract,
+  StakeManagerContract,
+  Erc20Contract
+} from './contracts';
+import { fetchRewardSnapshot, RewardSnapshot } from './rewards';
+import { fetchStakeSnapshot } from './staking';
+
+const PLATFORM_ROLE = 2n;
+
+export interface ReinvestOptions {
+  readonly dryRun?: boolean;
+  readonly claimOnly?: boolean;
+  readonly amountWei?: bigint;
+}
+
+export interface ReinvestReport {
+  readonly dryRun: boolean;
+  readonly thresholdWei: bigint;
+  readonly pendingWei: bigint;
+  readonly claimedWei: bigint;
+  readonly stakedWei: bigint;
+  readonly claimTransaction?: string;
+  readonly stakeTransaction?: string;
+  readonly notes: string[];
+}
+
+interface ReinvestDependencies {
+  readonly fetchRewards?: typeof fetchRewardSnapshot;
+  readonly fetchStake?: typeof fetchStakeSnapshot;
+  readonly connectFeePool?: (address: string, runner: Wallet) => FeePoolContract;
+  readonly connectStakeManager?: (address: string, runner: Wallet) => StakeManagerContract;
+  readonly connectToken?: (address: string, runner: Wallet) => Erc20Contract;
+}
+
+function formatEther(amount: bigint): string {
+  return formatUnits(amount, 18);
+}
+
+function ensurePositive(value: bigint): boolean {
+  return value > 0n;
+}
+
+async function ensureAllowance(
+  token: Erc20Contract,
+  signer: Wallet,
+  spender: string,
+  amount: bigint,
+  notes: string[],
+  dryRun: boolean
+): Promise<void> {
+  if (!ensurePositive(amount)) {
+    return;
+  }
+  const operator = await signer.getAddress();
+  const allowance: bigint = BigInt(await token.allowance(operator, spender));
+  if (allowance >= amount) {
+    return;
+  }
+  if (dryRun) {
+    notes.push(
+      `Dry run: would approve ${formatEther(amount)} $AGIALPHA for StakeManager ${spender}.`
+    );
+    return;
+  }
+  const approveTx = await token.approve(spender, amount);
+  notes.push(`Approve transaction broadcast: ${approveTx.hash}`);
+  const receipt = await approveTx.wait?.();
+  if (receipt) {
+    notes.push(`Approval confirmed in block ${receipt.blockNumber}.`);
+  }
+}
+
+export async function reinvestRewards(
+  signer: Wallet,
+  config: NormalisedAlphaNodeConfig,
+  options?: ReinvestOptions,
+  deps?: ReinvestDependencies
+): Promise<ReinvestReport> {
+  const notes: string[] = [];
+  const fetchRewards = deps?.fetchRewards ?? fetchRewardSnapshot;
+  const fetchStake = deps?.fetchStake ?? fetchStakeSnapshot;
+  const feePoolConnector = deps?.connectFeePool ?? connectFeePool;
+  const stakeManagerConnector = deps?.connectStakeManager ?? connectStakeManager;
+  const tokenConnector = deps?.connectToken ?? connectToken;
+
+  const rewardSnapshot: RewardSnapshot = await fetchRewards(signer, config);
+  const threshold = config.ai.reinvestThresholdWei;
+  const pending = rewardSnapshot.pending;
+
+  let desiredAmount = options?.amountWei ?? pending;
+  if (desiredAmount > pending) {
+    notes.push(
+      `Requested reinvest amount ${formatEther(desiredAmount)} exceeds pending rewards ${formatEther(pending)}. Limiting to pending.`
+    );
+    desiredAmount = pending;
+  }
+
+  if (!ensurePositive(desiredAmount)) {
+    notes.push('No pending rewards to reinvest.');
+    return {
+      dryRun: Boolean(options?.dryRun),
+      thresholdWei: threshold,
+      pendingWei: pending,
+      claimedWei: 0n,
+      stakedWei: 0n,
+      notes
+    };
+  }
+
+  if (pending < threshold && !options?.amountWei) {
+    notes.push(
+      `Pending rewards ${formatEther(pending)} below reinvest threshold ${formatEther(threshold)}. Override with --amount to force.`
+    );
+    return {
+      dryRun: Boolean(options?.dryRun),
+      thresholdWei: threshold,
+      pendingWei: pending,
+      claimedWei: 0n,
+      stakedWei: 0n,
+      notes
+    };
+  }
+
+  if (options?.dryRun) {
+    notes.push(
+      `Dry run: would claim ${formatEther(desiredAmount)} $AGIALPHA and restake via StakeManager.`
+    );
+    if (!options?.claimOnly) {
+      notes.push('Dry run: would call depositStake to increase platform position.');
+    }
+    return {
+      dryRun: true,
+      thresholdWei: threshold,
+      pendingWei: pending,
+      claimedWei: desiredAmount,
+      stakedWei: options?.claimOnly ? 0n : desiredAmount,
+      notes
+    };
+  }
+
+  const feePool = feePoolConnector(config.contracts.feePool, signer);
+  const claimTx = await feePool.claimRewards();
+  notes.push(`Claim transaction broadcast: ${claimTx.hash}`);
+  const claimReceipt = await claimTx.wait?.();
+  if (claimReceipt) {
+    notes.push(`Rewards claimed in block ${claimReceipt.blockNumber}.`);
+  }
+
+  let staked = 0n;
+  let stakeTxHash: string | undefined;
+
+  if (!options?.claimOnly && ensurePositive(desiredAmount)) {
+    const stakeManager = stakeManagerConnector(config.contracts.stakeManager, signer);
+    const token = tokenConnector(config.contracts.agialphaToken, signer);
+    const operator = await signer.getAddress();
+    const balance = BigInt(await token.balanceOf(operator));
+    if (balance < desiredAmount) {
+      notes.push(
+        `Wallet balance ${formatEther(balance)} $AGIALPHA insufficient for reinvestment of ${formatEther(desiredAmount)}. ` +
+          'Ensure claim settled or adjust amount.'
+      );
+    } else {
+      await ensureAllowance(token, signer, config.contracts.stakeManager, desiredAmount, notes, false);
+      const stakeTx = await stakeManager.depositStake(Number(PLATFORM_ROLE), desiredAmount);
+      stakeTxHash = stakeTx.hash;
+      notes.push(`Reinvest stake broadcast: ${stakeTxHash}`);
+      const stakeReceipt = await stakeTx.wait?.();
+      if (stakeReceipt) {
+        notes.push(`Stake increase confirmed in block ${stakeReceipt.blockNumber}.`);
+      }
+      staked = desiredAmount;
+    }
+  } else if (options?.claimOnly) {
+    notes.push('claimOnly: skipped automatic restake.');
+  }
+
+  // Refresh snapshots for operator visibility.
+  const postStake = await fetchStake(signer, config);
+  notes.push(
+    `Updated stake balance ${formatEther(postStake.currentStake)} / requirement ${formatEther(postStake.requiredStake)}.`
+  );
+
+  return {
+    dryRun: false,
+    thresholdWei: threshold,
+    pendingWei: pending,
+    claimedWei: desiredAmount,
+    stakedWei: staked,
+    claimTransaction: claimTx.hash,
+    stakeTransaction: stakeTxHash,
+    notes
+  };
+}

--- a/demo/AGI-Alpha-Node-v0/test/alpha_node_demo.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/alpha_node_demo.test.ts
@@ -3,3 +3,4 @@ import './planner.test';
 import './identity.test';
 import './antifragile.test';
 import './jobs.test';
+import './reinvest.test';

--- a/demo/AGI-Alpha-Node-v0/test/reinvest.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/reinvest.test.ts
@@ -1,0 +1,161 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { Wallet } from 'ethers';
+import { loadAlphaNodeConfig } from '../src/config';
+import { reinvestRewards } from '../src/blockchain/reinvest';
+import type { RewardSnapshot } from '../src/blockchain/rewards';
+import type { StakeSnapshot } from '../src/blockchain/staking';
+
+const fixturePath = path.resolve('demo/AGI-Alpha-Node-v0/config/mainnet.guide.json');
+
+class FakeTx {
+  constructor(readonly hash: string) {}
+  async wait(): Promise<{ blockNumber: number }> {
+    return { blockNumber: 999 };
+  }
+}
+
+class FakeFeePool {
+  public claimCount = 0;
+  async claimRewards(): Promise<FakeTx> {
+    this.claimCount += 1;
+    return new FakeTx('0xclaim');
+  }
+}
+
+class FakeStakeManager {
+  public deposits: Array<{ role: number; amount: bigint }> = [];
+  async depositStake(role: number, amount: bigint): Promise<FakeTx> {
+    this.deposits.push({ role, amount });
+    return new FakeTx('0xstake');
+  }
+}
+
+class FakeToken {
+  public allowanceValue = 0n;
+  public balance = 0n;
+  public approvals: Array<{ spender: string; amount: bigint }> = [];
+
+  async allowance(_owner?: string, _spender?: string): Promise<bigint> {
+    return this.allowanceValue;
+  }
+
+  async approve(spender: string, amount: bigint): Promise<FakeTx> {
+    this.allowanceValue = amount;
+    this.approvals.push({ spender, amount });
+    return new FakeTx('0xapprove');
+  }
+
+  async balanceOf(_account?: string): Promise<bigint> {
+    return this.balance;
+  }
+}
+
+function makeWallet(): Wallet {
+  const provider = {
+    async getBlockNumber(): Promise<number> {
+      return 2048;
+    }
+  } as any;
+  return new Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d', provider);
+}
+
+function makeStakeSnapshot(): StakeSnapshot {
+  return {
+    currentStake: 0n,
+    requiredStake: 0n,
+    allowance: 0n,
+    tokenBalance: 0n,
+    registered: false,
+    paused: false,
+    minimums: {
+      global: 0n,
+      platformRole: 0n,
+      registry: 0n,
+      config: 0n
+    }
+  };
+}
+
+test('reinvestRewards skips when pending is below threshold', async () => {
+  const config = await loadAlphaNodeConfig(fixturePath);
+  const wallet = makeWallet();
+  const pending = config.ai.reinvestThresholdWei - 1n;
+  const report = await reinvestRewards(
+    wallet,
+    config,
+    undefined,
+    {
+      fetchRewards: async (): Promise<RewardSnapshot> => ({
+        boostedStake: 0n,
+        cumulativePerToken: 0n,
+        checkpoint: 0n,
+        pending,
+        projectedDaily: '0'
+      }),
+      fetchStake: async (): Promise<StakeSnapshot> => makeStakeSnapshot()
+    }
+  );
+  assert.equal(report.claimedWei, 0n);
+  assert(report.notes.some((note) => note.includes('below reinvest threshold')));
+});
+
+test('reinvestRewards dry run reports intended actions', async () => {
+  const config = await loadAlphaNodeConfig(fixturePath);
+  const wallet = makeWallet();
+  const pending = config.ai.reinvestThresholdWei + 10n;
+  const report = await reinvestRewards(
+    wallet,
+    config,
+    { dryRun: true },
+    {
+      fetchRewards: async (): Promise<RewardSnapshot> => ({
+        boostedStake: 0n,
+        cumulativePerToken: 0n,
+        checkpoint: 0n,
+        pending,
+        projectedDaily: '0'
+      }),
+      fetchStake: async (): Promise<StakeSnapshot> => makeStakeSnapshot()
+    }
+  );
+  assert.equal(report.dryRun, true);
+  assert.equal(report.claimedWei, pending);
+  assert(report.notes.some((note) => note.includes('Dry run: would claim')));
+});
+
+test('reinvestRewards claims and deposits with injected contracts', async () => {
+  const config = await loadAlphaNodeConfig(fixturePath);
+  const wallet = makeWallet();
+  const feePool = new FakeFeePool();
+  const stakeManager = new FakeStakeManager();
+  const token = new FakeToken();
+  token.balance = config.ai.reinvestThresholdWei + 1n;
+
+  const report = await reinvestRewards(
+    wallet,
+    config,
+    {},
+    {
+      fetchRewards: async (): Promise<RewardSnapshot> => ({
+        boostedStake: 0n,
+        cumulativePerToken: 0n,
+        checkpoint: 0n,
+        pending: config.ai.reinvestThresholdWei + 1n,
+        projectedDaily: '42'
+      }),
+      fetchStake: async (): Promise<StakeSnapshot> => makeStakeSnapshot(),
+      connectFeePool: () => feePool as any,
+      connectStakeManager: () => stakeManager as any,
+      connectToken: () => token as any
+    }
+  );
+
+  assert.equal(feePool.claimCount, 1);
+  assert.equal(stakeManager.deposits.length, 1);
+  assert.equal(token.approvals.length, 1);
+  assert.equal(report.claimedWei, config.ai.reinvestThresholdWei + 1n);
+  assert.equal(report.stakedWei, config.ai.reinvestThresholdWei + 1n);
+  assert.equal(report.dryRun, false);
+});

--- a/demo/AGI-Alpha-Node-v0/web/index.html
+++ b/demo/AGI-Alpha-Node-v0/web/index.html
@@ -76,6 +76,7 @@
         const rewards = data.rewards;
         const plan = data.plan;
         const identity = data.identity;
+        const reinvestment = data.reinvestment;
         document.getElementById('stake').innerHTML = `
           <div class="metrics">
             <span>Stake Target</span>
@@ -117,6 +118,17 @@
           </div>
           <pre>${JSON.stringify(plan.insights, null, 2)}</pre>
         `;
+        document.getElementById('treasury').innerHTML = `
+          <div class="metrics">
+            <span>Pending → Threshold</span>
+            <strong>${formatEther(reinvestment.pendingWei)} / ${formatEther(reinvestment.thresholdWei)} $AGIALPHA</strong>
+          </div>
+          <div class="metrics">
+            <span>Last Action</span>
+            <strong>${reinvestment.dryRun ? 'Dry Run' : formatEther(reinvestment.stakedWei) + ' staked'}</strong>
+          </div>
+          <pre>${JSON.stringify(reinvestment.notes, null, 2)}</pre>
+        `;
         document.getElementById('stress').textContent = JSON.stringify(data.stress, null, 2);
       }
 
@@ -138,6 +150,7 @@
       <div class="card" id="rewards"></div>
       <div class="card" id="identity"></div>
       <div class="card" id="planning"></div>
+      <div class="card" id="treasury"></div>
     </div>
     <div class="card" style="margin-top: 1.5rem;">
       <h2>Stress Diagnostics</h2>


### PR DESCRIPTION
## Summary
- add a dedicated reinvestment module to claim rewards and restake $AGIALPHA for alpha node operators
- expose treasury automation through CLI, metrics, heartbeat responses, and the operator dashboard
- document the reinvestment workflow and cover it with new unit tests

## Testing
- npm run build:agi-alpha-node
- npm run test:agi-alpha-node

------
https://chatgpt.com/codex/tasks/task_e_690100d918c8833391fb1c49b875a4a9