### PR TITLE
Add sovereign safety mesh telemetry to Economic Power demo

### DIFF
--- a/demo/Economic-Power-v0/README.md
+++ b/demo/Economic-Power-v0/README.md
@@ -31,6 +31,7 @@ Outputs land in `demo/Economic-Power-v0/reports/`:
 - `owner-command-plan.md` – markdown playbook summarising quick actions, scripted upgrades, circuit breakers, and capital checkpoints in plain language.
 - `owner-command-checklist.json` – machine-auditable coverage ledger detailing per-surface command coverage percentages for jobs, validators, adapters, modules, treasury, pause/resume, and orchestrator surfaces.
 - `owner-governance-ledger.json` – deterministic custody ledger detailing module ownership, audit freshness, scripts, and alertable coverage gaps for governance dashboards.
+- `sovereign-safety-mesh.json` – composite readiness diagnostics across pause/resume readiness, alerting, scripted coverage, and circuit breaker posture.
 - `treasury-trajectory.json` – treasury state, yield, validator confidence, and automation lift captured after each job.
 - `assertions.json` – machine-readable verification ledger covering owner dominance, custody, validator strength, and treasury solvency.
 
@@ -112,6 +113,7 @@ The UI inside `demo/Economic-Power-v0/ui/` offers:
 - Owner command Mermaid graph mapping multi-sig authority to every module, circuit breaker, and upgrade path.
 - Drag-and-drop support for alternative `summary.json` files for instant what-if exploration.
 - Sovereign safety mesh panel cataloguing pause/resume playbooks, emergency contacts, circuit breakers, and module upgrade routes.
+- Safety mesh diagnostics scoring response readiness, alert channel breadth, circuit breaker posture, command coverage depth, and scripted responses.
 - Governance ledger visual linking custody posture, audit staleness, and alert feed directly from `owner-governance-ledger.json`.
 - Command catalog grid enumerating every deterministic owner program so the operator can launch missions instantly.
 
@@ -145,7 +147,7 @@ This guarantees a **fully green v2 CI gate**. Pull requests and `main` share ide
 - ✅ Modular architecture reflecting the v2 sprint blueprint.
 - ✅ Deterministic simulation and CI coverage.
 - ✅ Owner-first command catalog for every mutable lever plus sovereign custody scoring for every contract module.
-- ✅ Observability artefacts (Mermaid, JSON, HTML dashboard).
+- ✅ Observability artefacts (Mermaid, JSON, HTML dashboard) plus sovereign safety diagnostics for instant incident readiness reviews.
 - ✅ Non-technical operations workflow from single command to actionable dashboard.
 
 Run the loop, inspect the telemetry, execute the owner change-set, and step into an economy-scale command role.

--- a/demo/Economic-Power-v0/reports/baseline-summary.json
+++ b/demo/Economic-Power-v0/reports/baseline-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T16:59:49.680Z",
+  "executionTimestamp": "2025-10-28T17:40:41.635Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -23,6 +23,7 @@
     "stabilityIndex": 0.761,
     "ownerCommandCoverage": 1,
     "sovereignControlScore": 1,
+    "sovereignSafetyScore": 0.979,
     "assertionPassRate": 1
   },
   "ownerControl": {
@@ -101,6 +102,10 @@
         "script": "npm run owner:parameters",
         "description": "Rebalances stake requirements to throttle spam and fortify incentives."
       }
+    ],
+    "alertChannels": [
+      "slack://agi-ops-economic-power",
+      "pagerduty://agi-critical"
     ]
   },
   "commandCatalog": {
@@ -644,6 +649,28 @@
       "treasury": 1,
       "orchestrator": 1
     }
+  },
+  "sovereignSafetyMesh": {
+    "pauseReady": true,
+    "resumeReady": true,
+    "targetResponseMinutes": 15,
+    "responseMinutes": 9,
+    "responseScore": 1,
+    "circuitBreakerScore": 0.94,
+    "alertCoverageScore": 0.91,
+    "coverageScore": 1,
+    "scriptScore": 1,
+    "safetyScore": 0.979,
+    "alertChannels": [
+      "slack://agi-ops-economic-power",
+      "pagerduty://agi-critical"
+    ],
+    "emergencyContacts": [
+      "governance@agijobs.ai",
+      "security-operations@agijobs.ai",
+      "treasury@agijobs.ai"
+    ],
+    "notes": []
   },
   "assertions": [
     {

--- a/demo/Economic-Power-v0/reports/owner-command-plan.md
+++ b/demo/Economic-Power-v0/reports/owner-command-plan.md
@@ -1,6 +1,6 @@
 # Owner Command Playbook
 
-Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/28/2025, 5:00:29 PM (UTC)
+Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/28/2025, 5:42:01 PM (UTC)
 
 Command coverage: 100.0% — Owner multi-sig holds deterministic runbooks for every critical surface.
 

--- a/demo/Economic-Power-v0/reports/owner-sovereignty.json
+++ b/demo/Economic-Power-v0/reports/owner-sovereignty.json
@@ -47,7 +47,12 @@
       "description": "Rebalances stake requirements to throttle spam and fortify incentives."
     }
   ],
+  "alertChannels": [
+    "slack://agi-ops-economic-power",
+    "pagerduty://agi-critical"
+  ],
   "stabilityIndex": 0.761,
   "ownerCommandCoverage": 1,
-  "sovereignControlScore": 1
+  "sovereignControlScore": 1,
+  "sovereignSafetyScore": 0.979
 }

--- a/demo/Economic-Power-v0/reports/sovereign-safety-mesh.json
+++ b/demo/Economic-Power-v0/reports/sovereign-safety-mesh.json
@@ -1,0 +1,22 @@
+{
+  "pauseReady": true,
+  "resumeReady": true,
+  "targetResponseMinutes": 15,
+  "responseMinutes": 9,
+  "responseScore": 1,
+  "circuitBreakerScore": 0.94,
+  "alertCoverageScore": 0.91,
+  "coverageScore": 1,
+  "scriptScore": 1,
+  "safetyScore": 0.979,
+  "alertChannels": [
+    "slack://agi-ops-economic-power",
+    "pagerduty://agi-critical"
+  ],
+  "emergencyContacts": [
+    "governance@agijobs.ai",
+    "security-operations@agijobs.ai",
+    "treasury@agijobs.ai"
+  ],
+  "notes": []
+}

--- a/demo/Economic-Power-v0/reports/summary.json
+++ b/demo/Economic-Power-v0/reports/summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T17:00:29.486Z",
+  "executionTimestamp": "2025-10-28T17:42:01.671Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -23,6 +23,7 @@
     "stabilityIndex": 0.761,
     "ownerCommandCoverage": 1,
     "sovereignControlScore": 1,
+    "sovereignSafetyScore": 0.979,
     "assertionPassRate": 1
   },
   "ownerControl": {
@@ -101,6 +102,10 @@
         "script": "npm run owner:parameters",
         "description": "Rebalances stake requirements to throttle spam and fortify incentives."
       }
+    ],
+    "alertChannels": [
+      "slack://agi-ops-economic-power",
+      "pagerduty://agi-critical"
     ]
   },
   "commandCatalog": {
@@ -644,6 +649,28 @@
       "treasury": 1,
       "orchestrator": 1
     }
+  },
+  "sovereignSafetyMesh": {
+    "pauseReady": true,
+    "resumeReady": true,
+    "targetResponseMinutes": 15,
+    "responseMinutes": 9,
+    "responseScore": 1,
+    "circuitBreakerScore": 0.94,
+    "alertCoverageScore": 0.91,
+    "coverageScore": 1,
+    "scriptScore": 1,
+    "safetyScore": 0.979,
+    "alertChannels": [
+      "slack://agi-ops-economic-power",
+      "pagerduty://agi-critical"
+    ],
+    "emergencyContacts": [
+      "governance@agijobs.ai",
+      "security-operations@agijobs.ai",
+      "treasury@agijobs.ai"
+    ],
+    "notes": []
   },
   "assertions": [
     {

--- a/demo/Economic-Power-v0/test/economic_power_demo.test.ts
+++ b/demo/Economic-Power-v0/test/economic_power_demo.test.ts
@@ -44,6 +44,10 @@ test('economic power simulation produces deterministic metrics', async () => {
     );
   }
   assert(summary.metrics.sovereignControlScore >= 0.9, 'Sovereign control score should confirm custody');
+  assert(
+    summary.metrics.sovereignSafetyScore >= 0.95,
+    'Sovereign safety mesh score should confirm unstoppable readiness',
+  );
   assert.equal(
     summary.metrics.assertionPassRate,
     1,
@@ -82,11 +86,30 @@ test('economic power simulation produces deterministic metrics', async () => {
     scenario.safeguards.resumeScript,
     'Resume script should mirror scenario safeguards',
   );
+  assert.deepEqual(
+    summary.ownerSovereignty.alertChannels,
+    scenario.observability.alertChannels,
+    'Alert channel catalogue should mirror observability configuration',
+  );
   assert.equal(
     summary.ownerSovereignty.circuitBreakers.length,
     scenario.safeguards.circuitBreakers.length,
     'Circuit breaker counts should align',
   );
+
+  assert.equal(
+    summary.sovereignSafetyMesh.safetyScore,
+    summary.metrics.sovereignSafetyScore,
+    'Safety mesh score should align with surfaced metric',
+  );
+  assert(summary.sovereignSafetyMesh.pauseReady, 'Pause command should be production ready');
+  assert(summary.sovereignSafetyMesh.resumeReady, 'Resume command should be production ready');
+  assert(
+    summary.sovereignSafetyMesh.alertChannels.length ===
+      scenario.observability.alertChannels.length,
+    'Safety mesh should mirror configured alert channels',
+  );
+  assert(summary.sovereignSafetyMesh.notes.length === 0, 'Baseline scenario should have no outstanding safety notes');
 
   assert(summary.assertions.length >= 5, 'Should expose comprehensive assertion set');
   const coverageAssertion = summary.assertions.find(

--- a/demo/Economic-Power-v0/ui/data/default-summary.json
+++ b/demo/Economic-Power-v0/ui/data/default-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T16:59:49.680Z",
+  "executionTimestamp": "2025-10-28T17:42:01.671Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -23,6 +23,7 @@
     "stabilityIndex": 0.761,
     "ownerCommandCoverage": 1,
     "sovereignControlScore": 1,
+    "sovereignSafetyScore": 0.979,
     "assertionPassRate": 1
   },
   "ownerControl": {
@@ -101,6 +102,10 @@
         "script": "npm run owner:parameters",
         "description": "Rebalances stake requirements to throttle spam and fortify incentives."
       }
+    ],
+    "alertChannels": [
+      "slack://agi-ops-economic-power",
+      "pagerduty://agi-critical"
     ]
   },
   "commandCatalog": {
@@ -644,6 +649,28 @@
       "treasury": 1,
       "orchestrator": 1
     }
+  },
+  "sovereignSafetyMesh": {
+    "pauseReady": true,
+    "resumeReady": true,
+    "targetResponseMinutes": 15,
+    "responseMinutes": 9,
+    "responseScore": 1,
+    "circuitBreakerScore": 0.94,
+    "alertCoverageScore": 0.91,
+    "coverageScore": 1,
+    "scriptScore": 1,
+    "safetyScore": 0.979,
+    "alertChannels": [
+      "slack://agi-ops-economic-power",
+      "pagerduty://agi-critical"
+    ],
+    "emergencyContacts": [
+      "governance@agijobs.ai",
+      "security-operations@agijobs.ai",
+      "treasury@agijobs.ai"
+    ],
+    "notes": []
   },
   "assertions": [
     {

--- a/demo/Economic-Power-v0/ui/index.html
+++ b/demo/Economic-Power-v0/ui/index.html
@@ -161,6 +161,22 @@
             <h3>Immediate actions</h3>
             <div id="pause-resume"></div>
             <p>
+              <strong>Safety mesh score:</strong>
+              <span id="safety-score"></span>
+            </p>
+            <p id="safety-response"></p>
+            <div class="table-wrapper">
+              <table id="safety-metrics" aria-label="Safety mesh diagnostics">
+                <thead>
+                  <tr>
+                    <th>Dimension</th>
+                    <th>Score</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+            <p>
               <strong>Command coverage:</strong>
               <span id="coverage-percent"></span>
             </p>
@@ -178,6 +194,10 @@
             </div>
             <h4>Emergency contacts</h4>
             <ul id="emergency-contacts"></ul>
+            <h4>Alert channels</h4>
+            <ul id="alert-channels"></ul>
+            <h4>Safety notes</h4>
+            <ul id="safety-notes" class="note-list"></ul>
           </article>
           <article class="sovereignty-card" aria-label="Circuit breakers">
             <h3>Circuit breakers</h3>

--- a/demo/Economic-Power-v0/ui/styles.css
+++ b/demo/Economic-Power-v0/ui/styles.css
@@ -442,6 +442,60 @@ main {
   font-variant-numeric: tabular-nums;
 }
 
+#safety-metrics {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.75rem 0 1rem;
+}
+
+#safety-metrics th,
+#safety-metrics td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(56, 189, 248, 0.18);
+  text-align: left;
+}
+
+#safety-metrics th {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba(190, 242, 255, 0.9);
+}
+
+#safety-metrics td:last-child {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+#alert-channels,
+#safety-notes {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+#alert-channels li,
+#safety-notes li {
+  list-style: none;
+  position: relative;
+  padding-left: 1.5rem;
+}
+
+#alert-channels li::before {
+  content: '⚡';
+  position: absolute;
+  left: 0;
+}
+
+#safety-notes li::before {
+  content: '✳️';
+  position: absolute;
+  left: 0;
+}
+
 #deployment-table code {
   background: rgba(56, 189, 248, 0.12);
   padding: 0.15rem 0.35rem;


### PR DESCRIPTION
## Summary
- add sovereign safety mesh scoring and reporting to the Economic Power simulation pipeline, including new baseline telemetry and governance alerts
- expose safety mesh diagnostics throughout the UI, default summary, and documentation so non-technical operators can assess pause/readiness instantly

## Testing
- npm run demo:economic-power
- npm run test:economic-power

------
https://chatgpt.com/codex/tasks/task_e_6900feb5b5308333a1779b1a63146c1f