### PR TITLE
feat: add compliance audit to alpha node demo

### DIFF
--- a/demo/AGI-Alpha-Node-v0/README.md
+++ b/demo/AGI-Alpha-Node-v0/README.md
@@ -6,10 +6,10 @@ The **AGI Alpha Node Demo** showcases how a non-technical owner can command the 
 
 - ✅ **Owner sovereignty** – the node operator controls every configurable parameter, may pause the platform instantly, and can rotate governance safely.
 - 🔐 **Identity assurance** – ENS subdomain ownership is verified on-chain before any capability is granted.
-- 🪙 **$AGIALPHA-native economy** – staking, rewards, slashing, and reinvestment loops are enforced through the canonical V2 contracts.
 - 🪙 **$AGIALPHA-native economy** – staking, rewards, slashing, and automatic reinvestment loops are enforced through the canonical V2 contracts.
 - 🧠 **Swarm intelligence** – a MuZero-inspired planner, economic self-optimizer, and domain specialist mesh coordinate to deliver provable alpha on every job.
 - 🚀 **One-command deployment** – Dockerised runtime, Prometheus-compatible metrics, and a self-documenting operator console drop straight into institutional stacks.
+- 🧾 **Governance-grade compliance** – automated scorecards fuse ENS proofs, staking telemetry, pause authority, and antifragile stress drills in real time.
 
 This demo lives entirely inside `demo/AGI-Alpha-Node-v0/` so operators can audit, extend, and deploy without touching the rest of the monorepo.
 
@@ -107,16 +107,39 @@ Every transaction honours `SystemPause` guardrails and emits structured notes so
 
 ---
 
+## Compliance Scorecard
+
+The Alpha Node now ships with a **governance-grade compliance scorecard**. It fuses ENS identity checks, stake telemetry, governance controls, antifragile stress drills, and strategic intelligence into a single composite rating surfaced in the CLI, REST API, Prometheus metrics, and dashboard UI.
+
+```mermaid
+pie showData
+  title Alpha Node Compliance Fusion
+  "Identity & ENS" : 20
+  "Staking & Activation" : 20
+  "Governance & Safety" : 20
+  "Economic Engine" : 15
+  "Antifragile Shell" : 15
+  "Strategic Intelligence" : 10
+```
+
+- Run `npm run demo:agi-alpha-node -- compliance --config <file>` to print the machine-readable scorecard.
+- Open the Operator Console (`npm run demo:agi-alpha-node -- dashboard ...`) to view the score in real time, including detailed notes per dimension.
+- Monitor `agi_alpha_node_compliance_score` in Prometheus to enforce institutional SLAs or trigger automated playbooks.
+
+The scorecard defaults to optimistic-but-skeptical scoring. Any governance risk (e.g. blacklisting) produces a hard failure, while soft drifts (e.g. paused state) trigger alerts without interrupting operations. This ensures the operator can demonstrate proactive control to regulators, auditors, and institutional partners.
+
+---
+
 ## Directory Layout
 
-| Path | Purpose |
-|------|---------|
-| `config/` | JSON + schema definitions for operator, network, and AI mesh configuration. |
-| `scripts/` | One-command automation flows (ENS bootstrapping, staking, activation, diagnostics). |
-| `src/` | TypeScript implementation of the Alpha Node core. Organized into blockchain, identity, AI, monitoring, and utility modules. |
-| `docker/` | Container definitions for one-click deployments (Docker & Kubernetes). |
-| `web/` | Static dashboard assets for non-technical operators (auto-served by the node). |
-| `test/` | Deterministic unit + integration tests verifying planning, config validation, and antifragile safety shell scenarios. |
+| Path       | Purpose                                                                                                                     |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `config/`  | JSON + schema definitions for operator, network, and AI mesh configuration.                                                 |
+| `scripts/` | One-command automation flows (ENS bootstrapping, staking, activation, diagnostics).                                         |
+| `src/`     | TypeScript implementation of the Alpha Node core. Organized into blockchain, identity, AI, monitoring, and utility modules. |
+| `docker/`  | Container definitions for one-click deployments (Docker & Kubernetes).                                                      |
+| `web/`     | Static dashboard assets for non-technical operators (auto-served by the node).                                              |
+| `test/`    | Deterministic unit + integration tests verifying planning, config validation, and antifragile safety shell scenarios.       |
 
 ---
 
@@ -170,19 +193,20 @@ Every transaction honours `SystemPause` guardrails and emits structured notes so
 
 ## Command Reference
 
-| Command | Description |
-|---------|-------------|
-| `npm run demo:agi-alpha-node -- --config <file>` | Full bootstrap: identity verification → staking → AI mesh launch → monitoring. |
-| `npm run demo:agi-alpha-node -- verify --config <file>` | Identity-only verification with ENS + NameWrapper audit logs. |
-| `npm run demo:agi-alpha-node -- stake --config <file>` | Stake & activation workflow via `PlatformIncentives.stakeAndActivate`. |
-| `npm run demo:agi-alpha-node -- dashboard --config <file>` | Launch the operator dashboard and earnings API. |
-| `npm run demo:agi-alpha-node -- heartbeat --config <file>` | Submit a node heartbeat to PlatformRegistry and refresh Prometheus gauges. |
-| `npm run demo:agi-alpha-node -- diagnostics --config <file>` | Run antifragile stress tests and export compliance logs. |
-| `npm run demo:agi-alpha-node -- jobs discover --config <file>` | Query JobRegistry for ENS-authenticated opportunities (dry-run safe). |
-| `npm run demo:agi-alpha-node -- jobs autopilot --config <file> [--dry-run]` | Discover → plan → (optionally) execute the richest job end-to-end. |
-| `npm run demo:agi-alpha-node -- jobs submit <jobId> --result-uri <uri>` | Deliver results to JobRegistry with deterministic hashing. |
-| `npm run demo:agi-alpha-node -- owner pause --config <file>` | Invoke `SystemPause.pauseAll()` with governance safety checks. |
-| `npm run demo:agi-alpha-node -- owner resume --config <file>` | Resume execution across StakeManager, JobRegistry, FeePool, and peers. |
+| Command                                                                     | Description                                                                    |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `npm run demo:agi-alpha-node -- --config <file>`                            | Full bootstrap: identity verification → staking → AI mesh launch → monitoring. |
+| `npm run demo:agi-alpha-node -- verify --config <file>`                     | Identity-only verification with ENS + NameWrapper audit logs.                  |
+| `npm run demo:agi-alpha-node -- stake --config <file>`                      | Stake & activation workflow via `PlatformIncentives.stakeAndActivate`.         |
+| `npm run demo:agi-alpha-node -- dashboard --config <file>`                  | Launch the operator dashboard and earnings API.                                |
+| `npm run demo:agi-alpha-node -- heartbeat --config <file>`                  | Submit a node heartbeat to PlatformRegistry and refresh Prometheus gauges.     |
+| `npm run demo:agi-alpha-node -- compliance --config <file>`                 | Produce the composite compliance scorecard (JSON + Prometheus export).         |
+| `npm run demo:agi-alpha-node -- diagnostics --config <file>`                | Run antifragile stress tests and export compliance logs.                       |
+| `npm run demo:agi-alpha-node -- jobs discover --config <file>`              | Query JobRegistry for ENS-authenticated opportunities (dry-run safe).          |
+| `npm run demo:agi-alpha-node -- jobs autopilot --config <file> [--dry-run]` | Discover → plan → (optionally) execute the richest job end-to-end.             |
+| `npm run demo:agi-alpha-node -- jobs submit <jobId> --result-uri <uri>`     | Deliver results to JobRegistry with deterministic hashing.                     |
+| `npm run demo:agi-alpha-node -- owner pause --config <file>`                | Invoke `SystemPause.pauseAll()` with governance safety checks.                 |
+| `npm run demo:agi-alpha-node -- owner resume --config <file>`               | Resume execution across StakeManager, JobRegistry, FeePool, and peers.         |
 
 ### Trustless Job Lifecycle Flow
 
@@ -228,6 +252,7 @@ All commands support `--network`, `--rpc`, and `--dry-run` flags for local testi
 3. **Kubernetes (optional)** – `docker/kubernetes.yaml` describes a production-ready StatefulSet with secrets, network policies, and horizontal scaling hooks.
 
 The container exposes:
+
 - `4317/tcp` – OpenTelemetry metrics.
 - `4318/tcp` – Operator dashboard & API.
 
@@ -266,6 +291,7 @@ This suite covers config validation, world-model convergence, antifragile shell 
 ## Support
 
 If anything fails, run `npm run demo:agi-alpha-node -- diagnostics`. The output includes:
+
 - Mermaid diagrams of the current state.
 - Suggested remediation runbooks.
 - Links into AGI Jobs v0/v2 documentation for deeper dives.

--- a/demo/AGI-Alpha-Node-v0/src/blockchain/governance.ts
+++ b/demo/AGI-Alpha-Node-v0/src/blockchain/governance.ts
@@ -1,0 +1,40 @@
+import { Wallet, getAddress } from 'ethers';
+import { NormalisedAlphaNodeConfig } from '../config';
+import { connectPlatformRegistry, connectSystemPause } from './contracts';
+
+export interface GovernanceSnapshot {
+  readonly operator: string;
+  readonly governance: string;
+  readonly paused: boolean;
+  readonly operatorIsGovernance: boolean;
+  readonly operatorBlacklisted: boolean;
+}
+
+export async function fetchGovernanceSnapshot(
+  signer: Wallet,
+  config: NormalisedAlphaNodeConfig
+): Promise<GovernanceSnapshot> {
+  const platformRegistry = connectPlatformRegistry(
+    config.contracts.platformRegistry,
+    signer
+  );
+  const systemPause = connectSystemPause(config.contracts.systemPause, signer);
+  const operatorAddress = getAddress(await signer.getAddress());
+
+  const [governance, paused, blacklisted] = await Promise.all([
+    systemPause.governance(),
+    systemPause.paused(),
+    platformRegistry.blacklist(operatorAddress),
+  ]);
+
+  const governanceAddress = getAddress(governance);
+
+  return {
+    operator: operatorAddress,
+    governance: governanceAddress,
+    paused: Boolean(paused),
+    operatorIsGovernance:
+      governanceAddress.toLowerCase() === operatorAddress.toLowerCase(),
+    operatorBlacklisted: Boolean(blacklisted),
+  };
+}

--- a/demo/AGI-Alpha-Node-v0/src/cli.ts
+++ b/demo/AGI-Alpha-Node-v0/src/cli.ts
@@ -15,7 +15,10 @@ function parseProofOption(value: unknown): string[] | undefined {
     return value.map(String);
   }
   if (typeof value === 'string') {
-    return value.split(',').map((entry) => entry.trim()).filter(Boolean);
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
   }
   return undefined;
 }
@@ -49,26 +52,41 @@ yargs(hideBin(process.argv))
       cmd.option('config', {
         type: 'string',
         describe: 'Path to the alpha node config JSON file.',
-        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
       }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       await node.verifyIdentity();
       await node.stake();
       await node.collectRewards();
       await node.reinvest({ dryRun: true });
       const servers = await startAlphaNodeServer(node, {
         dashboardPort: node.getConfig().monitoring.dashboardPort,
-        metricsPort: node.getConfig().monitoring.metricsPort
+        metricsPort: node.getConfig().monitoring.metricsPort,
       });
       node.getLogger().info('bootstrap_complete', {
         dashboardPort: node.getConfig().monitoring.dashboardPort,
-        metricsPort: node.getConfig().monitoring.metricsPort
+        metricsPort: node.getConfig().monitoring.metricsPort,
       });
-      console.log(`Alpha Node live → dashboard http://localhost:${node.getConfig().monitoring.dashboardPort}`);
-      console.log(`Metrics exposed at http://localhost:${node.getConfig().monitoring.metricsPort}/metrics`);
-      servers.dashboard.on('close', () => node.getLogger().info('dashboard_shutdown'));
-      servers.metrics.on('close', () => node.getLogger().info('metrics_shutdown'));
+      console.log(
+        `Alpha Node live → dashboard http://localhost:${
+          node.getConfig().monitoring.dashboardPort
+        }`
+      );
+      console.log(
+        `Metrics exposed at http://localhost:${
+          node.getConfig().monitoring.metricsPort
+        }/metrics`
+      );
+      servers.dashboard.on('close', () =>
+        node.getLogger().info('dashboard_shutdown')
+      );
+      servers.metrics.on('close', () =>
+        node.getLogger().info('metrics_shutdown')
+      );
     }
   )
   .command(
@@ -77,10 +95,13 @@ yargs(hideBin(process.argv))
     (cmd) =>
       cmd.option('config', {
         type: 'string',
-        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
       }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       const result = await node.verifyIdentity();
       console.log(JSON.stringify(result, null, 2));
     }
@@ -92,22 +113,25 @@ yargs(hideBin(process.argv))
       cmd
         .option('config', {
           type: 'string',
-          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
         })
         .option('dry-run', {
           type: 'boolean',
-          default: false
+          default: false,
         })
         .option('no-ack', {
           type: 'boolean',
           default: false,
-          describe: 'Skip tax acknowledgement helper.'
+          describe: 'Skip tax acknowledgement helper.',
         }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       const report = await node.stake({
         dryRun: Boolean(args['dry-run']),
-        acknowledgeTax: !Boolean(args['no-ack'])
+        acknowledgeTax: !Boolean(args['no-ack']),
       });
       console.log(JSON.stringify(report, null, 2));
     }
@@ -118,10 +142,13 @@ yargs(hideBin(process.argv))
     (cmd) =>
       cmd.option('config', {
         type: 'string',
-        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
       }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       const heartbeat = await node.heartbeat(defaultOpportunities());
       console.log(JSON.stringify(heartbeat, null, 2));
     }
@@ -132,10 +159,13 @@ yargs(hideBin(process.argv))
     (cmd) =>
       cmd.option('config', {
         type: 'string',
-        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
       }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       const stress = node.stressTest();
       console.log(JSON.stringify(stress, null, 2));
     }
@@ -147,29 +177,50 @@ yargs(hideBin(process.argv))
       cmd
         .option('config', {
           type: 'string',
-          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
         })
         .option('dry-run', {
           type: 'boolean',
-          default: false
+          default: false,
         })
         .option('claim-only', {
           type: 'boolean',
           default: false,
-          describe: 'Claim rewards without restaking.'
+          describe: 'Claim rewards without restaking.',
         })
         .option('amount', {
           type: 'string',
-          describe: 'Override reinvestment amount in $AGIALPHA (ether units).'
+          describe: 'Override reinvestment amount in $AGIALPHA (ether units).',
         }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
-      const amount = typeof args.amount === 'string' ? parseEther(args.amount) : undefined;
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
+      const amount =
+        typeof args.amount === 'string' ? parseEther(args.amount) : undefined;
       const report = await node.reinvest({
         dryRun: Boolean(args['dry-run']),
         claimOnly: Boolean(args['claim-only']),
-        amountWei: amount
+        amountWei: amount,
       });
+      console.log(JSON.stringify(report, null, 2));
+    }
+  )
+  .command(
+    'compliance',
+    'Produce a governance-grade compliance scorecard',
+    (cmd) =>
+      cmd.option('config', {
+        type: 'string',
+        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
+      }),
+    async (args) => {
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
+      const report = await node.complianceAudit();
       console.log(JSON.stringify(report, null, 2));
     }
   )
@@ -179,18 +230,33 @@ yargs(hideBin(process.argv))
     (cmd) =>
       cmd.option('config', {
         type: 'string',
-        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
       }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       const servers = await startAlphaNodeServer(node, {
         dashboardPort: node.getConfig().monitoring.dashboardPort,
-        metricsPort: node.getConfig().monitoring.metricsPort
+        metricsPort: node.getConfig().monitoring.metricsPort,
       });
-      console.log(`Dashboard http://localhost:${node.getConfig().monitoring.dashboardPort}`);
-      console.log(`Metrics http://localhost:${node.getConfig().monitoring.metricsPort}/metrics`);
-      servers.dashboard.on('close', () => node.getLogger().info('dashboard_shutdown'));
-      servers.metrics.on('close', () => node.getLogger().info('metrics_shutdown'));
+      console.log(
+        `Dashboard http://localhost:${
+          node.getConfig().monitoring.dashboardPort
+        }`
+      );
+      console.log(
+        `Metrics http://localhost:${
+          node.getConfig().monitoring.metricsPort
+        }/metrics`
+      );
+      servers.dashboard.on('close', () =>
+        node.getLogger().info('dashboard_shutdown')
+      );
+      servers.metrics.on('close', () =>
+        node.getLogger().info('metrics_shutdown')
+      );
     }
   )
   .command(
@@ -200,36 +266,45 @@ yargs(hideBin(process.argv))
       cmd
         .option('config', {
           type: 'string',
-          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
         })
         .option('limit', {
           type: 'number',
-          describe: 'Maximum number of jobs to return.'
+          describe: 'Maximum number of jobs to return.',
         })
         .option('from-block', {
           type: 'number',
-          describe: 'Override the discovery start block.'
+          describe: 'Override the discovery start block.',
         })
         .option('to-block', {
           type: 'number',
-          describe: 'Override the discovery end block.'
+          describe: 'Override the discovery end block.',
         })
         .option('include-completed', {
           type: 'boolean',
-          default: false
+          default: false,
         }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       const jobs = await node.discoverJobs({
         limit: args.limit as number | undefined,
         fromBlock: args['from-block'] as number | undefined,
         toBlock: args['to-block'] as number | undefined,
-        includeCompleted: Boolean(args['include-completed'])
+        includeCompleted: Boolean(args['include-completed']),
       });
-      console.log(JSON.stringify({
-        jobs,
-        opportunities: node.toOpportunities(jobs)
-      }, null, 2));
+      console.log(
+        JSON.stringify(
+          {
+            jobs,
+            opportunities: node.toOpportunities(jobs),
+          },
+          null,
+          2
+        )
+      );
     }
   )
   .command(
@@ -239,25 +314,28 @@ yargs(hideBin(process.argv))
       cmd
         .positional('jobId', {
           type: 'string',
-          demandOption: true
+          demandOption: true,
         })
         .option('config', {
           type: 'string',
-          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
         })
         .option('dry-run', {
           type: 'boolean',
-          default: false
+          default: false,
         })
         .option('proof', {
           type: 'string',
-          describe: 'Comma-separated ENS merkle proof overrides.'
+          describe: 'Comma-separated ENS merkle proof overrides.',
         }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       const receipt = await node.applyForJob(parseJobId(args.jobId), {
         dryRun: Boolean(args['dry-run']),
-        proof: parseProofOption(args.proof)
+        proof: parseProofOption(args.proof),
       });
       console.log(JSON.stringify(receipt, null, 2));
     }
@@ -270,30 +348,39 @@ yargs(hideBin(process.argv))
         .positional('jobId', { type: 'string', demandOption: true })
         .option('config', {
           type: 'string',
-          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
         })
         .option('result-uri', {
           type: 'string',
-          describe: 'URI of the result artifact (defaults to config.jobs.execution.defaultResultUri).'
+          describe:
+            'URI of the result artifact (defaults to config.jobs.execution.defaultResultUri).',
         })
         .option('result-hash', {
           type: 'string',
-          describe: 'Precomputed hash of the result artifact.'
+          describe: 'Precomputed hash of the result artifact.',
         })
         .option('dry-run', { type: 'boolean', default: false })
-        .option('proof', { type: 'string', describe: 'Comma-separated ENS merkle proof overrides.' })
+        .option('proof', {
+          type: 'string',
+          describe: 'Comma-separated ENS merkle proof overrides.',
+        })
         .option('hash-algorithm', {
           type: 'string',
-          choices: ['keccak256', 'sha256'] as const
+          choices: ['keccak256', 'sha256'] as const,
         }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       const receipt = await node.submitJob(parseJobId(args.jobId), {
         dryRun: Boolean(args['dry-run']),
         proof: parseProofOption(args.proof),
         resultUri: (args['result-uri'] as string | undefined) ?? undefined,
         resultHash: (args['result-hash'] as string | undefined) ?? undefined,
-        hashAlgorithm: (args['hash-algorithm'] as 'keccak256' | 'sha256' | undefined) ?? undefined
+        hashAlgorithm:
+          (args['hash-algorithm'] as 'keccak256' | 'sha256' | undefined) ??
+          undefined,
       });
       console.log(JSON.stringify(receipt, null, 2));
     }
@@ -306,13 +393,16 @@ yargs(hideBin(process.argv))
         .positional('jobId', { type: 'string', demandOption: true })
         .option('config', {
           type: 'string',
-          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
         })
         .option('dry-run', { type: 'boolean', default: false }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       const receipt = await node.finalizeJob(parseJobId(args.jobId), {
-        dryRun: Boolean(args['dry-run'])
+        dryRun: Boolean(args['dry-run']),
       });
       console.log(JSON.stringify(receipt, null, 2));
     }
@@ -324,19 +414,22 @@ yargs(hideBin(process.argv))
       cmd
         .option('config', {
           type: 'string',
-          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
         })
         .option('limit', { type: 'number' })
         .option('dry-run', { type: 'boolean', default: false })
         .option('result-uri', { type: 'string' })
         .option('proof', { type: 'string' }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
       const report = await node.autopilot({
         limit: args.limit as number | undefined,
         dryRun: Boolean(args['dry-run']),
         resultUri: args['result-uri'] as string | undefined,
-        proof: parseProofOption(args.proof)
+        proof: parseProofOption(args.proof),
       });
       console.log(JSON.stringify(report, null, 2));
     }
@@ -347,11 +440,19 @@ yargs(hideBin(process.argv))
     (cmd) =>
       cmd.option('config', {
         type: 'string',
-        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
       }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
-      const receipt = await pausePlatform(node.getConfig(), node.getMetrics(), node.getLogger(), node.getSigner());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
+      const receipt = await pausePlatform(
+        node.getConfig(),
+        node.getMetrics(),
+        node.getLogger(),
+        node.getSigner()
+      );
       console.log(JSON.stringify(receipt, null, 2));
     }
   )
@@ -361,11 +462,19 @@ yargs(hideBin(process.argv))
     (cmd) =>
       cmd.option('config', {
         type: 'string',
-        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
+        default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
       }),
     async (args) => {
-      const node = await AlphaNode.fromConfig(args.config as string, requirePrivateKey());
-      const receipt = await resumePlatform(node.getConfig(), node.getMetrics(), node.getLogger(), node.getSigner());
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
+      const receipt = await resumePlatform(
+        node.getConfig(),
+        node.getMetrics(),
+        node.getLogger(),
+        node.getSigner()
+      );
       console.log(JSON.stringify(receipt, null, 2));
     }
   )

--- a/demo/AGI-Alpha-Node-v0/src/index.ts
+++ b/demo/AGI-Alpha-Node-v0/src/index.ts
@@ -9,3 +9,5 @@ export * from './identity/rpcLookup';
 export * from './monitoring/metrics';
 export * from './blockchain/staking';
 export * from './blockchain/rewards';
+export * from './blockchain/governance';
+export * from './utils/compliance';

--- a/demo/AGI-Alpha-Node-v0/src/monitoring/metrics.ts
+++ b/demo/AGI-Alpha-Node-v0/src/monitoring/metrics.ts
@@ -16,59 +16,68 @@ export class AlphaNodeMetrics {
   private readonly jobRewardGauge: Gauge<string>;
   private readonly reinvestAmountGauge: Gauge<string>;
   private readonly reinvestReadinessGauge: Gauge<string>;
+  private readonly complianceGauge: Gauge<string>;
 
   constructor() {
     this.registry.setDefaultLabels({ component: 'agi-alpha-node' });
     this.stakeGauge = new Gauge({
       name: 'agi_alpha_node_stake_total',
       help: 'Current platform stake held by the operator (wei).',
-      registers: [this.registry]
+      registers: [this.registry],
     });
     this.stakeDeficitGauge = new Gauge({
       name: 'agi_alpha_node_stake_deficit',
       help: 'Additional stake required to satisfy platform minimums (wei).',
-      registers: [this.registry]
+      registers: [this.registry],
     });
     this.rewardGauge = new Gauge({
       name: 'agi_alpha_node_rewards_pending',
       help: 'Unclaimed $AGIALPHA rewards (wei).',
-      registers: [this.registry]
+      registers: [this.registry],
     });
     this.verificationGauge = new Gauge({
       name: 'agi_alpha_node_identity_status',
       help: 'Identity verification status (1 = verified, 0 = mismatch).',
-      registers: [this.registry]
+      registers: [this.registry],
     });
     this.plannerScoreGauge = new Gauge({
       name: 'agi_alpha_node_planner_score',
       help: 'Latest MuZero++ planner alpha score (unitless).',
-      registers: [this.registry]
+      registers: [this.registry],
     });
     this.jobOpenGauge = new Gauge({
       name: 'agi_alpha_node_jobs_open',
       help: 'Number of open jobs detected in the latest discovery cycle.',
-      registers: [this.registry]
+      registers: [this.registry],
     });
     this.jobRewardGauge = new Gauge({
       name: 'agi_alpha_node_job_reward',
       help: 'Reward of the selected job in $AGIALPHA (ether units).',
-      registers: [this.registry]
+      registers: [this.registry],
     });
     this.reinvestAmountGauge = new Gauge({
       name: 'agi_alpha_node_reinvest_last_amount',
       help: 'Amount of $AGIALPHA reinvested in the latest cycle (wei).',
-      registers: [this.registry]
+      registers: [this.registry],
     });
     this.reinvestReadinessGauge = new Gauge({
       name: 'agi_alpha_node_reinvest_readiness',
       help: 'Ratio of pending rewards to reinvest threshold.',
-      registers: [this.registry]
+      registers: [this.registry],
+    });
+    this.complianceGauge = new Gauge({
+      name: 'agi_alpha_node_compliance_score',
+      help: 'Composite compliance score across governance, staking, and intelligence (0-1).',
+      registers: [this.registry],
     });
   }
 
   updateStake(snapshot: StakeSnapshot): void {
     this.stakeGauge.set(Number(snapshot.currentStake));
-    const deficit = snapshot.requiredStake > snapshot.currentStake ? snapshot.requiredStake - snapshot.currentStake : 0n;
+    const deficit =
+      snapshot.requiredStake > snapshot.currentStake
+        ? snapshot.requiredStake - snapshot.currentStake
+        : 0n;
     this.stakeDeficitGauge.set(Number(deficit));
   }
 
@@ -98,7 +107,9 @@ export class AlphaNodeMetrics {
 
   updateReinvestment(report: ReinvestReport, threshold: bigint): void {
     const amountEther = Number(report.stakedWei) / 1e18;
-    this.reinvestAmountGauge.set(Number.isFinite(amountEther) ? amountEther : 0);
+    this.reinvestAmountGauge.set(
+      Number.isFinite(amountEther) ? amountEther : 0
+    );
     if (threshold > 0n) {
       const ratioRaw = (report.pendingWei * 1_000_000n) / threshold;
       const ratio = Number(ratioRaw) / 1_000_000;
@@ -106,6 +117,10 @@ export class AlphaNodeMetrics {
     } else {
       this.reinvestReadinessGauge.set(0);
     }
+  }
+
+  updateCompliance(score: number): void {
+    this.complianceGauge.set(score);
   }
 
   async render(): Promise<string> {

--- a/demo/AGI-Alpha-Node-v0/src/node.ts
+++ b/demo/AGI-Alpha-Node-v0/src/node.ts
@@ -1,17 +1,27 @@
 import { JsonRpcProvider, Wallet } from 'ethers';
-import { loadAlphaNodeConfig, makeEnsName, NormalisedAlphaNodeConfig } from './config';
+import {
+  loadAlphaNodeConfig,
+  makeEnsName,
+  NormalisedAlphaNodeConfig,
+} from './config';
 import { RpcEnsLookup } from './identity/rpcLookup';
 import { verifyNodeIdentity } from './identity/verify';
 import type { IdentityVerificationResult } from './identity/types';
-import { fetchStakeSnapshot, ensureStake, StakeActionReport, StakeSnapshot } from './blockchain/staking';
+import {
+  fetchStakeSnapshot,
+  ensureStake,
+  StakeActionReport,
+  StakeSnapshot,
+} from './blockchain/staking';
 import { fetchRewardSnapshot, RewardSnapshot } from './blockchain/rewards';
+import { fetchGovernanceSnapshot } from './blockchain/governance';
 import {
   createJobLifecycle,
   DiscoveredJob,
   JobActionOptions,
   JobActionReceipt,
   JobCycleReport,
-  JobDiscoveryOptions
+  JobDiscoveryOptions,
 } from './blockchain/jobs';
 import { AlphaPlanner, JobOpportunity, PlanningSummary } from './ai/planner';
 import { SpecialistOrchestrator, SpecialistInsight } from './ai/orchestrator';
@@ -19,7 +29,15 @@ import { AntifragileShell, StressTestResult } from './ai/antifragile';
 import { AlphaNodeMetrics } from './monitoring/metrics';
 import { AlphaNodeLogger } from './utils/logger';
 import { defaultOpportunities } from './utils/opportunities';
-import { reinvestRewards, ReinvestOptions, ReinvestReport } from './blockchain/reinvest';
+import {
+  reinvestRewards,
+  ReinvestOptions,
+  ReinvestReport,
+} from './blockchain/reinvest';
+import {
+  AlphaNodeComplianceReport,
+  computeComplianceReport,
+} from './utils/compliance';
 
 export interface AlphaNodeContext {
   readonly config: NormalisedAlphaNodeConfig;
@@ -39,14 +57,25 @@ export class AlphaNode {
   constructor(private readonly context: AlphaNodeContext) {
     this.planner = new AlphaPlanner(context.config);
     this.orchestrator = new SpecialistOrchestrator(context.config);
-    this.jobLifecycle = createJobLifecycle({ signer: context.signer, config: context.config });
+    this.jobLifecycle = createJobLifecycle({
+      signer: context.signer,
+      config: context.config,
+    });
     this.operatorAddress = context.signer.address;
   }
 
-  static async fromConfig(configPath: string, privateKey: string): Promise<AlphaNode> {
+  static async fromConfig(
+    configPath: string,
+    privateKey: string
+  ): Promise<AlphaNode> {
     const config = await loadAlphaNodeConfig(configPath);
-    const provider = new JsonRpcProvider(config.network.rpcUrl, config.network.chainId);
-    const normalizedKey = privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`;
+    const provider = new JsonRpcProvider(
+      config.network.rpcUrl,
+      config.network.chainId
+    );
+    const normalizedKey = privateKey.startsWith('0x')
+      ? privateKey
+      : `0x${privateKey}`;
     const signer = new Wallet(normalizedKey, provider);
     const metrics = new AlphaNodeMetrics();
     const logger = new AlphaNodeLogger(config.monitoring.logFile);
@@ -73,60 +102,82 @@ export class AlphaNode {
     const lookup = new RpcEnsLookup(this.context.provider, {
       registry: this.context.config.contracts.ens.registry,
       nameWrapper: this.context.config.contracts.ens.nameWrapper,
-      publicResolver: this.context.config.contracts.ens.publicResolver
+      publicResolver: this.context.config.contracts.ens.publicResolver,
     });
     const result = await verifyNodeIdentity(this.context.config, lookup);
     this.context.metrics.updateIdentity(result);
     this.context.logger.info('identity_verified', {
       ensName: makeEnsName(this.context.config),
       matches: result.matches,
-      reasons: result.reasons
+      reasons: result.reasons,
     });
     return result;
   }
 
-  async stake(options?: { dryRun?: boolean; acknowledgeTax?: boolean }): Promise<StakeActionReport> {
-    const report = await ensureStake(this.context.signer, this.context.config, options);
-    const snapshot = await fetchStakeSnapshot(this.context.signer, this.context.config);
+  async stake(options?: {
+    dryRun?: boolean;
+    acknowledgeTax?: boolean;
+  }): Promise<StakeActionReport> {
+    const report = await ensureStake(
+      this.context.signer,
+      this.context.config,
+      options
+    );
+    const snapshot = await fetchStakeSnapshot(
+      this.context.signer,
+      this.context.config
+    );
     this.context.metrics.updateStake(snapshot);
     this.context.logger.info('stake_result', {
       amountStaked: report.amountStaked.toString(),
       activated: report.activated,
-      notes: report.notes
+      notes: report.notes,
     });
     return report;
   }
 
   async collectRewards(): Promise<RewardSnapshot> {
-    const snapshot = await fetchRewardSnapshot(this.context.signer, this.context.config);
+    const snapshot = await fetchRewardSnapshot(
+      this.context.signer,
+      this.context.config
+    );
     this.context.metrics.updateRewards(snapshot);
     this.context.logger.info('reward_snapshot', {
       pending: snapshot.pending.toString(),
-      projectedDaily: snapshot.projectedDaily
+      projectedDaily: snapshot.projectedDaily,
     });
     return snapshot;
   }
 
   async reinvest(options?: ReinvestOptions): Promise<ReinvestReport> {
-    const report = await reinvestRewards(this.context.signer, this.context.config, options);
-    this.context.metrics.updateReinvestment(report, this.context.config.ai.reinvestThresholdWei);
+    const report = await reinvestRewards(
+      this.context.signer,
+      this.context.config,
+      options
+    );
+    this.context.metrics.updateReinvestment(
+      report,
+      this.context.config.ai.reinvestThresholdWei
+    );
     this.context.logger.info('reinvestment_cycle', {
       dryRun: report.dryRun,
       claimed: report.claimedWei.toString(),
       staked: report.stakedWei.toString(),
-      notes: report.notes
+      notes: report.notes,
     });
     return report;
   }
 
   async discoverJobs(options?: JobDiscoveryOptions): Promise<DiscoveredJob[]> {
     const jobs = await this.jobLifecycle.discover(options);
-    this.context.metrics.updateJobDiscovery(jobs.filter((job) => job.isOpen).length);
+    this.context.metrics.updateJobDiscovery(
+      jobs.filter((job) => job.isOpen).length
+    );
     this.context.logger.info('job_discovery', {
       count: jobs.length,
       open: jobs.filter((job) => job.isOpen).length,
       fromBlock: options?.fromBlock,
-      toBlock: options?.toBlock
+      toBlock: options?.toBlock,
     });
     return jobs;
   }
@@ -135,36 +186,61 @@ export class AlphaNode {
     return this.jobLifecycle.toOpportunities(jobs);
   }
 
-  async applyForJob(jobId: bigint, options?: JobActionOptions): Promise<JobActionReceipt> {
+  async applyForJob(
+    jobId: bigint,
+    options?: JobActionOptions
+  ): Promise<JobActionReceipt> {
     const receipt = await this.jobLifecycle.apply(jobId, options);
     this.context.logger.info('job_apply', { jobId: jobId.toString(), receipt });
     return receipt;
   }
 
-  async submitJob(jobId: bigint, options?: JobActionOptions): Promise<JobActionReceipt> {
+  async submitJob(
+    jobId: bigint,
+    options?: JobActionOptions
+  ): Promise<JobActionReceipt> {
     const receipt = await this.jobLifecycle.submit(jobId, options);
-    this.context.logger.info('job_submit', { jobId: jobId.toString(), receipt });
+    this.context.logger.info('job_submit', {
+      jobId: jobId.toString(),
+      receipt,
+    });
     return receipt;
   }
 
-  async finalizeJob(jobId: bigint, options?: JobActionOptions): Promise<JobActionReceipt> {
+  async finalizeJob(
+    jobId: bigint,
+    options?: JobActionOptions
+  ): Promise<JobActionReceipt> {
     const receipt = await this.jobLifecycle.finalize(jobId, options);
-    this.context.logger.info('job_finalize', { jobId: jobId.toString(), receipt });
+    this.context.logger.info('job_finalize', {
+      jobId: jobId.toString(),
+      receipt,
+    });
     return receipt;
   }
 
-  async runJobCycle(jobId: bigint, options?: JobActionOptions): Promise<JobCycleReport> {
+  async runJobCycle(
+    jobId: bigint,
+    options?: JobActionOptions
+  ): Promise<JobCycleReport> {
     const report = await this.jobLifecycle.run(jobId, options);
     this.context.logger.info('job_cycle', { jobId: jobId.toString(), report });
     return report;
   }
 
-  async autopilot(options?: JobActionOptions & JobDiscoveryOptions): Promise<AlphaNodeAutopilot> {
+  async autopilot(
+    options?: JobActionOptions & JobDiscoveryOptions
+  ): Promise<AlphaNodeAutopilot> {
     const discovered = await this.discoverJobs(options);
-    const opportunities = discovered.length > 0 ? this.toOpportunities(discovered) : defaultOpportunities();
+    const opportunities =
+      discovered.length > 0
+        ? this.toOpportunities(discovered)
+        : defaultOpportunities();
     const plan = this.plan(opportunities);
     const selectedJobId = plan.summary.selectedJobId;
-    const selectedJob = selectedJobId ? opportunities.find((job) => job.jobId === selectedJobId) : undefined;
+    const selectedJob = selectedJobId
+      ? opportunities.find((job) => job.jobId === selectedJobId)
+      : undefined;
     let execution: JobCycleReport | undefined;
     if (selectedJobId && selectedJob) {
       if (/^\d+$/u.test(selectedJobId)) {
@@ -173,11 +249,16 @@ export class AlphaNode {
           proof: options?.proof,
           resultUri: options?.resultUri,
           resultHash: options?.resultHash,
-          hashAlgorithm: options?.hashAlgorithm
+          hashAlgorithm: options?.hashAlgorithm,
         };
-        execution = await this.runJobCycle(BigInt(selectedJobId), executionOptions);
+        execution = await this.runJobCycle(
+          BigInt(selectedJobId),
+          executionOptions
+        );
       } else {
-        this.context.logger.warn('autopilot_skipped_non_numeric_job', { selectedJobId });
+        this.context.logger.warn('autopilot_skipped_non_numeric_job', {
+          selectedJobId,
+        });
       }
     }
     this.context.metrics.updateJobExecution(selectedJob?.reward);
@@ -188,7 +269,7 @@ export class AlphaNode {
       opportunities,
       plan,
       execution,
-      reinvestment
+      reinvestment,
     };
   }
 
@@ -197,13 +278,15 @@ export class AlphaNode {
     insights: SpecialistInsight[];
   } {
     const summary = this.planner.plan(opportunities);
-    const tags = opportunities.find((job) => job.jobId === summary.selectedJobId)?.tags ?? [];
+    const tags =
+      opportunities.find((job) => job.jobId === summary.selectedJobId)?.tags ??
+      [];
     const insights = this.orchestrator.dispatch(tags);
     this.context.metrics.updatePlanning(summary);
     this.context.logger.info('planning_cycle', {
       alphaScore: summary.alphaScore,
       selectedJobId: summary.selectedJobId,
-      insights
+      insights,
     });
     return { summary, insights };
   }
@@ -216,11 +299,13 @@ export class AlphaNode {
     return results;
   }
 
-  async heartbeat(opportunities: JobOpportunity[]): Promise<AlphaNodeHeartbeat> {
+  async heartbeat(
+    opportunities: JobOpportunity[]
+  ): Promise<AlphaNodeHeartbeat> {
     const [identity, stakeSnapshot, rewards] = await Promise.all([
       this.verifyIdentity(),
       fetchStakeSnapshot(this.context.signer, this.context.config),
-      this.collectRewards()
+      this.collectRewards(),
     ]);
 
     const plan = this.plan(opportunities);
@@ -233,8 +318,46 @@ export class AlphaNode {
       rewards,
       plan,
       stress,
-      reinvestment
+      reinvestment,
     };
+  }
+
+  async complianceAudit(
+    opportunities?: JobOpportunity[]
+  ): Promise<AlphaNodeComplianceReport> {
+    const jobs = opportunities ?? defaultOpportunities();
+    const [identity, stakeSnapshot, rewards, governance] = await Promise.all([
+      this.verifyIdentity(),
+      fetchStakeSnapshot(this.context.signer, this.context.config),
+      this.collectRewards(),
+      fetchGovernanceSnapshot(this.context.signer, this.context.config),
+    ]);
+
+    const plan = this.plan(jobs);
+    const stress = this.stressTest();
+    const reinvestment = await this.reinvest({ dryRun: true });
+
+    const report = computeComplianceReport({
+      identity,
+      stake: stakeSnapshot,
+      governance,
+      rewards,
+      plan,
+      stress,
+      reinvestment,
+    });
+
+    this.context.metrics.updateCompliance(report.score);
+    this.context.logger.info('compliance_audit', {
+      score: report.score,
+      dimensions: report.dimensions.map((dimension) => ({
+        label: dimension.label,
+        status: dimension.status,
+        score: dimension.score,
+      })),
+    });
+
+    return report;
   }
 }
 
@@ -261,3 +384,5 @@ export interface AlphaNodeAutopilot {
   readonly execution?: JobCycleReport;
   readonly reinvestment: ReinvestReport;
 }
+
+export type { AlphaNodeComplianceReport } from './utils/compliance';

--- a/demo/AGI-Alpha-Node-v0/src/server/httpServer.ts
+++ b/demo/AGI-Alpha-Node-v0/src/server/httpServer.ts
@@ -22,6 +22,11 @@ export async function startAlphaNodeServer(
     res.json(heartbeat);
   });
 
+  dashboardApp.get('/api/compliance', async (_req, res) => {
+    const report = await node.complianceAudit(defaultOpportunities());
+    res.json(report);
+  });
+
   dashboardApp.post('/api/plan', async (req, res) => {
     const jobs = (req.body?.jobs ?? []) as JobOpportunity[];
     const plan = node.plan(jobs);
@@ -42,4 +47,3 @@ export async function startAlphaNodeServer(
 
   return { dashboard: dashboardServer, metrics: metricsServer };
 }
-

--- a/demo/AGI-Alpha-Node-v0/src/utils/compliance.ts
+++ b/demo/AGI-Alpha-Node-v0/src/utils/compliance.ts
@@ -1,0 +1,202 @@
+import { IdentityVerificationResult } from '../identity/types';
+import { StakeSnapshot } from '../blockchain/staking';
+import { RewardSnapshot } from '../blockchain/rewards';
+import { SpecialistInsight } from '../ai/orchestrator';
+import { PlanningSummary } from '../ai/planner';
+import { StressTestResult } from '../ai/antifragile';
+import { ReinvestReport } from '../blockchain/reinvest';
+import { GovernanceSnapshot } from '../blockchain/governance';
+
+export type ComplianceStatus = 'pass' | 'warn' | 'fail';
+
+export interface ComplianceDimension {
+  readonly label: string;
+  readonly status: ComplianceStatus;
+  readonly score: number;
+  readonly notes: readonly string[];
+}
+
+export interface AlphaNodeComplianceReport {
+  readonly timestamp: string;
+  readonly score: number;
+  readonly dimensions: readonly ComplianceDimension[];
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(value, 1));
+}
+
+function determineStatus(
+  score: number,
+  failureCondition?: boolean
+): ComplianceStatus {
+  if (failureCondition) {
+    return 'fail';
+  }
+  if (score >= 0.85) {
+    return 'pass';
+  }
+  if (score >= 0.55) {
+    return 'warn';
+  }
+  return 'fail';
+}
+
+export interface ComplianceInputs {
+  readonly identity: IdentityVerificationResult;
+  readonly stake: StakeSnapshot;
+  readonly governance: GovernanceSnapshot;
+  readonly rewards: RewardSnapshot;
+  readonly plan: {
+    readonly summary: PlanningSummary;
+    readonly insights: readonly SpecialistInsight[];
+  };
+  readonly stress: readonly StressTestResult[];
+  readonly reinvestment: ReinvestReport;
+}
+
+export function computeComplianceReport(
+  inputs: ComplianceInputs
+): AlphaNodeComplianceReport {
+  const dimensions: ComplianceDimension[] = [];
+
+  const identityScore = inputs.identity.matches ? 1 : 0;
+  const identityNotes = inputs.identity.matches
+    ? ['ENS ownership, wrapper, and text attestations verified.']
+    : inputs.identity.reasons;
+  dimensions.push({
+    label: 'Identity',
+    status: determineStatus(identityScore),
+    score: identityScore,
+    notes: identityNotes,
+  });
+
+  const stakeAdequacy =
+    inputs.stake.currentStake >= inputs.stake.requiredStake ? 1 : 0;
+  const pausePenalty = inputs.stake.paused ? 0.2 : 0;
+  const stakingScore = clampScore(stakeAdequacy - pausePenalty);
+  const stakeNotes = [] as string[];
+  if (stakeAdequacy === 1) {
+    stakeNotes.push(
+      'Stake satisfies minimum requirements across platform, role, and registry.'
+    );
+  } else {
+    stakeNotes.push(
+      'Stake below required threshold. Execute staking command immediately.'
+    );
+  }
+  if (inputs.stake.paused) {
+    stakeNotes.push(
+      'SystemPause currently active. Investigate incident response runbook.'
+    );
+  }
+  if (!inputs.stake.registered) {
+    stakeNotes.push(
+      'Operator not registered in PlatformRegistry. Complete activation.'
+    );
+  }
+  dimensions.push({
+    label: 'Staking & Activation',
+    status: determineStatus(stakingScore, !inputs.stake.registered),
+    score: stakingScore,
+    notes: stakeNotes,
+  });
+
+  const governanceScore = clampScore(
+    (inputs.governance.operatorIsGovernance ? 1 : 0.4) -
+      (inputs.governance.operatorBlacklisted ? 0.6 : 0)
+  );
+  const governanceNotes: string[] = [];
+  if (inputs.governance.operatorIsGovernance) {
+    governanceNotes.push('Operator controls SystemPause governance.');
+  } else {
+    governanceNotes.push(
+      `SystemPause governed by ${inputs.governance.governance}. Consider multisig delegation.`
+    );
+  }
+  if (inputs.governance.operatorBlacklisted) {
+    governanceNotes.push(
+      'Operator is blacklisted. Submit reinstatement request.'
+    );
+  }
+  if (inputs.governance.paused) {
+    governanceNotes.push('System currently paused.');
+  }
+  dimensions.push({
+    label: 'Governance & Safety',
+    status: determineStatus(
+      governanceScore,
+      inputs.governance.operatorBlacklisted
+    ),
+    score: governanceScore,
+    notes: governanceNotes,
+  });
+
+  const rewardsPending = Number(inputs.rewards.pending) / 1e18;
+  const reinvestRatio =
+    inputs.reinvestment.thresholdWei > 0n
+      ? Number(inputs.reinvestment.pendingWei) /
+        Number(inputs.reinvestment.thresholdWei)
+      : 0;
+  const economyScore = clampScore(
+    Math.min(rewardsPending / 10, 1) * 0.4 + Math.min(reinvestRatio, 1) * 0.6
+  );
+  const economyNotes = [
+    `Pending rewards: ${rewardsPending.toFixed(4)} $AGIALPHA.`,
+    `Reinvestment readiness: ${(reinvestRatio * 100).toFixed(2)}%.`,
+  ];
+  if (!inputs.reinvestment.dryRun && inputs.reinvestment.stakedWei > 0n) {
+    economyNotes.push('Autonomous reinvestment executed this cycle.');
+  }
+  dimensions.push({
+    label: 'Economic Engine',
+    status: determineStatus(economyScore),
+    score: economyScore,
+    notes: economyNotes,
+  });
+
+  const stressPassed = inputs.stress.filter((result) => result.passed).length;
+  const stressScore = clampScore(
+    inputs.stress.length === 0 ? 0.5 : stressPassed / inputs.stress.length
+  );
+  const stressNotes = inputs.stress.map(
+    (result) =>
+      `${result.id}: ${result.passed ? 'PASS' : 'IMPROVE'} – ${result.notes}`
+  );
+  dimensions.push({
+    label: 'Antifragile Shell',
+    status: determineStatus(stressScore, stressScore < 0.4),
+    score: stressScore,
+    notes: stressNotes,
+  });
+
+  const plannerScore = clampScore(inputs.plan.summary.alphaScore / 10);
+  const hasJob = Boolean(inputs.plan.summary.selectedJobId);
+  const insightsPreview = inputs.plan.insights.slice(0, 3).map((insight) => {
+    const confidencePct = Math.round(insight.confidence * 100);
+    return `${insight.specialistId} (${confidencePct}%): ${insight.recommendedAction} – ${insight.contribution}`;
+  });
+  const intelligenceNotes = [
+    hasJob
+      ? `Selected job ${inputs.plan.summary.selectedJobId}.`
+      : 'Awaiting strategic job selection.',
+    `Alpha score ${inputs.plan.summary.alphaScore.toFixed(2)}.`,
+    ...insightsPreview,
+  ];
+  dimensions.push({
+    label: 'Strategic Intelligence',
+    status: determineStatus(plannerScore, !hasJob),
+    score: plannerScore,
+    notes: intelligenceNotes,
+  });
+
+  const score =
+    dimensions.reduce((acc, dimension) => acc + dimension.score, 0) /
+    dimensions.length;
+
+  return {
+    timestamp: new Date().toISOString(),
+    score: clampScore(score),
+    dimensions,
+  };
+}

--- a/demo/AGI-Alpha-Node-v0/test/alpha_node_demo.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/alpha_node_demo.test.ts
@@ -4,3 +4,4 @@ import './identity.test';
 import './antifragile.test';
 import './jobs.test';
 import './reinvest.test';
+import './compliance.test';

--- a/demo/AGI-Alpha-Node-v0/test/compliance.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/compliance.test.ts
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeComplianceReport,
+  ComplianceInputs,
+} from '../src/utils/compliance';
+
+const baseInputs: ComplianceInputs = {
+  identity: {
+    matches: true,
+    ensName: 'apollo.alpha.node.agi.eth',
+    nodehash: '0x0',
+    expectedOwner: '0x0000000000000000000000000000000000000001',
+    reasons: [],
+    resolution: {
+      owner: '0x0000000000000000000000000000000000000001',
+      wrapperOwner: '0x0000000000000000000000000000000000000001',
+      registrant: '0x0000000000000000000000000000000000000001',
+      expiry: Math.floor(Date.now() / 1000) + 86_400,
+      contentHash: null,
+      records: {
+        'agijobs:v2:node': '0x0000000000000000000000000000000000000001',
+      },
+    },
+  },
+  stake: {
+    currentStake: 5_000_000_000_000_000_000n,
+    requiredStake: 1_000_000_000_000_000_000n,
+    allowance: 10_000_000_000_000_000_000n,
+    tokenBalance: 20_000_000_000_000_000_000n,
+    registered: true,
+    paused: false,
+    minimums: {
+      global: 1_000_000_000_000_000_000n,
+      platformRole: 1_000_000_000_000_000_000n,
+      registry: 1_000_000_000_000_000_000n,
+      config: 1_000_000_000_000_000_000n,
+    },
+  },
+  governance: {
+    operator: '0x0000000000000000000000000000000000000001',
+    governance: '0x0000000000000000000000000000000000000001',
+    paused: false,
+    operatorIsGovernance: true,
+    operatorBlacklisted: false,
+  },
+  rewards: {
+    boostedStake: 5_000_000_000_000_000_000n,
+    cumulativePerToken: 0n,
+    checkpoint: 0n,
+    pending: 4_000_000_000_000_000_000n,
+    projectedDaily: '42.0',
+  },
+  plan: {
+    summary: {
+      selectedJobId: '123',
+      alphaScore: 8.6,
+      expectedValue: 7.2,
+      explorationScore: 1.1,
+      exploitationScore: 7.5,
+      curriculumDifficulty: 0.75,
+      consideredJobs: 3,
+    },
+    insights: [
+      {
+        specialistId: 'finance',
+        confidence: 0.92,
+        contribution: 'Capital markets strategist engaged.',
+        recommendedAction: 'engage',
+      },
+    ],
+  },
+  stress: [
+    { id: 'scenario-a', passed: true, severity: 3, notes: 'Nominal.' },
+    { id: 'scenario-b', passed: true, severity: 4, notes: 'Mitigated.' },
+  ],
+  reinvestment: {
+    dryRun: false,
+    thresholdWei: 2_000_000_000_000_000_000n,
+    pendingWei: 4_000_000_000_000_000_000n,
+    claimedWei: 4_000_000_000_000_000_000n,
+    stakedWei: 4_000_000_000_000_000_000n,
+    notes: ['Reinvested successfully.'],
+  },
+};
+
+test('compliance report generates high score for healthy node', () => {
+  const report = computeComplianceReport(baseInputs);
+  assert(report.score > 0.75);
+  const identity = report.dimensions.find(
+    (dimension) => dimension.label === 'Identity'
+  );
+  assert(identity?.status === 'pass');
+  const governance = report.dimensions.find(
+    (dimension) => dimension.label === 'Governance & Safety'
+  );
+  assert(governance?.status === 'pass');
+});
+
+test('governance risk downgrades scorecard', () => {
+  const healthy = computeComplianceReport(baseInputs);
+  const riskyReport = computeComplianceReport({
+    ...baseInputs,
+    identity: { ...baseInputs.identity, matches: false, reasons: ['Mismatch'] },
+    governance: {
+      ...baseInputs.governance,
+      operatorIsGovernance: false,
+      operatorBlacklisted: true,
+      governance: '0x0000000000000000000000000000000000000002',
+    },
+  });
+  const governance = riskyReport.dimensions.find(
+    (dimension) => dimension.label === 'Governance & Safety'
+  );
+  assert(governance?.status === 'fail');
+  assert(riskyReport.score < healthy.score);
+});

--- a/demo/AGI-Alpha-Node-v0/web/index.html
+++ b/demo/AGI-Alpha-Node-v0/web/index.html
@@ -4,10 +4,14 @@
     <meta charset="utf-8" />
     <title>AGI Alpha Node Operator Console</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/chakra-ui-css-reset@2.0.0/dist/reset.min.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/chakra-ui-css-reset@2.0.0/dist/reset.min.css"
+    />
     <style>
       body {
-        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
+          'Segoe UI', sans-serif;
         background: radial-gradient(circle at 10% 20%, #020617, #0f172a);
         color: #e2e8f0;
         padding: 2rem;
@@ -66,9 +70,16 @@
       mermaid.initialize({ startOnLoad: true, theme: 'dark' });
 
       async function fetchHeartbeat() {
-        const response = await fetch('/api/heartbeat');
-        const data = await response.json();
-        renderHeartbeat(data);
+        const [heartbeatResponse, complianceResponse] = await Promise.all([
+          fetch('/api/heartbeat'),
+          fetch('/api/compliance'),
+        ]);
+        const [heartbeat, compliance] = await Promise.all([
+          heartbeatResponse.json(),
+          complianceResponse.json(),
+        ]);
+        renderHeartbeat(heartbeat);
+        renderCompliance(compliance);
       }
 
       function renderHeartbeat(data) {
@@ -104,7 +115,9 @@
           </div>
           <div class="metrics">
             <span>Status</span>
-            <strong>${identity.matches ? '✅ Verified' : '⚠️ Attention required'}</strong>
+            <strong>${
+              identity.matches ? '✅ Verified' : '⚠️ Attention required'
+            }</strong>
           </div>
         `;
         document.getElementById('planning').innerHTML = `
@@ -121,15 +134,52 @@
         document.getElementById('treasury').innerHTML = `
           <div class="metrics">
             <span>Pending → Threshold</span>
-            <strong>${formatEther(reinvestment.pendingWei)} / ${formatEther(reinvestment.thresholdWei)} $AGIALPHA</strong>
+            <strong>${formatEther(reinvestment.pendingWei)} / ${formatEther(
+          reinvestment.thresholdWei
+        )} $AGIALPHA</strong>
           </div>
           <div class="metrics">
             <span>Last Action</span>
-            <strong>${reinvestment.dryRun ? 'Dry Run' : formatEther(reinvestment.stakedWei) + ' staked'}</strong>
+            <strong>${
+              reinvestment.dryRun
+                ? 'Dry Run'
+                : formatEther(reinvestment.stakedWei) + ' staked'
+            }</strong>
           </div>
           <pre>${JSON.stringify(reinvestment.notes, null, 2)}</pre>
         `;
-        document.getElementById('stress').textContent = JSON.stringify(data.stress, null, 2);
+        document.getElementById('stress').textContent = JSON.stringify(
+          data.stress,
+          null,
+          2
+        );
+      }
+
+      function renderCompliance(report) {
+        const score = (report.score * 100).toFixed(1);
+        const listItems = report.dimensions
+          .map(
+            (dimension) => `
+              <li>
+                <strong>${
+                  dimension.label
+                }</strong> — ${dimension.status.toUpperCase()} (${(
+              dimension.score * 100
+            ).toFixed(0)}%)
+                <ul>
+                  ${dimension.notes.map((note) => `<li>${note}</li>`).join('')}
+                </ul>
+              </li>
+            `
+          )
+          .join('');
+        document.getElementById('compliance').innerHTML = `
+          <div class="metrics">
+            <span>Composite Score</span>
+            <strong>${score}%</strong>
+          </div>
+          <ol>${listItems}</ol>
+        `;
       }
 
       function formatEther(value) {
@@ -137,13 +187,18 @@
         return Number(bigInt) / 1e18;
       }
 
-      document.getElementById('refresh').addEventListener('click', fetchHeartbeat);
+      document
+        .getElementById('refresh')
+        .addEventListener('click', fetchHeartbeat);
       fetchHeartbeat();
     </script>
   </head>
   <body>
     <h1>AGI Alpha Node Operator Console</h1>
-    <p>Command the most economically potent AGI node ever assembled. Identity locked, capital fortified, AI swarm engaged.</p>
+    <p>
+      Command the most economically potent AGI node ever assembled. Identity
+      locked, capital fortified, AI swarm engaged.
+    </p>
     <button id="refresh">Refresh Heartbeat</button>
     <div class="grid">
       <div class="card" id="stake"></div>
@@ -151,24 +206,20 @@
       <div class="card" id="identity"></div>
       <div class="card" id="planning"></div>
       <div class="card" id="treasury"></div>
+      <div class="card" id="compliance"></div>
     </div>
-    <div class="card" style="margin-top: 1.5rem;">
+    <div class="card" style="margin-top: 1.5rem">
       <h2>Stress Diagnostics</h2>
       <pre id="stress"></pre>
     </div>
-    <div class="card" style="margin-top: 1.5rem;">
+    <div class="card" style="margin-top: 1.5rem">
       <h2>Alpha Mesh</h2>
       <div class="mermaid">
-        graph LR
-          Operator((Operator)) --> Dashboard
-          Dashboard --> Planner
-          Planner --> Finance[Finance Strategist]
-          Planner --> Biotech[Biotech Synthesist]
-          Planner --> Manufacturing[Manufacturing Oracle]
-          Finance --> Rewards
-          Biotech --> Rewards
-          Manufacturing --> Rewards
-          Rewards --> Treasury[(Treasury Growth)]
+        graph LR Operator((Operator)) --> Dashboard Dashboard --> Planner
+        Planner --> Finance[Finance Strategist] Planner --> Biotech[Biotech
+        Synthesist] Planner --> Manufacturing[Manufacturing Oracle] Finance -->
+        Rewards Biotech --> Rewards Manufacturing --> Rewards Rewards -->
+        Treasury[(Treasury Growth)]
       </div>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- add governance snapshot utility and compliance scoring engine for AGI Alpha Node
- surface compliance scorecard via CLI, REST API, metrics, dashboard, and documentation updates
- extend automated tests to validate compliance scoring behaviour

## Testing
- npm run build:agi-alpha-node
- npm run test:agi-alpha-node
- node -e "const compliance = require('./demo/AGI-Alpha-Node-v0/dist/utils/compliance'); console.log('complianceKeys', Object.keys(compliance));"

------
https://chatgpt.com/codex/tasks/task_e_69010ddd997483339330c9069e9cfb95