### PR TITLE
feat: add owner governance alignment workflow to AGI Alpha Node demo

### DIFF
--- a/demo/AGI-Alpha-Node-v0/README.md
+++ b/demo/AGI-Alpha-Node-v0/README.md
@@ -125,6 +125,7 @@ pie showData
 - Run `npm run demo:agi-alpha-node -- compliance --config <file>` to print the machine-readable scorecard.
 - Open the Operator Console (`npm run demo:agi-alpha-node -- dashboard ...`) to view the score in real time, including detailed notes per dimension.
 - Monitor `agi_alpha_node_compliance_score` in Prometheus to enforce institutional SLAs or trigger automated playbooks.
+- Inspect `agi_alpha_node_owner_alignment` to confirm the owner-governed parameters match the desired policy or trigger governance remediation.
 
 The scorecard defaults to optimistic-but-skeptical scoring. Any governance risk (e.g. blacklisting) produces a hard failure, while soft drifts (e.g. paused state) trigger alerts without interrupting operations. This ensures the operator can demonstrate proactive control to regulators, auditors, and institutional partners.
 
@@ -174,6 +175,11 @@ The scorecard defaults to optimistic-but-skeptical scoring. Any governance risk 
    npm run demo:agi-alpha-node -- treasury reinvest --dry-run --config my-alpha-node.json
    ```
    Remove `--dry-run` to claim and restake rewards when you are satisfied with the preview. Use `--amount 3500` to override the automatic threshold in $AGIALPHA.
+7. **Sync owner-governed parameters**
+   ```bash
+   npm run demo:agi-alpha-node -- owner configure --config my-alpha-node.json
+   ```
+   The command defaults to a dry run. Append `--execute` once you are ready to broadcast the multisig-grade transactions that align StakeManager and IdentityRegistry with your configuration.
 
 > **Safety rails:** All scripts honour the `SystemPause` contract. If any invariants fail (stake shortfall, ENS mismatch, validator dispute), the node pauses itself and guides the operator through remediation.
 
@@ -188,6 +194,7 @@ The scorecard defaults to optimistic-but-skeptical scoring. Any governance risk 
 - **Institutional observability** – Prometheus, OpenTelemetry, and compliance-grade action logs are enabled out of the box.
 - **Self-documenting** – every CLI command emits Markdown, JSON, and Mermaid summaries so that regulators and auditors can reconstruct the node state instantly.
 - **Trustless job autopilot** – the node now speaks directly to JobRegistry, auto-discovers ENS-gated jobs, dry-runs them by default, and can pause/resume the entire platform through SystemPause with a single command.
+- **Owner dominion alignment** – `owner configure` continuously reconciles StakeManager and IdentityRegistry parameters with your JSON policy, emits call data for audit trails, and surfaces an `agi_alpha_node_owner_alignment` metric.
 
 ---
 
@@ -205,6 +212,7 @@ The scorecard defaults to optimistic-but-skeptical scoring. Any governance risk 
 | `npm run demo:agi-alpha-node -- jobs discover --config <file>`              | Query JobRegistry for ENS-authenticated opportunities (dry-run safe).          |
 | `npm run demo:agi-alpha-node -- jobs autopilot --config <file> [--dry-run]` | Discover → plan → (optionally) execute the richest job end-to-end.             |
 | `npm run demo:agi-alpha-node -- jobs submit <jobId> --result-uri <uri>`     | Deliver results to JobRegistry with deterministic hashing.                     |
+| `npm run demo:agi-alpha-node -- owner configure --config <file> [--execute]`| Align owner-governed contract parameters; defaults to safe dry-run planning.    |
 | `npm run demo:agi-alpha-node -- owner pause --config <file>`                | Invoke `SystemPause.pauseAll()` with governance safety checks.                 |
 | `npm run demo:agi-alpha-node -- owner resume --config <file>`               | Resume execution across StakeManager, JobRegistry, FeePool, and peers.         |
 

--- a/demo/AGI-Alpha-Node-v0/config/mainnet.guide.json
+++ b/demo/AGI-Alpha-Node-v0/config/mainnet.guide.json
@@ -89,6 +89,15 @@
   "governance": {
     "systemPauseGuardian": "0x8888888888888888888888888888888888888888"
   },
+  "ownerControls": {
+    "stakeManager": {
+      "minStake": "15000"
+    },
+    "identityRegistry": {
+      "nodeRootEns": "alpha.node.agi.eth",
+      "nodeRootHash": "0x2d936bd2c82bc0aaa072a9d3c6d87aad1c1ec6a245f991129efb6ecc9fed57c4"
+    }
+  },
   "monitoring": {
     "metricsPort": 4317,
     "dashboardPort": 4318,

--- a/demo/AGI-Alpha-Node-v0/config/schema.json
+++ b/demo/AGI-Alpha-Node-v0/config/schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AGI Alpha Node Configuration",
   "type": "object",
-  "required": ["operator", "network", "contracts", "ai", "monitoring"],
+  "required": ["operator", "network", "contracts", "ai", "governance", "monitoring"],
   "properties": {
     "operator": {
       "type": "object",
@@ -124,6 +124,38 @@
               }
             }
           }
+        }
+      }
+    },
+    "governance": {
+      "type": "object",
+      "required": ["systemPauseGuardian"],
+      "properties": {
+        "systemPauseGuardian": {"type": "string", "pattern": "^0x[a-fA-F0-9]{40}$"}
+      }
+    },
+    "ownerControls": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "stakeManager": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "minStake": {"type": "string", "pattern": "^\\d+(\\.\\d+)?$"}
+          }
+        },
+        "identityRegistry": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "nodeRootEns": {"type": "string", "minLength": 3},
+            "nodeRootHash": {"type": "string", "pattern": "^0x[a-fA-F0-9]{64}$"}
+          },
+          "anyOf": [
+            {"required": ["nodeRootEns"]},
+            {"required": ["nodeRootHash"]}
+          ]
         }
       }
     },

--- a/demo/AGI-Alpha-Node-v0/src/blockchain/ownerControl.ts
+++ b/demo/AGI-Alpha-Node-v0/src/blockchain/ownerControl.ts
@@ -1,0 +1,291 @@
+import { Wallet, Interface, formatEther } from 'ethers';
+import { NormalisedAlphaNodeConfig } from '../config';
+import {
+  connectIdentityRegistry,
+  connectStakeManager,
+} from './contracts';
+import stakeManagerAbi from '../../../../scripts/v2/lib/prebuilt/StakeManager.json';
+import identityRegistryAbi from '../../../../scripts/v2/lib/prebuilt/IdentityRegistry.json';
+
+const STAKE_MANAGER_INTERFACE = new Interface(stakeManagerAbi.abi);
+const IDENTITY_REGISTRY_INTERFACE = new Interface(identityRegistryAbi.abi);
+
+export interface OwnerControlSnapshot {
+  readonly minStakeWei?: string;
+  readonly nodeRootHash?: string;
+}
+
+export interface OwnerControlActionPlan {
+  readonly target: 'stakeManager' | 'identityRegistry';
+  readonly method: string;
+  readonly description: string;
+  readonly current: string;
+  readonly desired: string;
+  readonly data: string;
+  readonly critical: boolean;
+}
+
+export interface OwnerControlPlan {
+  readonly current: OwnerControlSnapshot;
+  readonly desired: OwnerControlSnapshot;
+  readonly actions: readonly OwnerControlActionPlan[];
+  readonly notes: readonly string[];
+}
+
+export interface OwnerControlActionExecution {
+  readonly target: OwnerControlActionPlan['target'];
+  readonly method: string;
+  readonly hash?: string;
+  readonly description: string;
+}
+
+export interface OwnerControlExecutionReport extends OwnerControlPlan {
+  readonly dryRun: boolean;
+  readonly executed: readonly OwnerControlActionExecution[];
+  readonly remainingActions: readonly OwnerControlActionPlan[];
+}
+
+export interface OwnerControlOptions {
+  readonly dryRun?: boolean;
+}
+
+export interface OwnerControlDependencies {
+  readonly connectStakeManager?: typeof connectStakeManager;
+  readonly connectIdentityRegistry?: typeof connectIdentityRegistry;
+}
+
+interface OwnerContractsContext {
+  readonly stakeManager: ReturnType<typeof connectStakeManager>;
+  readonly identityRegistry: ReturnType<typeof connectIdentityRegistry>;
+  readonly minStake?: bigint;
+  readonly nodeRoot?: string;
+  readonly notes: string[];
+}
+
+function formatStake(value?: bigint): string {
+  if (value === undefined) {
+    return 'unavailable';
+  }
+  const ether = Number(formatEther(value));
+  const pretty = Number.isFinite(ether)
+    ? ether.toLocaleString(undefined, { maximumFractionDigits: 4 })
+    : value.toString();
+  return `${pretty} $AGIALPHA (${value.toString()} wei)`;
+}
+
+function formatNodeRoot(value?: string): string {
+  if (!value) {
+    return 'unavailable';
+  }
+  return value;
+}
+
+async function connectOwnerContracts(
+  signer: Wallet,
+  config: NormalisedAlphaNodeConfig,
+  dependencies?: OwnerControlDependencies
+): Promise<OwnerContractsContext> {
+  const stakeManagerConnector =
+    dependencies?.connectStakeManager ?? connectStakeManager;
+  const identityRegistryConnector =
+    dependencies?.connectIdentityRegistry ?? connectIdentityRegistry;
+  const stakeManager = stakeManagerConnector(
+    config.contracts.stakeManager,
+    signer
+  );
+  const identityRegistry = identityRegistryConnector(
+    config.contracts.identityRegistry,
+    signer
+  );
+
+  const notes: string[] = [];
+  let minStake: bigint | undefined;
+  try {
+    const value = await stakeManager.minStake();
+    minStake = BigInt(value);
+  } catch (error) {
+    notes.push(
+      `Unable to fetch StakeManager.minStake: ${(error as Error).message}`
+    );
+  }
+
+  let nodeRoot: string | undefined;
+  try {
+    const value = await identityRegistry.nodeRootNode();
+    nodeRoot = String(value);
+  } catch (error) {
+    notes.push(
+      `Unable to fetch IdentityRegistry.nodeRootNode: ${(error as Error).message}`
+    );
+  }
+
+  return { stakeManager, identityRegistry, minStake, nodeRoot, notes };
+}
+
+export async function planOwnerControls(
+  signer: Wallet,
+  config: NormalisedAlphaNodeConfig,
+  dependencies?: OwnerControlDependencies
+): Promise<OwnerControlPlan> {
+  const context = await connectOwnerContracts(signer, config, dependencies);
+  const desiredMinStake = config.ownerControls?.stakeManager?.minStakeWei;
+  const desiredNodeRoot = config.ownerControls?.identityRegistry?.nodeRootHash;
+
+  const desired: OwnerControlSnapshot = {
+    minStakeWei: desiredMinStake?.toString(),
+    nodeRootHash: desiredNodeRoot,
+  };
+  const current: OwnerControlSnapshot = {
+    minStakeWei: context.minStake?.toString(),
+    nodeRootHash: context.nodeRoot,
+  };
+
+  const notes = [...context.notes];
+  if (desiredMinStake === undefined) {
+    notes.push('StakeManager minStake left manual by owner configuration.');
+  }
+  if (!desiredNodeRoot) {
+    notes.push('IdentityRegistry node root left manual by owner configuration.');
+  }
+
+  const actions: OwnerControlActionPlan[] = [];
+
+  if (
+    desiredMinStake !== undefined &&
+    context.minStake !== undefined &&
+    desiredMinStake !== context.minStake
+  ) {
+    actions.push({
+      target: 'stakeManager',
+      method: 'setMinStake',
+      description: `Align StakeManager.minStake from ${formatStake(
+        context.minStake
+      )} to ${formatStake(desiredMinStake)}.`,
+      current: formatStake(context.minStake),
+      desired: formatStake(desiredMinStake),
+      data: STAKE_MANAGER_INTERFACE.encodeFunctionData('setMinStake', [
+        desiredMinStake,
+      ]),
+      critical: false,
+    });
+  }
+
+  if (desiredMinStake !== undefined && context.minStake === undefined) {
+    notes.push('Unable to read current minStake; manual verification required.');
+  }
+
+  if (desiredNodeRoot) {
+    if (!context.nodeRoot) {
+      actions.push({
+        target: 'identityRegistry',
+        method: 'setNodeRootNode',
+        description:
+          'Set IdentityRegistry node root to configured ENS hierarchy.',
+        current: formatNodeRoot(context.nodeRoot),
+        desired: desiredNodeRoot,
+        data: IDENTITY_REGISTRY_INTERFACE.encodeFunctionData(
+          'setNodeRootNode',
+          [desiredNodeRoot]
+        ),
+        critical: true,
+      });
+    } else if (desiredNodeRoot.toLowerCase() !== context.nodeRoot.toLowerCase()) {
+      actions.push({
+        target: 'identityRegistry',
+        method: 'setNodeRootNode',
+        description: `Rotate IdentityRegistry node root from ${context.nodeRoot} to ${desiredNodeRoot}.`,
+        current: context.nodeRoot,
+        desired: desiredNodeRoot,
+        data: IDENTITY_REGISTRY_INTERFACE.encodeFunctionData(
+          'setNodeRootNode',
+          [desiredNodeRoot]
+        ),
+        critical: true,
+      });
+    }
+  }
+
+  if (desiredNodeRoot && context.nodeRoot === undefined) {
+    notes.push('Unable to read current node root; manual verification required.');
+  }
+
+  if (actions.length === 0) {
+    notes.push('All owner-governed parameters aligned with configuration.');
+  } else {
+    notes.push('Owner action required to align governance parameters.');
+  }
+
+  return {
+    current,
+    desired,
+    actions,
+    notes,
+  };
+}
+
+export async function applyOwnerControls(
+  signer: Wallet,
+  config: NormalisedAlphaNodeConfig,
+  options?: OwnerControlOptions,
+  dependencies?: OwnerControlDependencies
+): Promise<OwnerControlExecutionReport> {
+  const initialPlan = await planOwnerControls(signer, config, dependencies);
+  const dryRun = options?.dryRun ?? true;
+  const executed: OwnerControlActionExecution[] = [];
+
+  if (!dryRun && initialPlan.actions.length > 0) {
+    const context = await connectOwnerContracts(signer, config, dependencies);
+
+    for (const action of initialPlan.actions) {
+      if (action.target === 'stakeManager') {
+        const desired = config.ownerControls?.stakeManager?.minStakeWei;
+        if (desired === undefined) {
+          continue;
+        }
+        const tx = await context.stakeManager.setMinStake(desired);
+        const receipt = await tx.wait();
+        executed.push({
+          target: action.target,
+          method: action.method,
+          hash: tx.hash,
+          description: `${action.description} (confirmed in block ${receipt.blockNumber}).`,
+        });
+      } else if (action.target === 'identityRegistry') {
+        const desired = config.ownerControls?.identityRegistry?.nodeRootHash;
+        if (!desired) {
+          continue;
+        }
+        const tx = await context.identityRegistry.setNodeRootNode(desired);
+        const receipt = await tx.wait();
+        executed.push({
+          target: action.target,
+          method: action.method,
+          hash: tx.hash,
+          description: `${action.description} (confirmed in block ${receipt.blockNumber}).`,
+        });
+      }
+    }
+  }
+
+  const finalPlan = dryRun
+    ? initialPlan
+    : await planOwnerControls(signer, config, dependencies);
+
+  const notes = dryRun
+    ? [...initialPlan.notes, 'Dry run: owner parameters not modified.']
+    : [
+        ...initialPlan.notes,
+        ...finalPlan.notes,
+        `Executed ${executed.length} owner action(s).`,
+      ];
+
+  return {
+    current: finalPlan.current,
+    desired: finalPlan.desired,
+    actions: initialPlan.actions,
+    notes,
+    dryRun,
+    executed,
+    remainingActions: finalPlan.actions,
+  };
+}

--- a/demo/AGI-Alpha-Node-v0/src/cli.ts
+++ b/demo/AGI-Alpha-Node-v0/src/cli.ts
@@ -435,6 +435,32 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
+    'owner configure',
+    'Align owner-controlled contract parameters with the configuration',
+    (cmd) =>
+      cmd
+        .option('config', {
+          type: 'string',
+          default: 'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json',
+        })
+        .option('execute', {
+          type: 'boolean',
+          default: false,
+          describe:
+            'Broadcast transactions instead of dry-run planning. Defaults to dry run for safety.',
+        }),
+    async (args) => {
+      const node = await AlphaNode.fromConfig(
+        args.config as string,
+        requirePrivateKey()
+      );
+      const report = await node.ownerConfigure({
+        dryRun: !Boolean(args.execute),
+      });
+      console.log(JSON.stringify(report, null, 2));
+    }
+  )
+  .command(
     'owner pause',
     'Pause all core modules via SystemPause',
     (cmd) =>

--- a/demo/AGI-Alpha-Node-v0/src/index.ts
+++ b/demo/AGI-Alpha-Node-v0/src/index.ts
@@ -10,4 +10,5 @@ export * from './monitoring/metrics';
 export * from './blockchain/staking';
 export * from './blockchain/rewards';
 export * from './blockchain/governance';
+export * from './blockchain/ownerControl';
 export * from './utils/compliance';

--- a/demo/AGI-Alpha-Node-v0/src/monitoring/metrics.ts
+++ b/demo/AGI-Alpha-Node-v0/src/monitoring/metrics.ts
@@ -17,6 +17,7 @@ export class AlphaNodeMetrics {
   private readonly reinvestAmountGauge: Gauge<string>;
   private readonly reinvestReadinessGauge: Gauge<string>;
   private readonly complianceGauge: Gauge<string>;
+  private readonly ownerAlignmentGauge: Gauge<string>;
 
   constructor() {
     this.registry.setDefaultLabels({ component: 'agi-alpha-node' });
@@ -70,6 +71,11 @@ export class AlphaNodeMetrics {
       help: 'Composite compliance score across governance, staking, and intelligence (0-1).',
       registers: [this.registry],
     });
+    this.ownerAlignmentGauge = new Gauge({
+      name: 'agi_alpha_node_owner_alignment',
+      help: 'Owner configuration alignment (1 = parameters aligned, 0 = drift detected).',
+      registers: [this.registry],
+    });
   }
 
   updateStake(snapshot: StakeSnapshot): void {
@@ -121,6 +127,10 @@ export class AlphaNodeMetrics {
 
   updateCompliance(score: number): void {
     this.complianceGauge.set(score);
+  }
+
+  updateOwnerAlignment(aligned: boolean): void {
+    this.ownerAlignmentGauge.set(aligned ? 1 : 0);
   }
 
   async render(): Promise<string> {

--- a/demo/AGI-Alpha-Node-v0/src/server/httpServer.ts
+++ b/demo/AGI-Alpha-Node-v0/src/server/httpServer.ts
@@ -27,6 +27,11 @@ export async function startAlphaNodeServer(
     res.json(report);
   });
 
+  dashboardApp.get('/api/owner-plan', async (_req, res) => {
+    const plan = await node.ownerControlPlan();
+    res.json(plan);
+  });
+
   dashboardApp.post('/api/plan', async (req, res) => {
     const jobs = (req.body?.jobs ?? []) as JobOpportunity[];
     const plan = node.plan(jobs);

--- a/demo/AGI-Alpha-Node-v0/test/alpha_node_demo.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/alpha_node_demo.test.ts
@@ -5,3 +5,4 @@ import './antifragile.test';
 import './jobs.test';
 import './reinvest.test';
 import './compliance.test';
+import './owner_control.test';

--- a/demo/AGI-Alpha-Node-v0/test/compliance.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/compliance.test.ts
@@ -5,6 +5,19 @@ import {
   ComplianceInputs,
 } from '../src/utils/compliance';
 
+const ownerAlignedPlan = {
+  current: {
+    minStakeWei: (5_000_000_000_000_000_000n).toString(),
+    nodeRootHash: '0x2d936bd2c82bc0aaa072a9d3c6d87aad1c1ec6a245f991129efb6ecc9fed57c4',
+  },
+  desired: {
+    minStakeWei: (5_000_000_000_000_000_000n).toString(),
+    nodeRootHash: '0x2d936bd2c82bc0aaa072a9d3c6d87aad1c1ec6a245f991129efb6ecc9fed57c4',
+  },
+  actions: [],
+  notes: ['All owner-governed parameters aligned with configuration.'],
+} as const;
+
 const baseInputs: ComplianceInputs = {
   identity: {
     matches: true,
@@ -82,6 +95,7 @@ const baseInputs: ComplianceInputs = {
     stakedWei: 4_000_000_000_000_000_000n,
     notes: ['Reinvested successfully.'],
   },
+  owner: ownerAlignedPlan,
 };
 
 test('compliance report generates high score for healthy node', () => {
@@ -107,6 +121,21 @@ test('governance risk downgrades scorecard', () => {
       operatorIsGovernance: false,
       operatorBlacklisted: true,
       governance: '0x0000000000000000000000000000000000000002',
+    },
+    owner: {
+      ...ownerAlignedPlan,
+      actions: [
+        {
+          target: 'identityRegistry',
+          method: 'setNodeRootNode',
+          description: 'Rotate IdentityRegistry node root to safe guardian.',
+          current: ownerAlignedPlan.current.nodeRootHash ?? '0x0',
+          desired: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          data: '0xdeadbeef',
+          critical: true,
+        },
+      ],
+      notes: ['Owner action required to restore node root authority.'],
     },
   });
   const governance = riskyReport.dimensions.find(

--- a/demo/AGI-Alpha-Node-v0/test/config.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/config.test.ts
@@ -15,4 +15,13 @@ test('loads and normalises alpha node config', async () => {
   assert.equal(config.jobs.execution.resultHashAlgorithm, 'keccak256');
   assert.equal(config.jobs.identityProof.length, 0);
   assert.equal(config.governance.systemPauseGuardian, '0x8888888888888888888888888888888888888888');
+  assert(config.ownerControls);
+  assert.equal(
+    config.ownerControls?.stakeManager?.minStakeWei,
+    BigInt('15000') * 10n ** 18n
+  );
+  assert.equal(
+    config.ownerControls?.identityRegistry?.nodeRootHash,
+    '0x2d936bd2c82bc0aaa072a9d3c6d87aad1c1ec6a245f991129efb6ecc9fed57c4'
+  );
 });

--- a/demo/AGI-Alpha-Node-v0/test/owner_control.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/owner_control.test.ts
@@ -1,0 +1,158 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { Wallet } from 'ethers';
+import { loadAlphaNodeConfig } from '../src/config';
+import {
+  planOwnerControls,
+  applyOwnerControls,
+} from '../src/blockchain/ownerControl';
+
+const fixturePath = path.resolve('demo/AGI-Alpha-Node-v0/config/mainnet.guide.json');
+
+class FakeTx {
+  constructor(readonly hash: string) {}
+  async wait(): Promise<{ blockNumber: number }> {
+    return { blockNumber: 1200 };
+  }
+}
+
+class FakeStakeManager {
+  constructor(public minStakeValue: bigint) {}
+
+  async minStake(): Promise<bigint> {
+    return this.minStakeValue;
+  }
+
+  async setMinStake(value: bigint): Promise<FakeTx> {
+    this.minStakeValue = value;
+    return new FakeTx('0xstake');
+  }
+}
+
+class FakeIdentityRegistry {
+  constructor(public nodeRoot: string) {}
+
+  async nodeRootNode(): Promise<string> {
+    return this.nodeRoot;
+  }
+
+  async setNodeRootNode(value: string): Promise<FakeTx> {
+    this.nodeRoot = value;
+    return new FakeTx('0xroot');
+  }
+}
+
+function makeWallet(): Wallet {
+  const provider = {
+    async getBlockNumber(): Promise<number> {
+      return 4096;
+    },
+  } as any;
+  return new Wallet(
+    '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+    provider
+  );
+}
+
+async function withDependencies(
+  plan: (deps: {
+    stakeManager: FakeStakeManager;
+    identityRegistry: FakeIdentityRegistry;
+  }) => Promise<void>
+): Promise<void> {
+  const stakeManager = new FakeStakeManager(0n);
+  const identityRegistry = new FakeIdentityRegistry('0x' + '0'.repeat(64));
+  await plan({ stakeManager, identityRegistry });
+}
+
+test('planOwnerControls reports aligned configuration when no drift', async () => {
+  await withDependencies(async ({ stakeManager, identityRegistry }) => {
+    const config = await loadAlphaNodeConfig(fixturePath);
+    stakeManager.minStakeValue = config.ownerControls?.stakeManager?.minStakeWei ?? 0n;
+    identityRegistry.nodeRoot =
+      config.ownerControls?.identityRegistry?.nodeRootHash ??
+      '0x' + '0'.repeat(64);
+
+    const wallet = makeWallet();
+    const plan = await planOwnerControls(wallet, config, {
+      connectStakeManager: () => stakeManager as any,
+      connectIdentityRegistry: () => identityRegistry as any,
+    });
+
+    assert.equal(plan.actions.length, 0);
+    assert(plan.notes.some((note) => note.includes('aligned with configuration')));
+  });
+});
+
+test('planOwnerControls identifies drift and produces deterministic call data', async () => {
+  await withDependencies(async ({ stakeManager, identityRegistry }) => {
+    const config = await loadAlphaNodeConfig(fixturePath);
+    stakeManager.minStakeValue = 1n;
+    identityRegistry.nodeRoot = '0x' + 'f'.repeat(64);
+
+    const wallet = makeWallet();
+    const plan = await planOwnerControls(wallet, config, {
+      connectStakeManager: () => stakeManager as any,
+      connectIdentityRegistry: () => identityRegistry as any,
+    });
+
+    assert.equal(plan.actions.length, 2);
+    const stakeAction = plan.actions.find(
+      (action) => action.target === 'stakeManager'
+    );
+    const identityAction = plan.actions.find(
+      (action) => action.target === 'identityRegistry'
+    );
+    assert(stakeAction, 'expected stake action');
+    assert(identityAction, 'expected identity action');
+    assert(stakeAction!.data.startsWith('0x'));
+    assert(identityAction!.critical);
+  });
+});
+
+test('applyOwnerControls dry run retains planned actions', async () => {
+  await withDependencies(async ({ stakeManager, identityRegistry }) => {
+    const config = await loadAlphaNodeConfig(fixturePath);
+    stakeManager.minStakeValue = 0n;
+    identityRegistry.nodeRoot = '0x' + '1'.repeat(64);
+
+    const wallet = makeWallet();
+    const report = await applyOwnerControls(
+      wallet,
+      config,
+      { dryRun: true },
+      {
+        connectStakeManager: () => stakeManager as any,
+        connectIdentityRegistry: () => identityRegistry as any,
+      }
+    );
+
+    assert.equal(report.dryRun, true);
+    assert.equal(report.executed.length, 0);
+    assert.equal(report.actions.length, report.remainingActions.length);
+  });
+});
+
+test('applyOwnerControls executes and clears remaining actions', async () => {
+  await withDependencies(async ({ stakeManager, identityRegistry }) => {
+    const config = await loadAlphaNodeConfig(fixturePath);
+    stakeManager.minStakeValue = 0n;
+    identityRegistry.nodeRoot = '0x' + '2'.repeat(64);
+
+    const wallet = makeWallet();
+    const report = await applyOwnerControls(
+      wallet,
+      config,
+      { dryRun: false },
+      {
+        connectStakeManager: () => stakeManager as any,
+        connectIdentityRegistry: () => identityRegistry as any,
+      }
+    );
+
+    assert.equal(report.dryRun, false);
+    assert(report.executed.length >= 1);
+    assert.equal(report.remainingActions.length, 0);
+  });
+});

--- a/demo/AGI-Alpha-Node-v0/web/index.html
+++ b/demo/AGI-Alpha-Node-v0/web/index.html
@@ -88,6 +88,12 @@
         const plan = data.plan;
         const identity = data.identity;
         const reinvestment = data.reinvestment;
+        const ownerPlan = data.ownerPlan ?? {
+          actions: [],
+          notes: [],
+          desired: {},
+          current: {},
+        };
         document.getElementById('stake').innerHTML = `
           <div class="metrics">
             <span>Stake Target</span>
@@ -153,6 +159,31 @@
           null,
           2
         );
+        const ownerStatus = ownerPlan.actions.length === 0
+          ? '✅ Parameters aligned'
+          : ownerPlan.actions.some((action) => action.critical)
+          ? '🚨 Critical owner action required'
+          : '⚠️ Owner action recommended';
+        document.getElementById('owner').innerHTML = `
+          <div class="metrics">
+            <span>Owner Alignment</span>
+            <strong>${ownerStatus}</strong>
+          </div>
+          <div class="metrics">
+            <span>Actions Pending</span>
+            <strong>${ownerPlan.actions.length}</strong>
+          </div>
+          <pre>${JSON.stringify(
+            ownerPlan.actions.map((action) => ({
+              target: action.target,
+              method: action.method,
+              critical: action.critical,
+            })),
+            null,
+            2
+          )}</pre>
+          <pre>${JSON.stringify(ownerPlan.notes, null, 2)}</pre>
+        `;
       }
 
       function renderCompliance(report) {
@@ -207,6 +238,7 @@
       <div class="card" id="planning"></div>
       <div class="card" id="treasury"></div>
       <div class="card" id="compliance"></div>
+      <div class="card" id="owner"></div>
     </div>
     <div class="card" style="margin-top: 1.5rem">
       <h2>Stress Diagnostics</h2>


### PR DESCRIPTION
## Summary
- add an owner control planner/executor for StakeManager and IdentityRegistry settings, surface it through the CLI and REST API
- extend metrics, compliance, dashboard UI, and configuration docs to highlight owner alignment flows for non-technical operators
- cover the new behaviour with focused unit tests and update the quickstart to guide safe execution

## Testing
- `npm run build:agi-alpha-node`
- `npm run test:agi-alpha-node`


------
https://chatgpt.com/codex/tasks/task_e_69011714ce308333b5bc89d11a0707a0