### PR TITLE
Harden AGI Alpha Node financial telemetry

### DIFF
--- a/demo/AGI-Alpha-Node-v0/src/utils/amounts.ts
+++ b/demo/AGI-Alpha-Node-v0/src/utils/amounts.ts
@@ -1,0 +1,23 @@
+import { formatUnits } from 'ethers';
+
+function parseFloatSafe(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function weiToEtherNumber(value: bigint): number {
+  return parseFloatSafe(formatUnits(value, 18));
+}
+
+export function ratioFromWei(numerator: bigint, denominator: bigint): number {
+  if (denominator <= 0n) {
+    return 0;
+  }
+  const numeratorValue = weiToEtherNumber(numerator);
+  const denominatorValue = weiToEtherNumber(denominator);
+  if (!Number.isFinite(denominatorValue) || denominatorValue <= 0) {
+    return 0;
+  }
+  const ratio = numeratorValue / denominatorValue;
+  return Number.isFinite(ratio) ? ratio : 0;
+}

--- a/demo/AGI-Alpha-Node-v0/src/utils/compliance.ts
+++ b/demo/AGI-Alpha-Node-v0/src/utils/compliance.ts
@@ -6,6 +6,7 @@ import { PlanningSummary } from '../ai/planner';
 import { StressTestResult } from '../ai/antifragile';
 import { ReinvestReport } from '../blockchain/reinvest';
 import { GovernanceSnapshot } from '../blockchain/governance';
+import { ratioFromWei, weiToEtherNumber } from './amounts';
 
 export type ComplianceStatus = 'pass' | 'warn' | 'fail';
 
@@ -132,12 +133,11 @@ export function computeComplianceReport(
     notes: governanceNotes,
   });
 
-  const rewardsPending = Number(inputs.rewards.pending) / 1e18;
-  const reinvestRatio =
-    inputs.reinvestment.thresholdWei > 0n
-      ? Number(inputs.reinvestment.pendingWei) /
-        Number(inputs.reinvestment.thresholdWei)
-      : 0;
+  const rewardsPending = weiToEtherNumber(inputs.rewards.pending);
+  const reinvestRatio = ratioFromWei(
+    inputs.reinvestment.pendingWei,
+    inputs.reinvestment.thresholdWei
+  );
   const economyScore = clampScore(
     Math.min(rewardsPending / 10, 1) * 0.4 + Math.min(reinvestRatio, 1) * 0.6
   );

--- a/demo/AGI-Alpha-Node-v0/test/alpha_node_demo.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/alpha_node_demo.test.ts
@@ -5,3 +5,4 @@ import './antifragile.test';
 import './jobs.test';
 import './reinvest.test';
 import './compliance.test';
+import './amounts.test';

--- a/demo/AGI-Alpha-Node-v0/test/amounts.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/amounts.test.ts
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ratioFromWei, weiToEtherNumber } from '../src/utils/amounts';
+
+const ONE = 1_000_000_000_000_000_000n;
+
+test('weiToEtherNumber converts safely for very large values', () => {
+  const value = 25_000_000n * ONE; // 25 million ether equivalent
+  const converted = weiToEtherNumber(value);
+  assert.equal(converted, 25_000_000);
+});
+
+test('ratioFromWei handles zero denominator and clamps infinities', () => {
+  assert.equal(ratioFromWei(ONE, 0n), 0);
+  assert.equal(ratioFromWei(ONE, -ONE), 0);
+});
+
+test('ratioFromWei computes floating ratios using token precision', () => {
+  const numerator = 5n * ONE;
+  const denominator = 2n * ONE;
+  const ratio = ratioFromWei(numerator, denominator);
+  assert.ok(Math.abs(ratio - 2.5) < 1e-9);
+});


### PR DESCRIPTION
## Summary
- convert Alpha Node gauges and compliance scoring to use robust wei→$AGIALPHA conversions
- add reusable amount helpers and regression tests covering large balances and reward ratios
- extend demo test harness to exercise the new telemetry utilities

## Testing
- npm run build:agi-alpha-node
- npm run test:agi-alpha-node

------
https://chatgpt.com/codex/tasks/task_e_69011d524d408333b5f331e394ead3c6