### PR TITLE
Add MuZero++ horizon world model to AGI Alpha Node planner

### DIFF
--- a/demo/AGI-Alpha-Node-v0/README.md
+++ b/demo/AGI-Alpha-Node-v0/README.md
@@ -78,6 +78,31 @@ flowchart TD
 
 ---
 
+## MuZero++ World Model & Horizon Sequencer
+
+The v2 demo uplifts the planner into a **MuZero++-style world model** that continuously simulates job sequences, risk, and reward curves before any capital is deployed. The planner’s decisions are no longer single-step heuristics: every heartbeat now evaluates multi-step strategies with confidence metrics surfaced in the UI, metrics, and compliance layer.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Calibrate
+  Calibrate: Initialise success prior
+  Calibrate --> Simulate: ingest ENS-aligned opportunities
+  Simulate --> Score: propagate MuZero++ rollouts
+  Score --> Sequence: maximise risk-adjusted alpha horizon
+  Sequence --> EmitPlan: expose summary + confidence + sequence value
+  EmitPlan --> [*]
+  Simulate --> Stress: feed antifragile shell with projected shocks
+  Stress --> EmitPlan
+```
+
+- 🌌 **World-model confidence** (0-1) quantifies how aggressively the node can pursue horizon plans.
+- 🧭 **Horizon sequence** projects the optimal job execution order; surfaced in the dashboard and compliance scorecard.
+- 📈 **Horizon value** gauges risk-adjusted alpha yield over the configured planning horizon (default 6 moves).
+
+Every completed job feeds back into the world model, tightening uncertainty bands and escalating the curriculum automatically.
+
+---
+
 ## Treasury Autopilot
 
 ```mermaid

--- a/demo/AGI-Alpha-Node-v0/config/mainnet.guide.json
+++ b/demo/AGI-Alpha-Node-v0/config/mainnet.guide.json
@@ -72,6 +72,12 @@
         "treasury": 0.15,
         "specialists": 0.3
       }
+    },
+    "worldModel": {
+      "baselineSuccessRate": 0.72,
+      "volatility": 0.33,
+      "adaptationRate": 0.18,
+      "exploitationBias": 0.28
     }
   },
   "jobs": {

--- a/demo/AGI-Alpha-Node-v0/src/ai/worldModel.ts
+++ b/demo/AGI-Alpha-Node-v0/src/ai/worldModel.ts
@@ -1,0 +1,185 @@
+import { NormalisedAlphaNodeConfig } from '../config';
+import type { JobOpportunity } from './planner';
+
+export interface WorldModelForecast {
+  readonly jobId: string;
+  readonly successProbability: number;
+  readonly expectedReward: number;
+  readonly expectedCost: number;
+  readonly riskAdjustedValue: number;
+  readonly confidence: number;
+  readonly rationale: string;
+}
+
+export interface WorldModelSequence {
+  readonly jobIds: readonly string[];
+  readonly cumulativeValue: number;
+  readonly confidence: number;
+}
+
+interface WorldModelState {
+  readonly successRate: number;
+  readonly uncertainty: number;
+  readonly iterations: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) {
+    return min;
+  }
+  return Math.max(min, Math.min(max, value));
+}
+
+function scoreTagSynergy(tags: readonly string[]): number {
+  if (tags.length === 0) {
+    return 0.05;
+  }
+  const premiumTags = new Set([
+    'capital-markets',
+    'governance',
+    'biotech',
+    'manufacturing',
+    'energy-optimization',
+    'resilience',
+  ]);
+  const overlap = tags.filter((tag) => premiumTags.has(tag)).length;
+  return clamp(0.1 * overlap, 0, 0.35);
+}
+
+function describeForecast(forecast: WorldModelForecast): string {
+  const successPct = Math.round(forecast.successProbability * 100);
+  const confidencePct = Math.round(forecast.confidence * 100);
+  return `Success ${successPct}% @ confidence ${confidencePct}% → risk-adjusted ${forecast.riskAdjustedValue.toFixed(2)}`;
+}
+
+export class AlphaWorldModel {
+  private readonly params = this.config.ai.worldModel;
+  private state: WorldModelState = {
+    successRate: this.config.ai.worldModel.baselineSuccessRate,
+    uncertainty: 0.25,
+    iterations: 0,
+  };
+
+  constructor(private readonly config: NormalisedAlphaNodeConfig) {}
+
+  forecast(
+    job: JobOpportunity,
+    step = 0,
+    state: WorldModelState = this.state,
+  ): WorldModelForecast {
+    const synergyBonus = scoreTagSynergy(job.tags);
+    const demandSignal = 1 - job.difficulty + synergyBonus;
+    const successProbability = clamp(
+      state.successRate + this.params.adaptationRate * demandSignal - job.risk * this.params.volatility + step * 0.015,
+      0.05,
+      0.99,
+    );
+    const expectedReward = clamp(job.reward, 0, Number.POSITIVE_INFINITY) * successProbability;
+    const expectedCost = clamp(job.reward * (job.risk + 0.1) * this.params.volatility, 0, Number.POSITIVE_INFINITY);
+    const riskAdjustedValue = expectedReward - expectedCost + synergyBonus * this.params.exploitationBias * job.reward;
+    const confidence = clamp(1 - state.uncertainty - job.risk * 0.35 + synergyBonus, 0.05, 0.99);
+    return {
+      jobId: job.jobId,
+      successProbability,
+      expectedReward,
+      expectedCost,
+      riskAdjustedValue,
+      confidence,
+      rationale: describeForecast({
+        jobId: job.jobId,
+        successProbability,
+        expectedReward,
+        expectedCost,
+        riskAdjustedValue,
+        confidence,
+        rationale: '',
+      }),
+    };
+  }
+
+  evaluate(
+    opportunities: JobOpportunity[],
+    horizon: number,
+  ): {
+    readonly forecasts: Map<string, WorldModelForecast>;
+    readonly bestForecast?: WorldModelForecast;
+    readonly sequence: WorldModelSequence;
+  } {
+    const forecasts = new Map<string, WorldModelForecast>();
+    for (const job of opportunities) {
+      forecasts.set(job.jobId, this.forecast(job));
+    }
+    const ordered = [...forecasts.values()].sort(
+      (a, b) => b.riskAdjustedValue - a.riskAdjustedValue,
+    );
+    const bestForecast = ordered[0];
+    const sequence = this.planSequence(opportunities, horizon);
+    return { forecasts, bestForecast, sequence };
+  }
+
+  recordOutcome(_jobId: string, success: boolean, reward: number, difficulty: number): void {
+    const adjustment = success ? 1 : 0;
+    const rewardSignal = clamp(Math.log10(1 + Math.max(reward, 0)) / 6, 0, 0.35);
+    const blendedSuccess =
+      this.state.successRate * (1 - this.params.adaptationRate) +
+      adjustment * this.params.adaptationRate * (1 - difficulty * 0.2 + rewardSignal * 0.3);
+    const volatilityBump = success
+      ? -0.05 - rewardSignal * 0.15
+      : 0.07 + difficulty * 0.05 + rewardSignal * 0.08;
+    this.state = {
+      successRate: clamp(blendedSuccess, 0.05, 0.99),
+      uncertainty: clamp(this.state.uncertainty + volatilityBump, 0.05, 0.6),
+      iterations: this.state.iterations + 1,
+    };
+  }
+
+  private planSequence(opportunities: JobOpportunity[], horizon: number): WorldModelSequence {
+    const available = [...opportunities];
+    const sequence: string[] = [];
+    let cumulativeValue = 0;
+    let confidence = 1;
+    let state = { ...this.state };
+
+    for (let step = 0; step < horizon; step += 1) {
+      if (available.length === 0) {
+        break;
+      }
+      const forecasts = available.map((job) => this.forecast(job, step, state));
+      forecasts.sort((a, b) => b.riskAdjustedValue - a.riskAdjustedValue);
+      const selected = forecasts[0];
+      if (!selected || selected.riskAdjustedValue <= 0) {
+        break;
+      }
+      sequence.push(selected.jobId);
+      cumulativeValue += selected.riskAdjustedValue;
+      confidence = Math.min(confidence, selected.confidence);
+      state = this.simulateStep(state, selected);
+      const index = available.findIndex((job) => job.jobId === selected.jobId);
+      if (index >= 0) {
+        available.splice(index, 1);
+      }
+    }
+
+    return { jobIds: sequence, cumulativeValue, confidence };
+  }
+
+  private simulateStep(state: WorldModelState, forecast: WorldModelForecast): WorldModelState {
+    const successRate = clamp(
+      state.successRate * (1 - this.params.adaptationRate * 0.5) +
+        forecast.successProbability * this.params.adaptationRate,
+      0.05,
+      0.99,
+    );
+    const uncertainty = clamp(
+      state.uncertainty * (1 - this.params.adaptationRate * 0.4) +
+        (1 - forecast.confidence) * this.params.adaptationRate,
+      0.05,
+      0.65,
+    );
+    return {
+      successRate,
+      uncertainty,
+      iterations: state.iterations + 1,
+    };
+  }
+}

--- a/demo/AGI-Alpha-Node-v0/src/index.ts
+++ b/demo/AGI-Alpha-Node-v0/src/index.ts
@@ -3,6 +3,7 @@ export * from './node';
 export * from './ai/planner';
 export * from './ai/orchestrator';
 export * from './ai/antifragile';
+export * from './ai/worldModel';
 export * from './identity/types';
 export * from './identity/verify';
 export * from './identity/rpcLookup';

--- a/demo/AGI-Alpha-Node-v0/src/monitoring/metrics.ts
+++ b/demo/AGI-Alpha-Node-v0/src/monitoring/metrics.ts
@@ -13,6 +13,8 @@ export class AlphaNodeMetrics {
   private readonly rewardGauge: Gauge<string>;
   private readonly verificationGauge: Gauge<string>;
   private readonly plannerScoreGauge: Gauge<string>;
+  private readonly worldModelConfidenceGauge: Gauge<string>;
+  private readonly horizonValueGauge: Gauge<string>;
   private readonly jobOpenGauge: Gauge<string>;
   private readonly jobRewardGauge: Gauge<string>;
   private readonly reinvestAmountGauge: Gauge<string>;
@@ -44,6 +46,16 @@ export class AlphaNodeMetrics {
     this.plannerScoreGauge = new Gauge({
       name: 'agi_alpha_node_planner_score',
       help: 'Latest MuZero++ planner alpha score (unitless).',
+      registers: [this.registry],
+    });
+    this.worldModelConfidenceGauge = new Gauge({
+      name: 'agi_alpha_node_world_model_confidence',
+      help: 'Confidence emitted by the integrated world model (0-1).',
+      registers: [this.registry],
+    });
+    this.horizonValueGauge = new Gauge({
+      name: 'agi_alpha_node_planner_horizon_value',
+      help: 'Cumulative risk-adjusted value across the planning horizon.',
       registers: [this.registry],
     });
     this.jobOpenGauge = new Gauge({
@@ -92,6 +104,8 @@ export class AlphaNodeMetrics {
 
   updatePlanning(summary: PlanningSummary): void {
     this.plannerScoreGauge.set(summary.alphaScore);
+    this.worldModelConfidenceGauge.set(summary.worldModelConfidence);
+    this.horizonValueGauge.set(summary.horizonValue);
   }
 
   updateJobDiscovery(openJobs: number): void {

--- a/demo/AGI-Alpha-Node-v0/src/node.ts
+++ b/demo/AGI-Alpha-Node-v0/src/node.ts
@@ -292,6 +292,8 @@ export class AlphaNode {
     this.context.logger.info('planning_cycle', {
       alphaScore: summary.alphaScore,
       selectedJobId: summary.selectedJobId,
+      worldModelConfidence: summary.worldModelConfidence,
+      horizonSequence: summary.horizonSequence,
       insights,
     });
     return { summary, insights };

--- a/demo/AGI-Alpha-Node-v0/src/utils/compliance.ts
+++ b/demo/AGI-Alpha-Node-v0/src/utils/compliance.ts
@@ -181,6 +181,11 @@ export function computeComplianceReport(
       ? `Selected job ${inputs.plan.summary.selectedJobId}.`
       : 'Awaiting strategic job selection.',
     `Alpha score ${inputs.plan.summary.alphaScore.toFixed(2)}.`,
+    inputs.plan.summary.horizonSequence.length > 0
+      ? `Horizon sequence → ${inputs.plan.summary.horizonSequence.join(' → ')}`
+      : 'Horizon sequence awaiting confident opportunities.',
+    `World-model confidence ${(inputs.plan.summary.worldModelConfidence * 100).toFixed(1)}%.`,
+    `Projected horizon value ${inputs.plan.summary.horizonValue.toFixed(2)} alpha units.`,
     ...insightsPreview,
   ];
   dimensions.push({

--- a/demo/AGI-Alpha-Node-v0/test/alpha_node_demo.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/alpha_node_demo.test.ts
@@ -7,3 +7,4 @@ import './reinvest.test';
 import './compliance.test';
 import './amounts.test';
 import './governance.test';
+import './world_model.test';

--- a/demo/AGI-Alpha-Node-v0/test/compliance.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/compliance.test.ts
@@ -60,6 +60,20 @@ const baseInputs: ComplianceInputs = {
       exploitationScore: 7.5,
       curriculumDifficulty: 0.75,
       consideredJobs: 3,
+      worldModelConfidence: 0.92,
+      horizonSequence: ['123', '789'],
+      horizonValue: 12.4,
+      forecasts: [
+        {
+          jobId: '123',
+          successProbability: 0.9,
+          expectedReward: 10,
+          expectedCost: 1,
+          riskAdjustedValue: 9,
+          confidence: 0.92,
+          rationale: 'High confidence forecast.',
+        },
+      ],
     },
     insights: [
       {

--- a/demo/AGI-Alpha-Node-v0/test/planner.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/planner.test.ts
@@ -20,6 +20,8 @@ test('planner favours higher alpha opportunities', async () => {
   const result = planner.plan(jobs);
   assert.equal(result.selectedJobId, 'b');
   assert(result.alphaScore > 0);
+  assert(result.worldModelConfidence >= 0 && result.worldModelConfidence <= 1);
+  assert(result.horizonSequence.length > 0);
 });
 
 test('planner curriculum escalates after success', async () => {
@@ -28,4 +30,18 @@ test('planner curriculum escalates after success', async () => {
   planner.recordOutcome('test', true, 100, 0.6);
   const next = planner.plan([]).curriculumDifficulty;
   assert(next >= base);
+});
+
+test('world model tracks sequence value and confidence', async () => {
+  const planner = await makePlanner();
+  const opportunities: JobOpportunity[] = [
+    { jobId: 'alpha', reward: 20, difficulty: 0.4, risk: 0.2, tags: ['capital-markets'] },
+    { jobId: 'beta', reward: 12, difficulty: 0.2, risk: 0.1, tags: ['manufacturing'] },
+    { jobId: 'gamma', reward: 30, difficulty: 0.8, risk: 0.5, tags: ['biotech'] }
+  ];
+  const summary = planner.plan(opportunities);
+  assert(summary.horizonValue > 0);
+  assert(summary.forecasts.length === opportunities.length);
+  const confidence = summary.worldModelConfidence;
+  assert(confidence >= 0 && confidence <= 1);
 });

--- a/demo/AGI-Alpha-Node-v0/test/world_model.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/world_model.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { loadAlphaNodeConfig } from '../src/config';
+import { AlphaWorldModel } from '../src/ai/worldModel';
+import type { JobOpportunity } from '../src/ai/planner';
+
+const fixturePath = path.resolve('demo/AGI-Alpha-Node-v0/config/mainnet.guide.json');
+
+async function createWorldModel(): Promise<AlphaWorldModel> {
+  const config = await loadAlphaNodeConfig(fixturePath);
+  return new AlphaWorldModel(config);
+}
+
+test('world model forecast responds to job attributes', async () => {
+  const worldModel = await createWorldModel();
+  const baseJob: JobOpportunity = {
+    jobId: 'alpha',
+    reward: 15,
+    difficulty: 0.4,
+    risk: 0.2,
+    tags: ['capital-markets'],
+  };
+  const conservative = worldModel.forecast(baseJob);
+  const risky = worldModel.forecast({ ...baseJob, jobId: 'beta', risk: 0.8 });
+  assert(conservative.successProbability > risky.successProbability);
+  assert(conservative.riskAdjustedValue > risky.riskAdjustedValue);
+});
+
+test('world model evaluate returns horizon sequence', async () => {
+  const worldModel = await createWorldModel();
+  const opportunities: JobOpportunity[] = [
+    { jobId: 'alpha', reward: 22, difficulty: 0.5, risk: 0.25, tags: ['capital-markets'] },
+    { jobId: 'beta', reward: 18, difficulty: 0.35, risk: 0.1, tags: ['manufacturing'] },
+    { jobId: 'gamma', reward: 30, difficulty: 0.7, risk: 0.45, tags: ['biotech'] },
+  ];
+  const result = worldModel.evaluate(opportunities, 4);
+  assert(result.sequence.jobIds.length > 0);
+  assert(result.sequence.cumulativeValue > 0);
+  assert(result.bestForecast);
+});

--- a/demo/AGI-Alpha-Node-v0/web/index.html
+++ b/demo/AGI-Alpha-Node-v0/web/index.html
@@ -120,6 +120,12 @@
             }</strong>
           </div>
         `;
+        const sequence =
+          plan.summary.horizonSequence.length > 0
+            ? plan.summary.horizonSequence.join(' → ')
+            : 'Awaiting intelligence loop';
+        const confidence = (plan.summary.worldModelConfidence * 100).toFixed(1);
+        const horizonValue = plan.summary.horizonValue.toFixed(2);
         document.getElementById('planning').innerHTML = `
           <div class="metrics">
             <span>Selected Job</span>
@@ -128,6 +134,18 @@
           <div class="metrics">
             <span>Alpha Score</span>
             <strong>${plan.summary.alphaScore.toFixed(2)}</strong>
+          </div>
+          <div class="metrics">
+            <span>World Model Confidence</span>
+            <strong>${confidence}%</strong>
+          </div>
+          <div class="metrics">
+            <span>Horizon Sequence</span>
+            <strong>${sequence}</strong>
+          </div>
+          <div class="metrics">
+            <span>Horizon Value</span>
+            <strong>${horizonValue}</strong>
           </div>
           <pre>${JSON.stringify(plan.insights, null, 2)}</pre>
         `;


### PR DESCRIPTION
## Summary
- add a dedicated MuZero++-style world model for Alpha Node planning and expose confidence, horizon sequence, and forecasts across the stack
- surface the new intelligence signals through metrics, compliance reporting, CLI/web UX, and documentation so operators and auditors see the horizon plan immediately
- extend configuration and tests to cover world model parameters, ensuring deterministic coverage for planner and compliance workflows

## Testing
- npm run build:agi-alpha-node
- npm run test:agi-alpha-node

------
https://chatgpt.com/codex/tasks/task_e_6901320697a48333ae531fc8775ae8e9