### PR TITLE
Add governance console and timeline controls to Validator Constellation demo

### DIFF
--- a/demo/Validator-Constellation-v0/tests/test_commit_reveal.py
+++ b/demo/Validator-Constellation-v0/tests/test_commit_reveal.py
@@ -72,6 +72,9 @@ def test_slashes_non_reveal(setup_environment):
         round_engine.commit(address, True, salts[address])
     for address in list(committee.keys())[:-1]:
         round_engine.reveal(address, True, salts[address])
+    with pytest.raises(RuntimeError):
+        round_engine.finalize()
+    round_engine.advance_blocks(config.reveal_phase_blocks)
     round_engine.finalize()
     slashed = [event.payload["address"] for event in bus.find("ValidatorSlashed")]
     assert len(slashed) == 1
@@ -100,3 +103,35 @@ def test_slashes_incorrect_vote(setup_environment):
     round_engine.finalize()
     slashed = [event.payload["address"] for event in bus.find("ValidatorSlashed")]
     assert "0x1" in slashed
+
+
+def test_commit_reveal_deadlines_enforced(setup_environment):
+    config, bus, stake_manager, validators = setup_environment
+    config.commit_phase_blocks = 2
+    config.reveal_phase_blocks = 2
+    config.quorum = 1
+    committee = {key: validators[key] for key in list(validators.keys())[:2]}
+    round_engine = CommitRevealRound(
+        round_id="deadline-round",
+        committee=committee,
+        config=config,
+        stake_manager=stake_manager,
+        event_bus=bus,
+        truthful_outcome=True,
+    )
+    salts = {address: f"salt::{i}" for i, address in enumerate(committee, start=1)}
+    addresses = list(committee.keys())
+    first, second = addresses[0], addresses[1]
+    round_engine.commit(first, True, salts[first])
+    round_engine.advance_blocks(config.commit_phase_blocks)
+    with pytest.raises(RuntimeError):
+        round_engine.commit(second, True, salts[second])
+    # Reveal is only allowed after the commit window closed
+    round_engine.reveal(first, True, salts[first])
+    round_engine.advance_blocks(config.reveal_phase_blocks)
+    result = round_engine.finalize()
+    assert result is True
+    timeline_event = next(bus.find("RoundFinalized"))
+    timeline = timeline_event.payload["timeline"]
+    assert timeline["commitDeadlineBlock"] == config.commit_phase_blocks
+    assert timeline["revealDeadlineBlock"] == config.commit_phase_blocks + config.reveal_phase_blocks

--- a/demo/Validator-Constellation-v0/tests/test_demo_runner.py
+++ b/demo/Validator-Constellation-v0/tests/test_demo_runner.py
@@ -11,3 +11,6 @@ def test_demo_runner_summary():
     assert summary.gas_saved > 0
     assert summary.batch_proof_root
     assert summary.indexed_events >= 1
+    assert summary.timeline
+    assert summary.timeline.get("commitDeadlineBlock") is not None
+    assert summary.owner_actions

--- a/demo/Validator-Constellation-v0/tests/test_governance.py
+++ b/demo/Validator-Constellation-v0/tests/test_governance.py
@@ -1,0 +1,38 @@
+import pytest
+
+from validator_constellation.config import SystemConfig
+from validator_constellation.events import EventBus
+from validator_constellation.governance import OwnerConsole
+from validator_constellation.sentinel import DomainPauseController
+from validator_constellation.staking import StakeManager
+from validator_constellation.subgraph import SubgraphIndexer
+
+
+def test_owner_console_controls_configuration():
+    config = SystemConfig()
+    bus = EventBus()
+    stake_manager = StakeManager(bus, config.owner_address)
+    pause_controller = DomainPauseController(bus)
+    indexer = SubgraphIndexer(bus)
+    console = OwnerConsole(config.owner_address, config, pause_controller, stake_manager, bus)
+
+    action = console.update_config(config.owner_address, quorum=4, slash_fraction_non_reveal=0.4)
+    assert config.quorum == 4
+    assert action.details["slash_fraction_non_reveal"] == 0.4
+    assert indexer.latest("ConfigUpdated")
+
+    pause_controller.pause("bio", "test")
+    console.resume_domain(config.owner_address, "bio")
+    assert not pause_controller.is_paused("bio")
+
+
+def test_owner_console_rejects_unauthorised_updates():
+    config = SystemConfig()
+    bus = EventBus()
+    stake_manager = StakeManager(bus, config.owner_address)
+    pause_controller = DomainPauseController(bus)
+    console = OwnerConsole(config.owner_address, config, pause_controller, stake_manager, bus)
+
+    with pytest.raises(PermissionError):
+        console.update_config("0xdead", quorum=10)
+

--- a/demo/Validator-Constellation-v0/validator_constellation/__init__.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/__init__.py
@@ -27,6 +27,7 @@ from .sentinel import (
 )
 from .demo_runner import run_validator_constellation_demo
 from .subgraph import SubgraphIndexer, IndexedEvent
+from .governance import OwnerConsole, OwnerAction
 
 __all__ = [
     "SystemConfig",
@@ -50,5 +51,7 @@ __all__ = [
     "SentinelRule",
     "SubgraphIndexer",
     "IndexedEvent",
+    "OwnerConsole",
+    "OwnerAction",
     "run_validator_constellation_demo",
 ]

--- a/demo/Validator-Constellation-v0/validator_constellation/__main__.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/__main__.py
@@ -9,6 +9,9 @@ def main() -> None:
     print(f"Committee: {summary.committee}")
     print(f"Paused domains: {summary.paused_domains}")
     print(f"Batch proof root: {summary.batch_proof_root}")
+    print(f"Timeline: {summary.timeline}")
+    if summary.owner_actions:
+        print(f"Owner actions: {summary.owner_actions}")
 
 
 if __name__ == "__main__":

--- a/demo/Validator-Constellation-v0/validator_constellation/commit_reveal.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/commit_reveal.py
@@ -56,6 +56,16 @@ class CommitRevealRound:
         self.reveals: Dict[str, VoteReveal] = {}
         self.truthful_outcome = truthful_outcome
         self.phase = RoundPhase.COMMIT
+        self._block_offset = 0
+        self._reveal_started_block: Optional[int] = None
+
+    @property
+    def commit_deadline(self) -> int:
+        return self.start_block + self.config.commit_phase_blocks
+
+    @property
+    def reveal_deadline(self) -> int:
+        return self.commit_deadline + self.config.reveal_phase_blocks
 
     def _hash_vote(self, vote: bool, salt: str) -> str:
         hasher = hashlib.blake2b(digest_size=32)
@@ -72,12 +82,29 @@ class CommitRevealRound:
         return normalized
 
     def _current_block(self) -> int:
-        return self.start_block + len(self.commitments) + len(self.reveals)
+        return self.start_block + self._block_offset
+
+    def _increment_block(self) -> None:
+        self._block_offset += 1
+
+    def advance_blocks(self, blocks: int = 1) -> int:
+        if blocks < 0:
+            raise ValueError("Cannot rewind blocks")
+        for _ in range(blocks):
+            self._increment_block()
+            self._maybe_transition_to_reveal()
+        return self._current_block()
+
+    def force_reveal_phase(self) -> None:
+        if self.phase == RoundPhase.COMMIT:
+            self._transition_to_reveal(reason="force")
 
     def commit(self, address: str, vote: bool, salt: str) -> VoteCommitment:
         normalized = self._assert_member(address)
         if self.phase != RoundPhase.COMMIT:
             raise RuntimeError("Commit phase closed")
+        if self._current_block() >= self.commit_deadline:
+            raise RuntimeError("Commit window elapsed")
         if normalized in self.commitments:
             raise RuntimeError("Commitment already submitted")
         commitment = self._hash_vote(vote, salt)
@@ -94,12 +121,13 @@ class CommitRevealRound:
                 "block": block_number,
             },
         )
-        if len(self.commitments) >= len(self.committee):
-            self.phase = RoundPhase.REVEAL
+        self._increment_block()
+        self._maybe_transition_to_reveal()
         return commitment_record
 
     def reveal(self, address: str, vote: bool, salt: str) -> VoteReveal:
         normalized = self._assert_member(address)
+        self._maybe_transition_to_reveal()
         if self.phase == RoundPhase.COMMIT:
             raise RuntimeError("Reveal phase not started")
         if self.phase == RoundPhase.FINALIZED:
@@ -110,6 +138,8 @@ class CommitRevealRound:
         actual = self._hash_vote(vote, salt)
         if actual != expected:
             raise ValueError("Reveal does not match commitment")
+        if self._current_block() >= self.reveal_deadline:
+            raise RuntimeError("Reveal window elapsed")
         block_number = self._current_block()
         reveal_record = VoteReveal(vote=vote, salt=salt, block_number=block_number)
         self.reveals[normalized] = reveal_record
@@ -123,11 +153,16 @@ class CommitRevealRound:
                 "block": block_number,
             },
         )
+        self._increment_block()
         return reveal_record
 
     def finalize(self) -> bool:
         if self.phase == RoundPhase.FINALIZED:
             raise RuntimeError("Round already finalized")
+        if self.phase == RoundPhase.COMMIT:
+            raise RuntimeError("Cannot finalize during commit phase")
+        if len(self.reveals) < len(self.commitments) and self._current_block() < self.reveal_deadline:
+            raise RuntimeError("Reveal phase still active")
         self.phase = RoundPhase.FINALIZED
         truth_votes = sum(1 for reveal in self.reveals.values() if reveal.vote == self.truthful_outcome)
         total_reveals = len(self.reveals)
@@ -163,6 +198,38 @@ class CommitRevealRound:
                 "totalReveals": total_reveals,
                 "truthVotes": truth_votes,
                 "result": outcome,
+                "timeline": {
+                    "commitStartBlock": self.start_block,
+                    "commitDeadlineBlock": self.commit_deadline,
+                    "revealStartBlock": self._reveal_started_block,
+                    "revealDeadlineBlock": self.reveal_deadline,
+                    "finalizedAtBlock": self._current_block(),
+                },
             },
         )
         return outcome
+
+    def _maybe_transition_to_reveal(self) -> None:
+        if self.phase != RoundPhase.COMMIT:
+            return
+        if len(self.commitments) >= len(self.committee):
+            self._transition_to_reveal(reason="committee-complete")
+            return
+        if self._current_block() >= self.commit_deadline:
+            self._transition_to_reveal(reason="timeout")
+
+    def _transition_to_reveal(self, reason: str) -> None:
+        if self.phase != RoundPhase.COMMIT:
+            return
+        self.phase = RoundPhase.REVEAL
+        self._reveal_started_block = self._current_block()
+        self.event_bus.publish(
+            "PhaseTransition",
+            {
+                "roundId": self.round_id,
+                "phase": RoundPhase.REVEAL.value,
+                "reason": reason,
+                "commitDeadline": self.commit_deadline,
+                "revealDeadline": self.reveal_deadline,
+            },
+        )

--- a/demo/Validator-Constellation-v0/validator_constellation/demo_runner.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/demo_runner.py
@@ -1,20 +1,19 @@
-"""High-level orchestration for the Validator Constellation demo."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Dict, Iterable, List
+from typing import Dict, List, Optional
 
 from .commit_reveal import CommitRevealRound
 from .config import SystemConfig
 from .events import EventBus
+from .governance import OwnerConsole
 from .identity import ENSIdentityVerifier
 from .sentinel import AgentAction, DomainPauseController, SentinelMonitor, SentinelRule
 from .staking import StakeManager
+from .subgraph import SubgraphIndexer
 from .vrf import VRFCoordinator
 from .zk_batch import JobResult, ZKBatchAttestor
-from .subgraph import SubgraphIndexer
 
 
 @dataclass(slots=True)
@@ -27,13 +26,46 @@ class DemoSummary:
     batch_proof_root: str
     gas_saved: int
     indexed_events: int
+    timeline: Dict[str, Optional[int]]
+    owner_actions: List[Dict[str, object]]
 
 
-def run_validator_constellation_demo(seed: str = "demo-seed", truthful_outcome: bool = True) -> DemoSummary:
+def run_validator_constellation_demo(
+    seed: str = "demo-seed",
+    truthful_outcome: bool = True,
+    *,
+    committee_size: Optional[int] = None,
+    job_count: Optional[int] = None,
+    config_overrides: Optional[Dict[str, object]] = None,
+    budget_limit: float = 1_000.0,
+) -> DemoSummary:
     config = SystemConfig()
+    overrides = dict(config_overrides or {})
+    owner_override = overrides.pop("owner_address", None)
+    if owner_override:
+        config.owner_address = str(owner_override)
+
     event_bus = EventBus()
-    stake_manager = StakeManager(event_bus, config.owner_address)
     SubgraphIndexer(event_bus)
+    stake_manager = StakeManager(event_bus, config.owner_address)
+    domain_pause = DomainPauseController(event_bus)
+    owner_console = OwnerConsole(
+        owner_address=config.owner_address,
+        config=config,
+        pause_controller=domain_pause,
+        stake_manager=stake_manager,
+        event_bus=event_bus,
+    )
+
+    owner_updates: Dict[str, object] = {
+        "reveal_phase_blocks": max(config.reveal_phase_blocks, 6),
+        "slash_fraction_non_reveal": max(config.slash_fraction_non_reveal, 0.35),
+    }
+    if committee_size is not None:
+        owner_updates["committee_size"] = committee_size
+    owner_updates.update(overrides)
+    owner_console.update_config(config.owner_address, **owner_updates)
+
     identity = ENSIdentityVerifier(
         allowed_validator_roots=config.allowed_validator_roots,
         allowed_agent_roots=config.allowed_agent_roots,
@@ -67,16 +99,14 @@ def run_validator_constellation_demo(seed: str = "demo-seed", truthful_outcome: 
         truthful_outcome=truthful_outcome,
     )
 
-    salts = {
-        address: f"salt::{i}" for i, address in enumerate(committee.keys(), start=1)
-    }
+    salts = {address: f"salt::{i}" for i, address in enumerate(committee.keys(), start=1)}
     for address in committee:
         round_engine.commit(address, truthful_outcome, salts[address])
     for address in list(committee.keys())[:-1]:
         round_engine.reveal(address, truthful_outcome, salts[address])
+    round_engine.advance_blocks(config.reveal_phase_blocks)
     round_result = round_engine.finalize()
 
-    domain_pause = DomainPauseController(event_bus)
     sentinel = SentinelMonitor(
         rules=[
             SentinelRule(
@@ -97,20 +127,23 @@ def run_validator_constellation_demo(seed: str = "demo-seed", truthful_outcome: 
     action = AgentAction(
         agent="eve.agent.agi.eth",
         domain="synthetic-biology",
-        spend=1200.0,
+        spend=1_200.0,
         call="allocate_funds",
-        metadata={"budget": 1000.0},
+        metadata={"budget": budget_limit},
     )
     sentinel.evaluate(action)
 
     batcher = ZKBatchAttestor(config)
+    job_target = max(1, job_count or config.batch_proof_capacity)
     jobs = [
         JobResult(job_id=f"job-{i}", outcome_hash=f"outcome::{i % 2}", execution_digest=f"digest::{i}")
-        for i in range(1, config.batch_proof_capacity + 1)
+        for i in range(1, min(job_target, config.batch_proof_capacity) + 1)
     ]
     proof = batcher.create_batch_proof(jobs)
 
     slashed = [event.payload["address"] for event in event_bus.find("ValidatorSlashed")]
+    finalized_event = next(event_bus.find("RoundFinalized"), None)
+    timeline = finalized_event.payload.get("timeline") if finalized_event else {}
 
     return DemoSummary(
         committee=committee,
@@ -121,4 +154,7 @@ def run_validator_constellation_demo(seed: str = "demo-seed", truthful_outcome: 
         batch_proof_root=proof.batch_root,
         gas_saved=batcher.estimate_gas_saved(len(jobs)),
         indexed_events=len(event_bus.events),
+        timeline=dict(timeline or {}),
+        owner_actions=[{"action": action.action, "details": action.details} for action in owner_console.actions],
     )
+

--- a/demo/Validator-Constellation-v0/validator_constellation/governance.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/governance.py
@@ -1,0 +1,84 @@
+"""Owner governance controls for the Validator Constellation demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+from .config import SystemConfig
+from .events import EventBus
+from .sentinel import DomainPauseController
+from .staking import StakeManager
+
+
+@dataclass(slots=True)
+class OwnerAction:
+    """Represents an action executed by the contract owner."""
+
+    operator: str
+    action: str
+    details: Dict[str, object]
+
+
+class OwnerConsole:
+    """High-level facade that mimics contract owner privileges."""
+
+    def __init__(
+        self,
+        owner_address: str,
+        config: SystemConfig,
+        pause_controller: DomainPauseController,
+        stake_manager: StakeManager,
+        event_bus: EventBus,
+    ) -> None:
+        self._owner = owner_address.lower()
+        self._config = config
+        self._pause_controller = pause_controller
+        self._stake_manager = stake_manager
+        self._event_bus = event_bus
+        self._actions: list[OwnerAction] = []
+
+    def _require_owner(self, caller: str) -> None:
+        if caller.lower() != self._owner:
+            raise PermissionError("Caller is not the contract owner")
+
+    def update_config(self, caller: str, **changes: object) -> OwnerAction:
+        self._require_owner(caller)
+        if not changes:
+            raise ValueError("No configuration changes provided")
+        validated: Dict[str, object] = {}
+        for key, value in changes.items():
+            if not hasattr(self._config, key):
+                raise AttributeError(f"Unknown configuration field: {key}")
+            validated[key] = value
+        self._config.update(**validated)
+        action = OwnerAction(operator=self._owner, action="config-update", details=validated)
+        self._actions.append(action)
+        self._event_bus.publish(
+            "ConfigUpdated",
+            {"owner": self._owner, "changes": validated},
+        )
+        return action
+
+    def resume_domain(self, caller: str, domain: str) -> OwnerAction:
+        self._require_owner(caller)
+        self._pause_controller.resume(domain, operator=caller)
+        action = OwnerAction(operator=self._owner, action="domain-resume", details={"domain": domain})
+        self._actions.append(action)
+        return action
+
+    def deactivate_validator(self, caller: str, address: str) -> OwnerAction:
+        self._require_owner(caller)
+        self._stake_manager.deactivate(address)
+        action = OwnerAction(
+            operator=self._owner,
+            action="validator-deactivate",
+            details={"address": address.lower()},
+        )
+        self._actions.append(action)
+        return action
+
+    @property
+    def actions(self) -> Iterable[OwnerAction]:
+        return tuple(self._actions)
+

--- a/demo/Validator-Constellation-v0/validator_constellation/subgraph.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/subgraph.py
@@ -24,7 +24,16 @@ class SubgraphIndexer:
         self.event_bus.subscribe(self._handle_event)
 
     def _handle_event(self, event: Event) -> None:
-        if event.type in {"ValidatorSlashed", "DomainPaused", "SentinelAlert", "RoundFinalized"}:
+        indexed_types = {
+            "ValidatorSlashed",
+            "DomainPaused",
+            "DomainResumed",
+            "SentinelAlert",
+            "RoundFinalized",
+            "PhaseTransition",
+            "ConfigUpdated",
+        }
+        if event.type in indexed_types:
             self.events.append(
                 IndexedEvent(
                     type=event.type,
@@ -38,3 +47,6 @@ class SubgraphIndexer:
             if event.type == event_type:
                 return event
         return None
+
+    def all(self, event_type: str) -> List[IndexedEvent]:
+        return [event for event in self.events if event.type == event_type]

--- a/demo/Validator-Constellation-v0/web/index.html
+++ b/demo/Validator-Constellation-v0/web/index.html
@@ -114,8 +114,16 @@
       <article class="card">
         <h3>Operator Playbook</h3>
         <pre class="code-block"><code>$ cd demo/Validator-Constellation-v0
-$ python run_demo.py --seed mission-12 --truth true --output mission-12.json
-# Review mission-12.json for committee, slashing, pause states & proof roots.</code></pre>
+$ python run_demo.py \
+    --seed mission-12 \
+    --truth true \
+    --committee-size 3 \
+    --quorum 2 \
+    --commit-blocks 5 \
+    --reveal-blocks 6 \
+    --slash-non-reveal 0.35 \
+    --output mission-12.json
+# Review mission-12.json for committee, timelines, owner actions, slashing & pause states.</code></pre>
       </article>
       <article class="card">
         <h3>Owner Controls</h3>
@@ -198,6 +206,26 @@ $ python run_demo.py --seed mission-12 --truth true --output mission-12.json
           },
         },
         {
+          type: "ConfigUpdated",
+          payload: {
+            owner: "0x0000000000000000000000000000000000000001",
+            changes: {
+              reveal_phase_blocks: 6,
+              slash_fraction_non_reveal: 0.35,
+            },
+          },
+        },
+        {
+          type: "PhaseTransition",
+          payload: {
+            roundId: "constellation-round-1",
+            phase: "reveal",
+            reason: "committee-complete",
+            commitDeadline: 5,
+            revealDeadline: 11,
+          },
+        },
+        {
           type: "SentinelAlert",
           payload: {
             domain: "synthetic-biology",
@@ -226,6 +254,13 @@ $ python run_demo.py --seed mission-12 --truth true --output mission-12.json
             truthVotes: 2,
             totalReveals: 2,
             result: true,
+            timeline: {
+              commitStartBlock: 0,
+              commitDeadlineBlock: 5,
+              revealStartBlock: 3,
+              revealDeadlineBlock: 11,
+              finalizedAtBlock: 11,
+            },
           },
         },
       ];


### PR DESCRIPTION
## Summary
- enforce commit/reveal block timelines and surface them in demo outputs and UI
- introduce an OwnerConsole facade plus CLI controls so operators can update configuration and export governance history
- expand documentation, web dashboard, and tests to cover new governance, timeline, and subgraph telemetry features

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Validator-Constellation-v0/tests

------
https://chatgpt.com/codex/tasks/task_e_69014c0a365c8333afa8ffc207cf9303