### PR TITLE
Add owner dominion analytics to Economic Power demo

### DIFF
--- a/demo/Economic-Power-v0/README.md
+++ b/demo/Economic-Power-v0/README.md
@@ -31,6 +31,7 @@ Outputs land in `demo/Economic-Power-v0/reports/`:
 - `owner-command-plan.md` – markdown playbook summarising quick actions, scripted upgrades, circuit breakers, and capital checkpoints in plain language.
 - `owner-command-checklist.json` – machine-auditable coverage ledger detailing per-surface command coverage percentages for jobs, validators, adapters, modules, treasury, pause/resume, and orchestrator surfaces.
 - `owner-governance-ledger.json` – deterministic custody ledger detailing module ownership, audit freshness, scripts, and alertable coverage gaps for governance dashboards.
+- `owner-dominion.json` – composite dominion index fusing coverage, safety mesh readiness, custody, guardrails, and recommended actions for the owner multi-sig.
 - `sovereign-safety-mesh.json` – composite readiness diagnostics across pause/resume readiness, alerting, scripted coverage, and circuit breaker posture.
 - `treasury-trajectory.json` – treasury state, yield, validator confidence, and automation lift captured after each job.
 - `assertions.json` – machine-readable verification ledger covering owner dominance, custody, validator strength, and treasury solvency.
@@ -119,6 +120,7 @@ The UI inside `demo/Economic-Power-v0/ui/` offers:
 - Owner command Mermaid graph mapping multi-sig authority to every module, circuit breaker, and upgrade path.
 - Drag-and-drop support for alternative `summary.json` files for instant what-if exploration.
 - Sovereign safety mesh panel cataloguing pause/resume playbooks, emergency contacts, circuit breakers, and module upgrade routes.
+- Owner dominion index panel quantifying composite control, safety, and custody readiness with live guardrail and action feed.
 - Safety mesh diagnostics scoring response readiness, alert channel breadth, circuit breaker posture, command coverage depth, and scripted responses.
 - Governance ledger visual linking custody posture, audit staleness, and alert feed directly from `owner-governance-ledger.json`.
 - Command catalog grid enumerating every deterministic owner program so the operator can launch missions instantly.

--- a/demo/Economic-Power-v0/reports/baseline-summary.json
+++ b/demo/Economic-Power-v0/reports/baseline-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T23:07:42.681Z",
+  "executionTimestamp": "2025-10-28T23:41:12.298Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -22,6 +22,7 @@
     "riskMitigationScore": 0.912,
     "stabilityIndex": 0.761,
     "ownerCommandCoverage": 1,
+    "ownerDominionScore": 0.994,
     "sovereignControlScore": 1,
     "sovereignSafetyScore": 0.979,
     "assertionPassRate": 1,
@@ -1147,6 +1148,47 @@
         "script": "npm run owner:program -- --program orchestrator-pause-drill",
         "objective": "Run full-stack pause/resume drill to validate emergency readiness."
       }
+    ]
+  },
+  "ownerDominion": {
+    "score": 0.994,
+    "classification": "total-dominion",
+    "summary": "Owner multi-sig exerts absolute dominion – every command, pause, and upgrade is scripted and rehearsed.",
+    "guardrails": [
+      "Pause • npm run owner:system-pause",
+      "Resume • npm run owner:update-all",
+      "validatorConfidence < 0.95 → npm run owner:system-pause",
+      "automationScore < 0.8 → npm run owner:parameters",
+      "treasuryAfterRun < 1800000 → npm run owner:audit"
+    ],
+    "readiness": {
+      "pauseReady": true,
+      "resumeReady": true,
+      "responseMinutes": 9,
+      "coverage": 1,
+      "safety": 0.979,
+      "control": 1
+    },
+    "coverageDetail": {
+      "jobs": 1,
+      "validators": 1,
+      "stablecoinAdapters": 1,
+      "modules": 1,
+      "parameters": 1,
+      "pause": 1,
+      "resume": 1,
+      "treasury": 1,
+      "orchestrator": 1
+    },
+    "signals": [
+      "Command coverage 100.0%",
+      "Safety mesh 97.9%",
+      "Custody 100.0%",
+      "Guardrails 5",
+      "Response 9m"
+    ],
+    "recommendedActions": [
+      "Maintain autopilot cadence and periodic drills to preserve total dominion."
     ]
   },
   "globalExpansionPlan": [

--- a/demo/Economic-Power-v0/reports/economic-dominance.json
+++ b/demo/Economic-Power-v0/reports/economic-dominance.json
@@ -1,6 +1,6 @@
 {
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T23:08:17.428Z",
+  "executionTimestamp": "2025-10-28T23:41:44.154Z",
   "dominanceIndex": 0.994,
   "capitalVelocity": 26290.99,
   "roiMultiplier": 3.28,

--- a/demo/Economic-Power-v0/reports/global-expansion-plan.md
+++ b/demo/Economic-Power-v0/reports/global-expansion-plan.md
@@ -1,7 +1,7 @@
 # Global Expansion Autopilot Plan
 
 Scenario: AGIJobs Economic Power Launch
-Generated 2025-10-28T23:08:17.428Z • Dominance 99.4%
+Generated 2025-10-28T23:41:44.154Z • Dominance 99.4%
 
 ## Phase I – Testnet Supremacy
 

--- a/demo/Economic-Power-v0/reports/owner-command-plan.md
+++ b/demo/Economic-Power-v0/reports/owner-command-plan.md
@@ -1,6 +1,6 @@
 # Owner Command Playbook
 
-Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/28/2025, 11:08:17 PM (UTC)
+Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/28/2025, 11:41:44 PM (UTC)
 
 Command coverage: 100.0% — Owner multi-sig holds deterministic runbooks for every critical surface.
 

--- a/demo/Economic-Power-v0/reports/owner-dominion.json
+++ b/demo/Economic-Power-v0/reports/owner-dominion.json
@@ -1,0 +1,41 @@
+{
+  "score": 0.994,
+  "classification": "total-dominion",
+  "summary": "Owner multi-sig exerts absolute dominion – every command, pause, and upgrade is scripted and rehearsed.",
+  "guardrails": [
+    "Pause • npm run owner:system-pause",
+    "Resume • npm run owner:update-all",
+    "validatorConfidence < 0.95 → npm run owner:system-pause",
+    "automationScore < 0.8 → npm run owner:parameters",
+    "treasuryAfterRun < 1800000 → npm run owner:audit"
+  ],
+  "readiness": {
+    "pauseReady": true,
+    "resumeReady": true,
+    "responseMinutes": 9,
+    "coverage": 1,
+    "safety": 0.979,
+    "control": 1
+  },
+  "coverageDetail": {
+    "jobs": 1,
+    "validators": 1,
+    "stablecoinAdapters": 1,
+    "modules": 1,
+    "parameters": 1,
+    "pause": 1,
+    "resume": 1,
+    "treasury": 1,
+    "orchestrator": 1
+  },
+  "signals": [
+    "Command coverage 100.0%",
+    "Safety mesh 97.9%",
+    "Custody 100.0%",
+    "Guardrails 5",
+    "Response 9m"
+  ],
+  "recommendedActions": [
+    "Maintain autopilot cadence and periodic drills to preserve total dominion."
+  ]
+}

--- a/demo/Economic-Power-v0/reports/summary.json
+++ b/demo/Economic-Power-v0/reports/summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T23:08:17.428Z",
+  "executionTimestamp": "2025-10-28T23:41:44.154Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -22,6 +22,7 @@
     "riskMitigationScore": 0.912,
     "stabilityIndex": 0.761,
     "ownerCommandCoverage": 1,
+    "ownerDominionScore": 0.994,
     "sovereignControlScore": 1,
     "sovereignSafetyScore": 0.979,
     "assertionPassRate": 1,
@@ -1147,6 +1148,47 @@
         "script": "npm run owner:program -- --program orchestrator-pause-drill",
         "objective": "Run full-stack pause/resume drill to validate emergency readiness."
       }
+    ]
+  },
+  "ownerDominion": {
+    "score": 0.994,
+    "classification": "total-dominion",
+    "summary": "Owner multi-sig exerts absolute dominion – every command, pause, and upgrade is scripted and rehearsed.",
+    "guardrails": [
+      "Pause • npm run owner:system-pause",
+      "Resume • npm run owner:update-all",
+      "validatorConfidence < 0.95 → npm run owner:system-pause",
+      "automationScore < 0.8 → npm run owner:parameters",
+      "treasuryAfterRun < 1800000 → npm run owner:audit"
+    ],
+    "readiness": {
+      "pauseReady": true,
+      "resumeReady": true,
+      "responseMinutes": 9,
+      "coverage": 1,
+      "safety": 0.979,
+      "control": 1
+    },
+    "coverageDetail": {
+      "jobs": 1,
+      "validators": 1,
+      "stablecoinAdapters": 1,
+      "modules": 1,
+      "parameters": 1,
+      "pause": 1,
+      "resume": 1,
+      "treasury": 1,
+      "orchestrator": 1
+    },
+    "signals": [
+      "Command coverage 100.0%",
+      "Safety mesh 97.9%",
+      "Custody 100.0%",
+      "Guardrails 5",
+      "Response 9m"
+    ],
+    "recommendedActions": [
+      "Maintain autopilot cadence and periodic drills to preserve total dominion."
     ]
   },
   "globalExpansionPlan": [

--- a/demo/Economic-Power-v0/test/economic_power_demo.test.ts
+++ b/demo/Economic-Power-v0/test/economic_power_demo.test.ts
@@ -23,6 +23,10 @@ test('economic power simulation produces deterministic metrics', async () => {
     1,
     'Owner command coverage should confirm total command supremacy',
   );
+  assert(
+    summary.metrics.ownerDominionScore >= 0.95,
+    'Owner dominion score should confirm total dominion control',
+  );
   const coverageDetail = summary.ownerCommandPlan.coverageDetail;
   assert(coverageDetail, 'Coverage detail should be present');
   const coverageSurfaces = [
@@ -198,6 +202,28 @@ test('economic power simulation produces deterministic metrics', async () => {
   assert(
     summary.ownerAutopilot.guardrails.some((guardrail) => guardrail.includes(summary.ownerSovereignty.pauseScript)),
     'Autopilot guardrails should include pause command',
+  );
+  assert.equal(
+    summary.ownerDominion.score,
+    summary.metrics.ownerDominionScore,
+    'Owner dominion report score should mirror surfaced metric',
+  );
+  assert.equal(
+    summary.ownerDominion.classification,
+    'total-dominion',
+    'Baseline dominion classification should be total-dominion',
+  );
+  assert(
+    summary.ownerDominion.guardrails.length >= summary.ownerAutopilot.guardrails.length,
+    'Dominion guardrail list should mirror autopilot guardrails',
+  );
+  assert(
+    summary.ownerDominion.recommendedActions.length >= 1,
+    'Dominion recommendations should provide actionable guidance',
+  );
+  assert(
+    summary.ownerDominion.signals.length >= 3,
+    'Dominion signals should expose composite telemetry',
   );
   assert.equal(
     summary.ownerAutopilot.telemetry.economicDominanceIndex,

--- a/demo/Economic-Power-v0/ui/data/default-summary.json
+++ b/demo/Economic-Power-v0/ui/data/default-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T23:07:42.681Z",
+  "executionTimestamp": "2025-10-28T23:41:12.298Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -22,6 +22,7 @@
     "riskMitigationScore": 0.912,
     "stabilityIndex": 0.761,
     "ownerCommandCoverage": 1,
+    "ownerDominionScore": 0.994,
     "sovereignControlScore": 1,
     "sovereignSafetyScore": 0.979,
     "assertionPassRate": 1,
@@ -1147,6 +1148,47 @@
         "script": "npm run owner:program -- --program orchestrator-pause-drill",
         "objective": "Run full-stack pause/resume drill to validate emergency readiness."
       }
+    ]
+  },
+  "ownerDominion": {
+    "score": 0.994,
+    "classification": "total-dominion",
+    "summary": "Owner multi-sig exerts absolute dominion – every command, pause, and upgrade is scripted and rehearsed.",
+    "guardrails": [
+      "Pause • npm run owner:system-pause",
+      "Resume • npm run owner:update-all",
+      "validatorConfidence < 0.95 → npm run owner:system-pause",
+      "automationScore < 0.8 → npm run owner:parameters",
+      "treasuryAfterRun < 1800000 → npm run owner:audit"
+    ],
+    "readiness": {
+      "pauseReady": true,
+      "resumeReady": true,
+      "responseMinutes": 9,
+      "coverage": 1,
+      "safety": 0.979,
+      "control": 1
+    },
+    "coverageDetail": {
+      "jobs": 1,
+      "validators": 1,
+      "stablecoinAdapters": 1,
+      "modules": 1,
+      "parameters": 1,
+      "pause": 1,
+      "resume": 1,
+      "treasury": 1,
+      "orchestrator": 1
+    },
+    "signals": [
+      "Command coverage 100.0%",
+      "Safety mesh 97.9%",
+      "Custody 100.0%",
+      "Guardrails 5",
+      "Response 9m"
+    ],
+    "recommendedActions": [
+      "Maintain autopilot cadence and periodic drills to preserve total dominion."
     ]
   },
   "globalExpansionPlan": [

--- a/demo/Economic-Power-v0/ui/index.html
+++ b/demo/Economic-Power-v0/ui/index.html
@@ -52,6 +52,31 @@
         </table>
       </section>
 
+      <section class="panel" aria-labelledby="dominion-heading">
+        <div class="panel-header">
+          <h2 id="dominion-heading">Owner dominion index</h2>
+          <p>Composite dominion gauge spanning command coverage, safety mesh readiness, and custody supremacy.</p>
+        </div>
+        <div class="dominion-grid">
+          <article class="dominion-card" aria-label="Dominion score">
+            <h3>Dominion status</h3>
+            <p id="dominion-score" class="dominion-score">—</p>
+            <span id="dominion-classification" class="dominion-chip">Awaiting data</span>
+            <p id="dominion-summary" class="narrative"></p>
+            <p id="dominion-readiness" class="dominion-readiness"></p>
+          </article>
+          <article class="dominion-card" aria-label="Guardrails and signals">
+            <h3>Guardrails &amp; signals</h3>
+            <ul id="dominion-guardrails" class="dominion-list"></ul>
+            <div id="dominion-signals" class="dominion-signals"></div>
+          </article>
+          <article class="dominion-card" aria-label="Recommended actions">
+            <h3>Recommended actions</h3>
+            <ul id="dominion-actions" class="dominion-list"></ul>
+          </article>
+        </div>
+      </section>
+
       <section class="panel" aria-labelledby="command-catalog-heading">
         <div class="panel-header">
           <h2 id="command-catalog-heading">Command catalog supremacy</h2>

--- a/demo/Economic-Power-v0/ui/script.js
+++ b/demo/Economic-Power-v0/ui/script.js
@@ -51,6 +51,12 @@ const metricMap = [
     description: 'Share of critical surfaces with deterministic owner command paths.',
   },
   {
+    id: 'ownerDominionScore',
+    label: 'Owner Dominion',
+    formatter: (value) => `${(value * 100).toFixed(1)}%`,
+    description: 'Composite dominion index across command coverage, custody, and safety mesh readiness.',
+  },
+  {
     id: 'treasuryAfterRun',
     label: 'Treasury After Run (AGI)',
     formatter: (value) => formatNumber(value),
@@ -138,6 +144,72 @@ function renderOwnerTable(summary) {
       <td>${control.description}</td>
     `;
     tbody.append(row);
+  }
+}
+
+function renderOwnerDominion(summary) {
+  const dominion = summary.ownerDominion;
+  const scoreEl = document.getElementById('dominion-score');
+  const classificationEl = document.getElementById('dominion-classification');
+  const summaryEl = document.getElementById('dominion-summary');
+  const readinessEl = document.getElementById('dominion-readiness');
+  const guardrailList = document.getElementById('dominion-guardrails');
+  const signalsContainer = document.getElementById('dominion-signals');
+  const actionsList = document.getElementById('dominion-actions');
+
+  if (!scoreEl || !classificationEl || !summaryEl || !readinessEl || !guardrailList || !signalsContainer || !actionsList) {
+    return;
+  }
+
+  if (!dominion) {
+    scoreEl.textContent = '—';
+    classificationEl.textContent = 'Unavailable';
+    summaryEl.textContent = 'Dominion report unavailable.';
+    readinessEl.textContent = '';
+    guardrailList.innerHTML = '';
+    actionsList.innerHTML = '';
+    signalsContainer.innerHTML = '';
+    return;
+  }
+
+  scoreEl.textContent = `${(dominion.score * 100).toFixed(1)}%`;
+  const classificationLabel = dominion.classification.replace(/-/g, ' ');
+  classificationEl.textContent = classificationLabel;
+  classificationEl.className = `dominion-chip dominion-${dominion.classification}`;
+  summaryEl.textContent = dominion.summary;
+  readinessEl.textContent = `Coverage ${(dominion.readiness.coverage * 100).toFixed(1)}% • Safety ${(dominion.readiness.safety * 100).toFixed(1)}% • Custody ${(dominion.readiness.control * 100).toFixed(1)}% • Response ${dominion.readiness.responseMinutes}m`;
+
+  guardrailList.innerHTML = '';
+  if (dominion.guardrails.length === 0) {
+    const li = document.createElement('li');
+    li.textContent = 'No guardrails published – authorise guardrail scripts to preserve dominion.';
+    guardrailList.append(li);
+  } else {
+    for (const guardrail of dominion.guardrails) {
+      const li = document.createElement('li');
+      li.textContent = guardrail;
+      guardrailList.append(li);
+    }
+  }
+
+  signalsContainer.innerHTML = '';
+  for (const signal of dominion.signals) {
+    const span = document.createElement('span');
+    span.textContent = signal;
+    signalsContainer.append(span);
+  }
+
+  actionsList.innerHTML = '';
+  if (dominion.recommendedActions.length === 0) {
+    const li = document.createElement('li');
+    li.textContent = 'Dominion secure – continue automated cadence.';
+    actionsList.append(li);
+  } else {
+    for (const action of dominion.recommendedActions) {
+      const li = document.createElement('li');
+      li.textContent = action;
+      actionsList.append(li);
+    }
   }
 }
 
@@ -720,6 +792,7 @@ async function bootstrap(dataPath = defaultDataPath) {
   const summary = await loadSummary(dataPath);
   renderMetricCards(summary);
   renderOwnerTable(summary);
+  renderOwnerDominion(summary);
   renderCommandCatalog(summary);
   renderAssignments(summary);
   renderSovereignty(summary);
@@ -774,6 +847,7 @@ function setupFileHandlers() {
 async function renderSummary(summary) {
   renderMetricCards(summary);
   renderOwnerTable(summary);
+  renderOwnerDominion(summary);
   renderCommandCatalog(summary);
   renderAssignments(summary);
   renderSovereignty(summary);

--- a/demo/Economic-Power-v0/ui/styles.css
+++ b/demo/Economic-Power-v0/ui/styles.css
@@ -173,6 +173,111 @@ main {
   color: var(--accent);
 }
 
+.dominion-grid {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.dominion-card {
+  background: rgba(9, 15, 28, 0.8);
+  border: 1px solid rgba(110, 231, 255, 0.18);
+  border-radius: 1.2rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  box-shadow: 0 28px 46px rgba(4, 12, 24, 0.65);
+}
+
+.dominion-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.dominion-score {
+  font-size: 2.2rem;
+  font-weight: 700;
+}
+
+.dominion-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.18);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.dominion-chip.dominion-total-dominion {
+  background: rgba(34, 197, 94, 0.22);
+  border-color: rgba(34, 197, 94, 0.6);
+}
+
+.dominion-chip.dominion-fortified {
+  background: rgba(59, 130, 246, 0.22);
+  border-color: rgba(59, 130, 246, 0.55);
+}
+
+.dominion-chip.dominion-elevated {
+  background: rgba(250, 204, 21, 0.22);
+  border-color: rgba(250, 204, 21, 0.55);
+}
+
+.dominion-chip.dominion-attention {
+  background: rgba(248, 113, 113, 0.25);
+  border-color: rgba(248, 113, 113, 0.6);
+}
+
+.dominion-readiness {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.dominion-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.dominion-list li {
+  background: rgba(59, 130, 246, 0.12);
+  border-left: 3px solid rgba(59, 130, 246, 0.55);
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.85rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.dominion-signals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.dominion-signals span {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.2);
+  border: 1px solid rgba(14, 165, 233, 0.45);
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
 .assertion-card {
   background: rgba(7, 13, 26, 0.78);
   border: 1px solid rgba(56, 189, 248, 0.25);


### PR DESCRIPTION
## Summary
- add an owner dominion score and report to the Economic Power simulation, including deterministic guardrails and readiness data
- generate a dedicated owner-dominion.json artifact and refresh baseline summaries, dominance reports, and documentation to surface the new control layer
- extend the UI with an owner dominion panel and metric card so non-technical operators can review guardrails, signals, and recommended actions at a glance

## Testing
- npm run demo:economic-power
- npm run test:economic-power
- npm run demo:economic-power:ci

------
https://chatgpt.com/codex/tasks/task_e_690152bb71788333857105971ec14459