### PR TITLE
Enhance validator demo sentinel governance controls

### DIFF
--- a/demo/Validator-Constellation-v0/run_demo.py
+++ b/demo/Validator-Constellation-v0/run_demo.py
@@ -85,6 +85,8 @@ def main() -> None:
         "gasSaved": summary.gas_saved,
         "timeline": summary.timeline,
         "ownerActions": summary.owner_actions,
+        "sentinelAlerts": summary.sentinel_alerts,
+        "domainEvents": summary.domain_events,
     }
     print(json.dumps(data, indent=2))
     if args.output:

--- a/demo/Validator-Constellation-v0/tests/test_demo_runner.py
+++ b/demo/Validator-Constellation-v0/tests/test_demo_runner.py
@@ -14,3 +14,5 @@ def test_demo_runner_summary():
     assert summary.timeline
     assert summary.timeline.get("commitDeadlineBlock") is not None
     assert summary.owner_actions
+    assert len(summary.sentinel_alerts) >= 3
+    assert any(event["domain"] == "synthetic-biology" for event in summary.domain_events)

--- a/demo/Validator-Constellation-v0/tests/test_governance.py
+++ b/demo/Validator-Constellation-v0/tests/test_governance.py
@@ -12,7 +12,16 @@ def test_owner_console_controls_configuration():
     config = SystemConfig()
     bus = EventBus()
     stake_manager = StakeManager(bus, config.owner_address)
-    pause_controller = DomainPauseController(bus)
+    pause_controller = DomainPauseController(
+        bus,
+        domains=[
+            {
+                "domain": "bio",
+                "human_name": "Biosecurity Domain",
+                "budget_limit": 1_000,
+            }
+        ],
+    )
     indexer = SubgraphIndexer(bus)
     console = OwnerConsole(config.owner_address, config, pause_controller, stake_manager, bus)
 
@@ -21,7 +30,7 @@ def test_owner_console_controls_configuration():
     assert action.details["slash_fraction_non_reveal"] == 0.4
     assert indexer.latest("ConfigUpdated")
 
-    pause_controller.pause("bio", "test")
+    pause_controller.pause("bio", reason="test", triggered_by="pytest")
     console.resume_domain(config.owner_address, "bio")
     assert not pause_controller.is_paused("bio")
 
@@ -30,7 +39,16 @@ def test_owner_console_rejects_unauthorised_updates():
     config = SystemConfig()
     bus = EventBus()
     stake_manager = StakeManager(bus, config.owner_address)
-    pause_controller = DomainPauseController(bus)
+    pause_controller = DomainPauseController(
+        bus,
+        domains=[
+            {
+                "domain": "bio",
+                "human_name": "Biosecurity Domain",
+                "budget_limit": 1_000,
+            }
+        ],
+    )
     console = OwnerConsole(config.owner_address, config, pause_controller, stake_manager, bus)
 
     with pytest.raises(PermissionError):

--- a/demo/Validator-Constellation-v0/validator_constellation/__init__.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/__init__.py
@@ -24,6 +24,8 @@ from .sentinel import (
     AgentAction,
     DomainPauseController,
     SentinelRule,
+    PauseRecord,
+    DomainState,
 )
 from .demo_runner import run_validator_constellation_demo
 from .subgraph import SubgraphIndexer, IndexedEvent
@@ -49,6 +51,8 @@ __all__ = [
     "AgentAction",
     "DomainPauseController",
     "SentinelRule",
+    "PauseRecord",
+    "DomainState",
     "SubgraphIndexer",
     "IndexedEvent",
     "OwnerConsole",

--- a/demo/Validator-Constellation-v0/validator_constellation/__main__.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/__main__.py
@@ -12,6 +12,10 @@ def main() -> None:
     print(f"Timeline: {summary.timeline}")
     if summary.owner_actions:
         print(f"Owner actions: {summary.owner_actions}")
+    if summary.sentinel_alerts:
+        print(f"Sentinel alerts: {summary.sentinel_alerts}")
+    if summary.domain_events:
+        print(f"Domain events: {summary.domain_events}")
 
 
 if __name__ == "__main__":

--- a/demo/Validator-Constellation-v0/validator_constellation/sentinel.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/sentinel.py
@@ -2,106 +2,533 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Callable, Dict, Iterable, List, Optional
+from decimal import Decimal
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+from uuid import uuid4
 
 from .events import EventBus
+
+
+def _normalize_target(value: str) -> str:
+    return value.strip().lower()
+
+
+def _hash_target(value: str) -> str:
+    return hashlib.sha3_256(value.encode()).hexdigest()
+
+
+def _normalize_selector(value: str) -> str:
+    normalized = value.strip().lower()
+    if not normalized.startswith("0x"):
+        normalized = f"0x{normalized}"
+    return normalized
 
 
 @dataclass(slots=True)
 class AgentAction:
     agent: str
     domain: str
-    spend: float
+    spend: float | Decimal
     call: str
-    metadata: Dict[str, object]
+    metadata: Dict[str, object] = field(default_factory=dict)
+    opcode: Optional[str] = None
+    target: Optional[str] = None
+    calldata_bytes: Optional[int] = None
+    function_selector: Optional[str] = None
+    block_number: Optional[int] = None
+    agent_address: Optional[str] = None
 
 
 @dataclass(slots=True)
 class SentinelAlert:
+    id: str
     domain: str
     reason: str
+    rule: str
+    severity: str
     action: AgentAction
     timestamp: datetime
+    block_number: Optional[int]
+    metadata: Dict[str, object]
 
 
 @dataclass(slots=True)
 class SentinelRule:
     name: str
     description: str
-    predicate: Callable[[AgentAction], bool]
+    predicate: Callable[[AgentAction, "DomainState"], bool]
+    severity: str = "HIGH"
+
+
+@dataclass(slots=True)
+class PauseRecord:
+    domain: str
+    reason: str
+    triggered_by: str
+    timestamp: datetime
+    block_number: Optional[int]
+    metadata: Dict[str, object] = field(default_factory=dict)
+    resumed_at: Optional[datetime] = None
+    resumed_by: Optional[str] = None
+    resumed_block: Optional[int] = None
+
+
+@dataclass(slots=True)
+class DomainState:
+    id: str
+    human_name: str
+    budget_limit: Decimal
+    unsafe_opcodes: set[str] = field(default_factory=set)
+    allowed_targets: set[str] = field(default_factory=set)
+    allowed_target_hashes: set[str] = field(default_factory=set)
+    max_calldata_bytes: int = 0
+    forbidden_selectors: set[str] = field(default_factory=set)
+    pause_record: Optional[PauseRecord] = None
+
+    @property
+    def paused(self) -> bool:
+        return self.pause_record is not None
 
 
 class DomainPauseController:
     """Manages emergency domain pauses triggered by Sentinel alerts."""
 
-    def __init__(self, event_bus: EventBus) -> None:
+    def __init__(self, event_bus: EventBus, domains: Optional[Iterable[Dict[str, object]]] = None) -> None:
         self._event_bus = event_bus
-        self._paused: Dict[str, datetime] = {}
+        self._domains: Dict[str, DomainState] = {}
+        if domains:
+            for domain in domains:
+                self.register_domain(**domain)
 
-    def pause(self, domain: str, reason: str) -> None:
-        if domain not in self._paused:
-            timestamp = datetime.now(timezone.utc)
-            self._paused[domain] = timestamp
-            self._event_bus.publish(
-                "DomainPaused", {"domain": domain, "reason": reason, "timestamp": timestamp.isoformat()}
-            )
+    def register_domain(
+        self,
+        *,
+        domain: str,
+        human_name: str,
+        budget_limit: float | Decimal,
+        unsafe_opcodes: Iterable[str] | None = None,
+        allowed_targets: Iterable[str] | None = None,
+        max_calldata_bytes: int = 0,
+        forbidden_selectors: Iterable[str] | None = None,
+    ) -> DomainState:
+        normalized_targets = {_normalize_target(target) for target in allowed_targets or ()}
+        state = DomainState(
+            id=domain,
+            human_name=human_name,
+            budget_limit=Decimal(str(budget_limit)),
+            unsafe_opcodes={opcode.upper() for opcode in (unsafe_opcodes or ())},
+            allowed_targets=normalized_targets,
+            allowed_target_hashes={_hash_target(target) for target in normalized_targets},
+            max_calldata_bytes=max(0, int(max_calldata_bytes)),
+            forbidden_selectors={_normalize_selector(selector) for selector in (forbidden_selectors or ())},
+        )
+        self._domains[state.id] = state
+        self._event_bus.publish(
+            "DomainRegistered",
+            {
+                "domain": state.id,
+                "humanName": state.human_name,
+                "budgetLimit": float(state.budget_limit),
+                "maxCalldataBytes": state.max_calldata_bytes,
+            },
+        )
+        return state
 
-    def resume(self, domain: str, operator: str) -> None:
-        if domain in self._paused:
-            timestamp = self._paused.pop(domain)
-            self._event_bus.publish(
-                "DomainResumed",
-                {"domain": domain, "operator": operator, "pausedAt": timestamp.isoformat()},
-            )
+    def _get(self, domain: str) -> DomainState:
+        if domain not in self._domains:
+            raise KeyError(f"Unknown domain '{domain}'")
+        return self._domains[domain]
+
+    def pause(
+        self,
+        domain: str,
+        reason: str,
+        triggered_by: str,
+        block_number: Optional[int] = None,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> PauseRecord:
+        state = self._get(domain)
+        if state.pause_record:
+            return state.pause_record
+        timestamp = datetime.now(timezone.utc)
+        record = PauseRecord(
+            domain=state.id,
+            reason=reason,
+            triggered_by=triggered_by,
+            timestamp=timestamp,
+            block_number=block_number,
+            metadata=dict(metadata or {}),
+        )
+        state.pause_record = record
+        self._event_bus.publish(
+            "DomainPaused",
+            {
+                "domain": state.id,
+                "humanName": state.human_name,
+                "reason": reason,
+                "triggeredBy": triggered_by,
+                "timestamp": timestamp.isoformat(),
+                "blockNumber": block_number,
+                "metadata": record.metadata,
+            },
+        )
+        return record
+
+    def resume(self, domain: str, operator: str, block_number: Optional[int] = None) -> PauseRecord:
+        state = self._get(domain)
+        if not state.pause_record:
+            raise RuntimeError("Domain is not paused")
+        record = state.pause_record
+        record.resumed_at = datetime.now(timezone.utc)
+        record.resumed_by = operator
+        record.resumed_block = block_number
+        state.pause_record = None
+        self._event_bus.publish(
+            "DomainResumed",
+            {
+                "domain": state.id,
+                "humanName": state.human_name,
+                "operator": operator,
+                "resumedAt": record.resumed_at.isoformat(),
+                "blockNumber": block_number,
+            },
+        )
+        return record
+
+    def update_domain(
+        self,
+        domain: str,
+        *,
+        human_name: Optional[str] = None,
+        budget_limit: Optional[float | Decimal] = None,
+        unsafe_opcodes: Optional[Iterable[str]] = None,
+        allowed_targets: Optional[Iterable[str]] = None,
+        max_calldata_bytes: Optional[int] = None,
+        forbidden_selectors: Optional[Iterable[str]] = None,
+    ) -> DomainState:
+        state = self._get(domain)
+        if human_name is not None:
+            state.human_name = human_name
+        if budget_limit is not None:
+            state.budget_limit = Decimal(str(budget_limit))
+        if unsafe_opcodes is not None:
+            state.unsafe_opcodes = {opcode.upper() for opcode in unsafe_opcodes}
+        if allowed_targets is not None:
+            normalized_targets = {_normalize_target(target) for target in allowed_targets}
+            state.allowed_targets = normalized_targets
+            state.allowed_target_hashes = {_hash_target(target) for target in normalized_targets}
+        if max_calldata_bytes is not None:
+            state.max_calldata_bytes = max(0, int(max_calldata_bytes))
+        if forbidden_selectors is not None:
+            state.forbidden_selectors = {_normalize_selector(selector) for selector in forbidden_selectors}
+        self._event_bus.publish(
+            "DomainSafetyUpdated",
+            {
+                "domain": state.id,
+                "humanName": state.human_name,
+                "budgetLimit": float(state.budget_limit),
+                "maxCalldataBytes": state.max_calldata_bytes,
+                "unsafeOpcodes": sorted(state.unsafe_opcodes),
+                "allowedTargets": sorted(state.allowed_targets),
+                "forbiddenSelectors": sorted(state.forbidden_selectors),
+            },
+        )
+        return state
 
     def is_paused(self, domain: str) -> bool:
-        return domain in self._paused
+        return self._get(domain).paused
 
     @property
-    def paused_domains(self) -> Dict[str, datetime]:
-        return dict(self._paused)
+    def paused_domains(self) -> Dict[str, PauseRecord]:
+        return {domain: state.pause_record for domain, state in self._domains.items() if state.pause_record}
+
+    def get_state(self, domain: str) -> DomainState:
+        return self._get(domain)
+
+    def list_domains(self) -> Tuple[DomainState, ...]:
+        return tuple(self._domains.values())
 
 
 class SentinelMonitor:
     """Runs deterministic anomaly detection rules across agent actions."""
 
-    def __init__(self, rules: Iterable[SentinelRule], pause_controller: DomainPauseController, event_bus: EventBus) -> None:
-        self.rules = list(rules)
-        self.pause_controller = pause_controller
-        self.event_bus = event_bus
+    def __init__(
+        self,
+        *,
+        pause_controller: DomainPauseController,
+        event_bus: EventBus,
+        budget_grace_ratio: float = 0.05,
+        custom_rules: Optional[Iterable[SentinelRule]] = None,
+    ) -> None:
+        self._pause_controller = pause_controller
+        self._event_bus = event_bus
+        self._budget_grace_ratio = Decimal(str(budget_grace_ratio))
+        self._spend_tracker: Dict[Tuple[str, str], Decimal] = {}
+        self._custom_rules = list(custom_rules or [])
         self.alerts: List[SentinelAlert] = []
 
     def evaluate(self, action: AgentAction) -> Optional[SentinelAlert]:
-        if self.pause_controller.is_paused(action.domain):
+        state = self._pause_controller.get_state(action.domain)
+        if state.paused:
             return None
-        for rule in self.rules:
-            if rule.predicate(action):
-                alert = SentinelAlert(
-                    domain=action.domain,
+
+        block_number = action.block_number
+        if block_number is None:
+            block_metadata = action.metadata.get("blockNumber") or action.metadata.get("block")
+            if isinstance(block_metadata, int):
+                block_number = block_metadata
+
+        alert = self._check_budget(state, action, block_number)
+        if alert:
+            return alert
+
+        alert = self._check_opcode(state, action, block_number)
+        if alert:
+            return alert
+
+        alert = self._check_selector(state, action, block_number)
+        if alert:
+            return alert
+
+        alert = self._check_target(state, action, block_number)
+        if alert:
+            return alert
+
+        alert = self._check_calldata(state, action, block_number)
+        if alert:
+            return alert
+
+        if action.metadata.get("restricted"):
+            return self._raise_alert(
+                state,
+                action,
+                rule="RESTRICTED_CALL",
+                reason="Agent invoked a restricted function",
+                severity="CRITICAL",
+                metadata={"call": action.call},
+                block_number=block_number,
+            )
+
+        for rule in self._custom_rules:
+            if rule.predicate(action, state):
+                return self._raise_alert(
+                    state,
+                    action,
+                    rule=rule.name,
                     reason=rule.description,
-                    action=action,
-                    timestamp=datetime.now(timezone.utc),
+                    severity=rule.severity,
+                    metadata=dict(action.metadata),
+                    block_number=block_number,
                 )
-                self.alerts.append(alert)
-                self.pause_controller.pause(action.domain, reason=rule.description)
-                self.event_bus.publish(
-                    "SentinelAlert",
-                    {
-                        "domain": action.domain,
-                        "reason": rule.description,
-                        "agent": action.agent,
-                        "call": action.call,
-                        "spend": action.spend,
-                        "metadata": action.metadata,
-                    },
-                )
-                return alert
+
         return None
 
-    def resume_domain(self, domain: str, operator: str) -> None:
-        self.pause_controller.resume(domain, operator)
+    def _check_budget(
+        self, state: DomainState, action: AgentAction, block_number: Optional[int]
+    ) -> Optional[SentinelAlert]:
+        tracker_key = (
+            state.id,
+            (action.agent_address or action.agent).lower(),
+        )
+        spend = Decimal(str(action.spend))
+        previous = self._spend_tracker.get(tracker_key, Decimal(0))
+        updated = previous + spend
+        self._spend_tracker[tracker_key] = updated
+
+        raw_budget = action.metadata.get("budget") or action.metadata.get("budgetLimit")
+        budget = Decimal(str(raw_budget)) if raw_budget is not None else state.budget_limit
+        if budget <= 0:
+            budget = state.budget_limit
+        grace = budget * self._budget_grace_ratio
+        if updated > budget + grace:
+            return self._raise_alert(
+                state,
+                action,
+                rule="BUDGET_OVERRUN",
+                reason=f"Agent exceeded budget in {state.human_name}",
+                severity="CRITICAL",
+                metadata={
+                    "spent": float(updated),
+                    "budget": float(budget),
+                    "grace": float(grace),
+                },
+                block_number=block_number,
+            )
+        return None
+
+    def _check_opcode(
+        self, state: DomainState, action: AgentAction, block_number: Optional[int]
+    ) -> Optional[SentinelAlert]:
+        if not action.opcode:
+            return None
+        opcode = action.opcode.upper()
+        if opcode in state.unsafe_opcodes:
+            return self._raise_alert(
+                state,
+                action,
+                rule="UNSAFE_OPCODE",
+                reason=f"Unsafe opcode {opcode} invoked",
+                severity="HIGH",
+                metadata={"opcode": opcode},
+                block_number=block_number,
+            )
+        return None
+
+    def _check_selector(
+        self, state: DomainState, action: AgentAction, block_number: Optional[int]
+    ) -> Optional[SentinelAlert]:
+        selector = action.function_selector or action.metadata.get("functionSelector")
+        if selector is None:
+            selector = action.metadata.get("function_selector")
+        if not isinstance(selector, str):
+            return None
+        normalized = _normalize_selector(selector)
+        if normalized in state.forbidden_selectors:
+            return self._raise_alert(
+                state,
+                action,
+                rule="FORBIDDEN_SELECTOR",
+                reason=f"Function selector {normalized} blocked",
+                severity="CRITICAL",
+                metadata={
+                    "selector": normalized,
+                    "allowed": sorted(state.forbidden_selectors),
+                },
+                block_number=block_number,
+            )
+        return None
+
+    def _check_target(
+        self, state: DomainState, action: AgentAction, block_number: Optional[int]
+    ) -> Optional[SentinelAlert]:
+        if not state.allowed_targets:
+            return None
+        target = action.target or action.metadata.get("target")
+        if not isinstance(target, str):
+            return None
+        normalized = _normalize_target(target)
+        hashed = _hash_target(normalized)
+        if normalized not in state.allowed_targets and hashed not in state.allowed_target_hashes:
+            return self._raise_alert(
+                state,
+                action,
+                rule="UNAUTHORIZED_TARGET",
+                reason=f"Target {target} is not authorised",
+                severity="CRITICAL",
+                metadata={
+                    "target": target,
+                    "normalized": normalized,
+                },
+                block_number=block_number,
+            )
+        return None
+
+    def _check_calldata(
+        self, state: DomainState, action: AgentAction, block_number: Optional[int]
+    ) -> Optional[SentinelAlert]:
+        if state.max_calldata_bytes <= 0:
+            return None
+        calldata_bytes = action.calldata_bytes
+        if calldata_bytes is None:
+            raw = action.metadata.get("calldataBytes") or action.metadata.get("calldata_bytes")
+            if raw is not None:
+                calldata_bytes = int(raw)
+        if calldata_bytes is None:
+            return None
+        if calldata_bytes > state.max_calldata_bytes:
+            return self._raise_alert(
+                state,
+                action,
+                rule="CALLDATA_EXPLOSION",
+                reason=f"Calldata size {calldata_bytes}b exceeds limit",
+                severity="HIGH",
+                metadata={
+                    "calldataBytes": calldata_bytes,
+                    "threshold": state.max_calldata_bytes,
+                },
+                block_number=block_number,
+            )
+        return None
+
+    def _raise_alert(
+        self,
+        state: DomainState,
+        action: AgentAction,
+        *,
+        rule: str,
+        reason: str,
+        severity: str,
+        metadata: Dict[str, object],
+        block_number: Optional[int],
+    ) -> SentinelAlert:
+        record = self._pause_controller.pause(
+            state.id,
+            reason=reason,
+            triggered_by=f"sentinel::{rule}",
+            block_number=block_number,
+            metadata={
+                "agent": action.agent,
+                "call": action.call,
+                **metadata,
+            },
+        )
+        alert = SentinelAlert(
+            id=f"{rule}-{uuid4().hex}",
+            domain=state.id,
+            reason=reason,
+            rule=rule,
+            severity=severity,
+            action=action,
+            timestamp=record.timestamp,
+            block_number=block_number,
+            metadata=dict(metadata),
+        )
+        self.alerts.append(alert)
+        spend_value = float(Decimal(str(action.spend)))
+        self._event_bus.publish(
+            "SentinelAlert",
+            {
+                "domain": state.id,
+                "humanName": state.human_name,
+                "rule": rule,
+                "reason": reason,
+                "severity": severity,
+                "agent": action.agent,
+                "agentAddress": action.agent_address,
+                "call": action.call,
+                "spend": spend_value,
+                "metadata": metadata,
+                "blockNumber": block_number,
+                "pauseRecord": {
+                    "triggeredBy": record.triggered_by,
+                    "timestamp": record.timestamp.isoformat(),
+                    "reason": record.reason,
+                },
+            },
+        )
+        return alert
+
+    def resume_domain(self, domain: str, operator: str, block_number: Optional[int] = None) -> PauseRecord:
+        return self._pause_controller.resume(domain, operator, block_number=block_number)
 
     def add_rule(self, rule: SentinelRule) -> None:
-        self.rules.append(rule)
+        self._custom_rules.append(rule)
+
+    def update_budget_grace_ratio(self, ratio: float) -> None:
+        if ratio < 0:
+            raise ValueError("Budget grace ratio cannot be negative")
+        self._budget_grace_ratio = Decimal(str(ratio))
+
+    def get_budget_grace_ratio(self) -> float:
+        return float(self._budget_grace_ratio)
+
+    def update_domain_policy(self, domain: str, **changes: object) -> DomainState:
+        return self._pause_controller.update_domain(domain, **changes)
+
+    def domain_policy(self, domain: str) -> DomainState:
+        return self._pause_controller.get_state(domain)

--- a/demo/Validator-Constellation-v0/validator_constellation/subgraph.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/subgraph.py
@@ -32,6 +32,9 @@ class SubgraphIndexer:
             "RoundFinalized",
             "PhaseTransition",
             "ConfigUpdated",
+            "DomainSafetyUpdated",
+            "DomainRegistered",
+            "SentinelConfigUpdated",
         }
         if event.type in indexed_types:
             self.events.append(


### PR DESCRIPTION
## Summary
- expand the validator constellation sentinel to enforce budget, opcode, selector, target, calldata, and custom risk rules while emitting rich pause records
- empower the owner console with domain pause, policy, and sentinel configuration controls and surface new telemetry through the CLI summary
- extend the demo scenario, subgraph indexing, and regression tests to exercise multi-domain anomalies, governance actions, and exported alert streams

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Validator-Constellation-v0/tests

------
https://chatgpt.com/codex/tasks/task_e_69015e52a0808333a88609c3ee57c346