### PR TITLE
Add shock resilience analytics and UI surfaces to Economic Power demo

### DIFF
--- a/demo/Economic-Power-v0/README.md
+++ b/demo/Economic-Power-v0/README.md
@@ -40,6 +40,7 @@ Outputs land in `demo/Economic-Power-v0/reports/`:
 - `owner-autopilot.mmd` – mermaid control graph visualising cadence, guardrails, and command objectives.
 - `global-expansion-plan.md` – markdown roadmap breaking down testnet supremacy, mainnet pilot, planetary expansion, and governance acceleration phases.
 - `global-expansion.mmd` – mermaid gantt of the expansion cadence, immediately embeddable into ops dashboards.
+- `shock-resilience.json` – fortified shock defence dossier detailing score, drivers, recommendations, and telemetry powering the resilience gauge.
 
 > **Non-technical quick start** – run `npm run demo:economic-power` then open `demo/Economic-Power-v0/ui/index.html` with any static server (`npx http-server demo/Economic-Power-v0/ui`). The command refreshes `ui/data/default-summary.json`, so the dashboard autoloads the latest generated reports immediately.
 
@@ -124,6 +125,7 @@ The UI inside `demo/Economic-Power-v0/ui/` offers:
 - Owner command Mermaid graph mapping multi-sig authority to every module, circuit breaker, and upgrade path.
 - Drag-and-drop support for alternative `summary.json` files for instant what-if exploration.
 - Sovereign safety mesh panel cataloguing pause/resume playbooks, emergency contacts, circuit breakers, and module upgrade routes.
+- Shock resilience cockpit rendering the new fortified index, classification chip, driver analysis, and recommended countermeasures.
 - Owner dominion index panel quantifying composite control, safety, and custody readiness with live guardrail and action feed.
 - Safety mesh diagnostics scoring response readiness, alert channel breadth, circuit breaker posture, command coverage depth, and scripted responses.
 - Governance ledger visual linking custody posture, audit staleness, and alert feed directly from `owner-governance-ledger.json`.

--- a/demo/Economic-Power-v0/reports/assertions.json
+++ b/demo/Economic-Power-v0/reports/assertions.json
@@ -63,6 +63,24 @@
     ]
   },
   {
+    "id": "shock-resilience",
+    "title": "Shock resilience remains at fortified threshold or higher",
+    "outcome": "pass",
+    "severity": "critical",
+    "summary": "Shock defences surpass the fortified threshold ensuring economic continuity under stress.",
+    "target": 0.9,
+    "metric": 0.98,
+    "evidence": [
+      "Stability index 76.1%",
+      "Guardrail coverage 98.7%",
+      "Risk dampening 73.4%",
+      "Emergency depth 3 contact(s)",
+      "Alert mesh 2 channel(s)",
+      "Operations buffer 14.4% of treasury",
+      "Automation density 85.2%"
+    ]
+  },
+  {
     "id": "treasury-resilience",
     "title": "Treasury remains solvent after every execution step",
     "outcome": "pass",

--- a/demo/Economic-Power-v0/reports/baseline-summary.json
+++ b/demo/Economic-Power-v0/reports/baseline-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T23:41:12.298Z",
+  "executionTimestamp": "2025-10-29T02:17:06.884Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -28,7 +28,8 @@
     "assertionPassRate": 1,
     "economicDominanceIndex": 0.994,
     "capitalVelocity": 26290.99,
-    "globalExpansionReadiness": 0.966
+    "globalExpansionReadiness": 0.966,
+    "shockResilienceScore": 0.98
   },
   "ownerControl": {
     "threshold": "4-of-7",
@@ -110,7 +111,10 @@
     "alertChannels": [
       "slack://agi-ops-economic-power",
       "pagerduty://agi-critical"
-    ]
+    ],
+    "shockResilienceScore": 0.98,
+    "shockResilienceClassification": "impregnable",
+    "shockResilienceSummary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield."
   },
   "commandCatalog": {
     "jobPrograms": [
@@ -674,7 +678,10 @@
       "security-operations@agijobs.ai",
       "treasury@agijobs.ai"
     ],
-    "notes": []
+    "notes": [],
+    "shockResilienceScore": 0.98,
+    "shockClassification": "impregnable",
+    "shockSummary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield."
   },
   "assertions": [
     {
@@ -738,6 +745,24 @@
         "job-governance-upgrade:quorum=5/5;confidence=0.979",
         "job-market-expansion:quorum=4/4;confidence=0.985",
         "job-oracle-integration:quorum=3/3;confidence=0.982"
+      ]
+    },
+    {
+      "id": "shock-resilience",
+      "title": "Shock resilience remains at fortified threshold or higher",
+      "outcome": "pass",
+      "severity": "critical",
+      "summary": "Shock defences surpass the fortified threshold ensuring economic continuity under stress.",
+      "target": 0.9,
+      "metric": 0.98,
+      "evidence": [
+        "Stability index 76.1%",
+        "Guardrail coverage 98.7%",
+        "Risk dampening 73.4%",
+        "Emergency depth 3 contact(s)",
+        "Alert mesh 2 channel(s)",
+        "Operations buffer 14.4% of treasury",
+        "Automation density 85.2%"
       ]
     },
     {
@@ -1075,11 +1100,12 @@
       "automationScore < 0.8 → npm run owner:parameters",
       "treasuryAfterRun < 1800000 → npm run owner:audit"
     ],
-    "narrative": "Autopilot cycles every 6.7h to refresh capital, validator posture, and orchestrator coverage.",
+    "narrative": "Autopilot cycles every 6.7h to refresh capital, validator posture, and orchestrator coverage while preserving 98.0% shock resilience (impregnable).",
     "telemetry": {
       "economicDominanceIndex": 0.994,
       "capitalVelocity": 26290.99,
-      "globalExpansionReadiness": 0.966
+      "globalExpansionReadiness": 0.966,
+      "shockResilienceScore": 0.98
     },
     "commandSequence": [
       {
@@ -1185,7 +1211,8 @@
       "Safety mesh 97.9%",
       "Custody 100.0%",
       "Guardrails 5",
-      "Response 9m"
+      "Response 9m",
+      "Shock resilience 98.0% (impregnable)"
     ],
     "recommendedActions": [
       "Maintain autopilot cadence and periodic drills to preserve total dominion."
@@ -1249,5 +1276,31 @@
         "alerts=1"
       ]
     }
-  ]
+  ],
+  "shockResilience": {
+    "score": 0.98,
+    "classification": "impregnable",
+    "summary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield.",
+    "drivers": [
+      "Stability index 76.1%",
+      "Guardrail coverage 98.7%",
+      "Risk dampening 73.4%",
+      "Emergency depth 3 contact(s)",
+      "Alert mesh 2 channel(s)",
+      "Operations buffer 14.4% of treasury",
+      "Automation density 85.2%"
+    ],
+    "recommendations": [
+      "Maintain drill cadence and telemetry mirroring to preserve impregnable resilience."
+    ],
+    "telemetry": {
+      "stabilityIndex": 0.761,
+      "guardrailCoverage": 0.9873999999999999,
+      "riskFactor": 0.7344999999999999,
+      "emergencyContacts": 3,
+      "alertChannels": 2,
+      "bufferRatio": 0.144,
+      "automationDensity": 0.852152943997299
+    }
+  }
 }

--- a/demo/Economic-Power-v0/reports/economic-dominance.json
+++ b/demo/Economic-Power-v0/reports/economic-dominance.json
@@ -1,12 +1,13 @@
 {
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T23:41:44.154Z",
+  "executionTimestamp": "2025-10-29T02:17:06.884Z",
   "dominanceIndex": 0.994,
   "capitalVelocity": 26290.99,
   "roiMultiplier": 3.28,
   "automationScore": 0.852,
   "sovereignSafetyScore": 0.979,
   "sovereignControlScore": 1,
+  "shockResilienceScore": 0.98,
   "summary": "Economic dominance index blends ROI, automation, sovereignty, and safety mesh readiness to evidence unstoppable scale.",
   "recommendations": [
     "Maintain current cadence; dominance metrics exceed unstoppable thresholds."

--- a/demo/Economic-Power-v0/reports/global-expansion-plan.md
+++ b/demo/Economic-Power-v0/reports/global-expansion-plan.md
@@ -1,7 +1,7 @@
 # Global Expansion Autopilot Plan
 
 Scenario: AGIJobs Economic Power Launch
-Generated 2025-10-28T23:41:44.154Z • Dominance 99.4%
+Generated 2025-10-29T02:17:06.884Z • Dominance 99.4%
 
 ## Phase I – Testnet Supremacy
 

--- a/demo/Economic-Power-v0/reports/owner-autopilot.json
+++ b/demo/Economic-Power-v0/reports/owner-autopilot.json
@@ -9,11 +9,12 @@
     "automationScore < 0.8 → npm run owner:parameters",
     "treasuryAfterRun < 1800000 → npm run owner:audit"
   ],
-  "narrative": "Autopilot cycles every 6.7h to refresh capital, validator posture, and orchestrator coverage.",
+  "narrative": "Autopilot cycles every 6.7h to refresh capital, validator posture, and orchestrator coverage while preserving 98.0% shock resilience (impregnable).",
   "telemetry": {
     "economicDominanceIndex": 0.994,
     "capitalVelocity": 26290.99,
-    "globalExpansionReadiness": 0.966
+    "globalExpansionReadiness": 0.966,
+    "shockResilienceScore": 0.98
   },
   "commandSequence": [
     {

--- a/demo/Economic-Power-v0/reports/owner-command-plan.md
+++ b/demo/Economic-Power-v0/reports/owner-command-plan.md
@@ -1,6 +1,6 @@
 # Owner Command Playbook
 
-Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/28/2025, 11:41:44 PM (UTC)
+Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/29/2025, 2:17:06 AM (UTC)
 
 Command coverage: 100.0% — Owner multi-sig holds deterministic runbooks for every critical surface.
 

--- a/demo/Economic-Power-v0/reports/owner-dominion.json
+++ b/demo/Economic-Power-v0/reports/owner-dominion.json
@@ -33,7 +33,8 @@
     "Safety mesh 97.9%",
     "Custody 100.0%",
     "Guardrails 5",
-    "Response 9m"
+    "Response 9m",
+    "Shock resilience 98.0% (impregnable)"
   ],
   "recommendedActions": [
     "Maintain autopilot cadence and periodic drills to preserve total dominion."

--- a/demo/Economic-Power-v0/reports/owner-sovereignty.json
+++ b/demo/Economic-Power-v0/reports/owner-sovereignty.json
@@ -54,5 +54,8 @@
   "stabilityIndex": 0.761,
   "ownerCommandCoverage": 1,
   "sovereignControlScore": 1,
-  "sovereignSafetyScore": 0.979
+  "sovereignSafetyScore": 0.979,
+  "shockResilienceScore": 0.98,
+  "shockResilienceClassification": "impregnable",
+  "shockResilienceSummary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield."
 }

--- a/demo/Economic-Power-v0/reports/shock-resilience.json
+++ b/demo/Economic-Power-v0/reports/shock-resilience.json
@@ -1,0 +1,26 @@
+{
+  "score": 0.98,
+  "classification": "impregnable",
+  "summary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield.",
+  "drivers": [
+    "Stability index 76.1%",
+    "Guardrail coverage 98.7%",
+    "Risk dampening 73.4%",
+    "Emergency depth 3 contact(s)",
+    "Alert mesh 2 channel(s)",
+    "Operations buffer 14.4% of treasury",
+    "Automation density 85.2%"
+  ],
+  "recommendations": [
+    "Maintain drill cadence and telemetry mirroring to preserve impregnable resilience."
+  ],
+  "telemetry": {
+    "stabilityIndex": 0.761,
+    "guardrailCoverage": 0.9873999999999999,
+    "riskFactor": 0.7344999999999999,
+    "emergencyContacts": 3,
+    "alertChannels": 2,
+    "bufferRatio": 0.144,
+    "automationDensity": 0.852152943997299
+  }
+}

--- a/demo/Economic-Power-v0/reports/sovereign-safety-mesh.json
+++ b/demo/Economic-Power-v0/reports/sovereign-safety-mesh.json
@@ -18,5 +18,8 @@
     "security-operations@agijobs.ai",
     "treasury@agijobs.ai"
   ],
-  "notes": []
+  "notes": [],
+  "shockResilienceScore": 0.98,
+  "shockClassification": "impregnable",
+  "shockSummary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield."
 }

--- a/demo/Economic-Power-v0/reports/summary.json
+++ b/demo/Economic-Power-v0/reports/summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T23:41:44.154Z",
+  "executionTimestamp": "2025-10-29T02:17:06.884Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -28,7 +28,8 @@
     "assertionPassRate": 1,
     "economicDominanceIndex": 0.994,
     "capitalVelocity": 26290.99,
-    "globalExpansionReadiness": 0.966
+    "globalExpansionReadiness": 0.966,
+    "shockResilienceScore": 0.98
   },
   "ownerControl": {
     "threshold": "4-of-7",
@@ -110,7 +111,10 @@
     "alertChannels": [
       "slack://agi-ops-economic-power",
       "pagerduty://agi-critical"
-    ]
+    ],
+    "shockResilienceScore": 0.98,
+    "shockResilienceClassification": "impregnable",
+    "shockResilienceSummary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield."
   },
   "commandCatalog": {
     "jobPrograms": [
@@ -674,7 +678,10 @@
       "security-operations@agijobs.ai",
       "treasury@agijobs.ai"
     ],
-    "notes": []
+    "notes": [],
+    "shockResilienceScore": 0.98,
+    "shockClassification": "impregnable",
+    "shockSummary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield."
   },
   "assertions": [
     {
@@ -738,6 +745,24 @@
         "job-governance-upgrade:quorum=5/5;confidence=0.979",
         "job-market-expansion:quorum=4/4;confidence=0.985",
         "job-oracle-integration:quorum=3/3;confidence=0.982"
+      ]
+    },
+    {
+      "id": "shock-resilience",
+      "title": "Shock resilience remains at fortified threshold or higher",
+      "outcome": "pass",
+      "severity": "critical",
+      "summary": "Shock defences surpass the fortified threshold ensuring economic continuity under stress.",
+      "target": 0.9,
+      "metric": 0.98,
+      "evidence": [
+        "Stability index 76.1%",
+        "Guardrail coverage 98.7%",
+        "Risk dampening 73.4%",
+        "Emergency depth 3 contact(s)",
+        "Alert mesh 2 channel(s)",
+        "Operations buffer 14.4% of treasury",
+        "Automation density 85.2%"
       ]
     },
     {
@@ -1075,11 +1100,12 @@
       "automationScore < 0.8 → npm run owner:parameters",
       "treasuryAfterRun < 1800000 → npm run owner:audit"
     ],
-    "narrative": "Autopilot cycles every 6.7h to refresh capital, validator posture, and orchestrator coverage.",
+    "narrative": "Autopilot cycles every 6.7h to refresh capital, validator posture, and orchestrator coverage while preserving 98.0% shock resilience (impregnable).",
     "telemetry": {
       "economicDominanceIndex": 0.994,
       "capitalVelocity": 26290.99,
-      "globalExpansionReadiness": 0.966
+      "globalExpansionReadiness": 0.966,
+      "shockResilienceScore": 0.98
     },
     "commandSequence": [
       {
@@ -1185,7 +1211,8 @@
       "Safety mesh 97.9%",
       "Custody 100.0%",
       "Guardrails 5",
-      "Response 9m"
+      "Response 9m",
+      "Shock resilience 98.0% (impregnable)"
     ],
     "recommendedActions": [
       "Maintain autopilot cadence and periodic drills to preserve total dominion."
@@ -1249,5 +1276,31 @@
         "alerts=1"
       ]
     }
-  ]
+  ],
+  "shockResilience": {
+    "score": 0.98,
+    "classification": "impregnable",
+    "summary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield.",
+    "drivers": [
+      "Stability index 76.1%",
+      "Guardrail coverage 98.7%",
+      "Risk dampening 73.4%",
+      "Emergency depth 3 contact(s)",
+      "Alert mesh 2 channel(s)",
+      "Operations buffer 14.4% of treasury",
+      "Automation density 85.2%"
+    ],
+    "recommendations": [
+      "Maintain drill cadence and telemetry mirroring to preserve impregnable resilience."
+    ],
+    "telemetry": {
+      "stabilityIndex": 0.761,
+      "guardrailCoverage": 0.9873999999999999,
+      "riskFactor": 0.7344999999999999,
+      "emergencyContacts": 3,
+      "alertChannels": 2,
+      "bufferRatio": 0.144,
+      "automationDensity": 0.852152943997299
+    }
+  }
 }

--- a/demo/Economic-Power-v0/scripts/ownerAutopilot.ts
+++ b/demo/Economic-Power-v0/scripts/ownerAutopilot.ts
@@ -33,6 +33,11 @@ type AutopilotBrief = {
   guardrails: string[];
   commandSequence: Summary['ownerAutopilot']['commandSequence'];
   telemetry: Summary['ownerAutopilot']['telemetry'];
+  shockResilienceScore: number;
+  shockResilienceClassification: Summary['shockResilience']['classification'];
+  shockResilienceSummary: string;
+  shockResilienceDrivers: string[];
+  shockResilienceRecommendations: string[];
   coverage: number;
   coverageNarrative: string;
   coverageDetail: Summary['ownerCommandPlan']['coverageDetail'];
@@ -70,6 +75,11 @@ export function buildAutopilotBrief(summary: Summary): AutopilotBrief {
     guardrails: [...autopilot.guardrails],
     commandSequence: [...autopilot.commandSequence],
     telemetry: { ...autopilot.telemetry },
+    shockResilienceScore: summary.shockResilience.score,
+    shockResilienceClassification: summary.shockResilience.classification,
+    shockResilienceSummary: summary.shockResilience.summary,
+    shockResilienceDrivers: [...summary.shockResilience.drivers],
+    shockResilienceRecommendations: [...summary.shockResilience.recommendations],
     coverage: summary.ownerCommandPlan.commandCoverage,
     coverageNarrative: summary.ownerCommandPlan.coverageNarrative,
     coverageDetail: { ...summary.ownerCommandPlan.coverageDetail },
@@ -178,6 +188,26 @@ export function renderAutopilotBrief(brief: AutopilotBrief): string {
   lines.push(
     `- Global expansion readiness: ${formatPercent(brief.telemetry.globalExpansionReadiness)}`,
   );
+  lines.push(`- Shock resilience: ${formatPercent(brief.telemetry.shockResilienceScore)}`);
+  lines.push('');
+
+  lines.push('## Shock resilience posture');
+  lines.push(
+    `- Score: ${formatPercent(brief.shockResilienceScore)} (${brief.shockResilienceClassification})`,
+  );
+  lines.push(`- Summary: ${brief.shockResilienceSummary}`);
+  if (brief.shockResilienceDrivers.length > 0) {
+    lines.push('- Drivers:');
+    for (const driver of brief.shockResilienceDrivers) {
+      lines.push(`  - ${driver}`);
+    }
+  }
+  if (brief.shockResilienceRecommendations.length > 0) {
+    lines.push('- Recommended actions:');
+    for (const rec of brief.shockResilienceRecommendations) {
+      lines.push(`  - ${rec}`);
+    }
+  }
   lines.push('');
 
   lines.push('## Dominance signals');

--- a/demo/Economic-Power-v0/ui/data/default-summary.json
+++ b/demo/Economic-Power-v0/ui/data/default-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-28T23:41:12.298Z",
+  "executionTimestamp": "2025-10-29T02:17:06.884Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -28,7 +28,8 @@
     "assertionPassRate": 1,
     "economicDominanceIndex": 0.994,
     "capitalVelocity": 26290.99,
-    "globalExpansionReadiness": 0.966
+    "globalExpansionReadiness": 0.966,
+    "shockResilienceScore": 0.98
   },
   "ownerControl": {
     "threshold": "4-of-7",
@@ -110,7 +111,10 @@
     "alertChannels": [
       "slack://agi-ops-economic-power",
       "pagerduty://agi-critical"
-    ]
+    ],
+    "shockResilienceScore": 0.98,
+    "shockResilienceClassification": "impregnable",
+    "shockResilienceSummary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield."
   },
   "commandCatalog": {
     "jobPrograms": [
@@ -674,7 +678,10 @@
       "security-operations@agijobs.ai",
       "treasury@agijobs.ai"
     ],
-    "notes": []
+    "notes": [],
+    "shockResilienceScore": 0.98,
+    "shockClassification": "impregnable",
+    "shockSummary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield."
   },
   "assertions": [
     {
@@ -738,6 +745,24 @@
         "job-governance-upgrade:quorum=5/5;confidence=0.979",
         "job-market-expansion:quorum=4/4;confidence=0.985",
         "job-oracle-integration:quorum=3/3;confidence=0.982"
+      ]
+    },
+    {
+      "id": "shock-resilience",
+      "title": "Shock resilience remains at fortified threshold or higher",
+      "outcome": "pass",
+      "severity": "critical",
+      "summary": "Shock defences surpass the fortified threshold ensuring economic continuity under stress.",
+      "target": 0.9,
+      "metric": 0.98,
+      "evidence": [
+        "Stability index 76.1%",
+        "Guardrail coverage 98.7%",
+        "Risk dampening 73.4%",
+        "Emergency depth 3 contact(s)",
+        "Alert mesh 2 channel(s)",
+        "Operations buffer 14.4% of treasury",
+        "Automation density 85.2%"
       ]
     },
     {
@@ -1075,11 +1100,12 @@
       "automationScore < 0.8 → npm run owner:parameters",
       "treasuryAfterRun < 1800000 → npm run owner:audit"
     ],
-    "narrative": "Autopilot cycles every 6.7h to refresh capital, validator posture, and orchestrator coverage.",
+    "narrative": "Autopilot cycles every 6.7h to refresh capital, validator posture, and orchestrator coverage while preserving 98.0% shock resilience (impregnable).",
     "telemetry": {
       "economicDominanceIndex": 0.994,
       "capitalVelocity": 26290.99,
-      "globalExpansionReadiness": 0.966
+      "globalExpansionReadiness": 0.966,
+      "shockResilienceScore": 0.98
     },
     "commandSequence": [
       {
@@ -1185,7 +1211,8 @@
       "Safety mesh 97.9%",
       "Custody 100.0%",
       "Guardrails 5",
-      "Response 9m"
+      "Response 9m",
+      "Shock resilience 98.0% (impregnable)"
     ],
     "recommendedActions": [
       "Maintain autopilot cadence and periodic drills to preserve total dominion."
@@ -1249,5 +1276,31 @@
         "alerts=1"
       ]
     }
-  ]
+  ],
+  "shockResilience": {
+    "score": 0.98,
+    "classification": "impregnable",
+    "summary": "Shockwaves are fully absorbed – treasury buffers, guardrails, and automation form an impregnable shield.",
+    "drivers": [
+      "Stability index 76.1%",
+      "Guardrail coverage 98.7%",
+      "Risk dampening 73.4%",
+      "Emergency depth 3 contact(s)",
+      "Alert mesh 2 channel(s)",
+      "Operations buffer 14.4% of treasury",
+      "Automation density 85.2%"
+    ],
+    "recommendations": [
+      "Maintain drill cadence and telemetry mirroring to preserve impregnable resilience."
+    ],
+    "telemetry": {
+      "stabilityIndex": 0.761,
+      "guardrailCoverage": 0.9873999999999999,
+      "riskFactor": 0.7344999999999999,
+      "emergencyContacts": 3,
+      "alertChannels": 2,
+      "bufferRatio": 0.144,
+      "automationDensity": 0.852152943997299
+    }
+  }
 }

--- a/demo/Economic-Power-v0/ui/index.html
+++ b/demo/Economic-Power-v0/ui/index.html
@@ -190,6 +190,22 @@
               <span id="safety-score"></span>
             </p>
             <p id="safety-response"></p>
+            <p>
+              <strong>Shock resilience:</strong>
+              <span id="shock-score"></span>
+              <span id="shock-classification" class="shock-chip">Awaiting data</span>
+            </p>
+            <p id="shock-summary" class="narrative"></p>
+            <div class="grid-two">
+              <div>
+                <h4>Shock resilience drivers</h4>
+                <ul id="shock-drivers"></ul>
+              </div>
+              <div>
+                <h4>Shock resilience actions</h4>
+                <ul id="shock-actions"></ul>
+              </div>
+            </div>
             <div class="table-wrapper">
               <table id="safety-metrics" aria-label="Safety mesh diagnostics">
                 <thead>

--- a/demo/Economic-Power-v0/ui/script.js
+++ b/demo/Economic-Power-v0/ui/script.js
@@ -98,6 +98,12 @@ const metricMap = [
     formatter: (value) => `${(value * 100).toFixed(1)}%`,
     description: 'Readiness index for unlocking mainnet pilots and planetary rollout.',
   },
+  {
+    id: 'shockResilienceScore',
+    label: 'Shock Resilience',
+    formatter: (value) => `${(value * 100).toFixed(1)}%`,
+    description: 'Composite resilience score fusing guardrails, emergency response, and treasury buffers.',
+  },
 ];
 
 async function loadSummary(path) {
@@ -290,6 +296,13 @@ function renderSovereignty(summary) {
     alertChannels: [],
     notes: [],
   };
+  const shockResilience = summary.shockResilience || {
+    score: 0,
+    classification: 'attention',
+    summary: 'Shock resilience telemetry unavailable.',
+    drivers: [],
+    recommendations: [],
+  };
 
   const safetyScoreEl = document.getElementById('safety-score');
   if (safetyScoreEl) {
@@ -299,6 +312,52 @@ function renderSovereignty(summary) {
   const safetyResponseEl = document.getElementById('safety-response');
   if (safetyResponseEl) {
     safetyResponseEl.textContent = `Response readiness: ${safetyMesh.responseMinutes} minutes (target ≤ ${safetyMesh.targetResponseMinutes} minutes)`;
+  }
+
+  const shockScoreEl = document.getElementById('shock-score');
+  const shockClassificationEl = document.getElementById('shock-classification');
+  const shockSummaryEl = document.getElementById('shock-summary');
+  if (shockScoreEl) {
+    shockScoreEl.textContent = `${(shockResilience.score * 100).toFixed(1)}%`;
+  }
+  if (shockClassificationEl) {
+    shockClassificationEl.textContent = shockResilience.classification.replace(/-/g, ' ');
+    shockClassificationEl.className = `shock-chip shock-${shockResilience.classification}`;
+  }
+  if (shockSummaryEl) {
+    shockSummaryEl.textContent = shockResilience.summary;
+  }
+
+  const shockDrivers = document.getElementById('shock-drivers');
+  if (shockDrivers) {
+    shockDrivers.innerHTML = '';
+    if (shockResilience.drivers && shockResilience.drivers.length > 0) {
+      for (const driver of shockResilience.drivers) {
+        const li = document.createElement('li');
+        li.textContent = driver;
+        shockDrivers.append(li);
+      }
+    } else {
+      const li = document.createElement('li');
+      li.textContent = 'No drivers published.';
+      shockDrivers.append(li);
+    }
+  }
+
+  const shockActions = document.getElementById('shock-actions');
+  if (shockActions) {
+    shockActions.innerHTML = '';
+    if (shockResilience.recommendations && shockResilience.recommendations.length > 0) {
+      for (const rec of shockResilience.recommendations) {
+        const li = document.createElement('li');
+        li.textContent = rec;
+        shockActions.append(li);
+      }
+    } else {
+      const li = document.createElement('li');
+      li.textContent = 'Shock resilience already impregnable.';
+      shockActions.append(li);
+    }
   }
 
   const safetyTable = document.querySelector('#safety-metrics tbody');
@@ -715,12 +774,13 @@ function renderAutopilot(summary) {
       economicDominanceIndex: 0,
       capitalVelocity: 0,
       globalExpansionReadiness: 0,
+      shockResilienceScore: 0,
     },
     commandSequence: [],
   };
   missionEl.textContent = autopilot.mission;
   cadenceEl.textContent = `${autopilot.cadenceHours.toFixed(1)}h cadence`;
-  dominanceEl.textContent = `${(autopilot.telemetry.economicDominanceIndex * 100).toFixed(1)}% dominance • ${autopilot.telemetry.capitalVelocity.toFixed(2)} AGI/h • ${(autopilot.telemetry.globalExpansionReadiness * 100).toFixed(1)}% readiness`;
+  dominanceEl.textContent = `${(autopilot.telemetry.economicDominanceIndex * 100).toFixed(1)}% dominance • ${autopilot.telemetry.capitalVelocity.toFixed(2)} AGI/h • ${(autopilot.telemetry.globalExpansionReadiness * 100).toFixed(1)}% readiness • ${(autopilot.telemetry.shockResilienceScore * 100).toFixed(1)}% shock resilience`;
   guardrailList.innerHTML = '';
   for (const guardrail of autopilot.guardrails) {
     const li = document.createElement('li');

--- a/demo/Economic-Power-v0/ui/styles.css
+++ b/demo/Economic-Power-v0/ui/styles.css
@@ -237,6 +237,39 @@ main {
   border-color: rgba(248, 113, 113, 0.6);
 }
 
+.shock-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.2);
+  border: 1px solid rgba(14, 165, 233, 0.45);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.shock-chip.shock-impregnable {
+  background: rgba(34, 197, 94, 0.24);
+  border-color: rgba(34, 197, 94, 0.65);
+}
+
+.shock-chip.shock-fortified {
+  background: rgba(59, 130, 246, 0.24);
+  border-color: rgba(59, 130, 246, 0.6);
+}
+
+.shock-chip.shock-resilient {
+  background: rgba(250, 204, 21, 0.24);
+  border-color: rgba(250, 204, 21, 0.55);
+}
+
+.shock-chip.shock-attention {
+  background: rgba(248, 113, 113, 0.28);
+  border-color: rgba(248, 113, 113, 0.65);
+}
+
 .dominion-readiness {
   font-size: 0.9rem;
   color: var(--text-secondary);
@@ -606,8 +639,25 @@ main {
   gap: 0.25rem;
 }
 
+#shock-drivers,
+#shock-actions {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 #alert-channels li,
 #safety-notes li {
+  list-style: none;
+  position: relative;
+  padding-left: 1.5rem;
+}
+
+#shock-drivers li,
+#shock-actions li {
   list-style: none;
   position: relative;
   padding-left: 1.5rem;
@@ -621,6 +671,18 @@ main {
 
 #safety-notes li::before {
   content: '✳️';
+  position: absolute;
+  left: 0;
+}
+
+#shock-drivers li::before {
+  content: '🛡️';
+  position: absolute;
+  left: 0;
+}
+
+#shock-actions li::before {
+  content: '🚀';
   position: absolute;
   left: 0;
 }


### PR DESCRIPTION
## Summary
- extend the Economic Power simulation to compute and persist a shock resilience report, wiring it into metrics, assertions, governance, and autopilot telemetry
- update the UI, default summary, and documentation to surface the new resilience cockpit alongside regenerated artifacts

## Testing
- npm run test:economic-power

------
https://chatgpt.com/codex/tasks/task_e_6901752e199c8333bcc4c4c4f6777c6d