### PR TITLE
Add blueprint-driven orchestration workflow

### DIFF
--- a/demo/Planetary-Orchestrator-Fabric-v0/README.md
+++ b/demo/Planetary-Orchestrator-Fabric-v0/README.md
@@ -36,6 +36,7 @@ This demo packages **Planetary Orchestrator Fabric** as a runnable, checkpointab
   ```bash
   demo/Planetary-Orchestrator-Fabric-v0/bin/run-demo.sh \
      --jobs 10000 \
+     --jobs-blueprint demo/Planetary-Orchestrator-Fabric-v0/config/jobs.blueprint.example.json \
      --simulate-outage "mars.gpu-helion" \
      --checkpoint-interval 30 \
      --output-label "kardashev-kill-switch" \
@@ -46,6 +47,7 @@ This demo packages **Planetary Orchestrator Fabric** as a runnable, checkpointab
   demo/Planetary-Orchestrator-Fabric-v0/bin/run-restart-drill.sh \
      --jobs 12000 \
      --stop-after 200 \
+     --jobs-blueprint demo/Planetary-Orchestrator-Fabric-v0/config/jobs.blueprint.example.json \
      --label "resume-drill" \
      --owner-commands demo/Planetary-Orchestrator-Fabric-v0/config/owner-commands.example.json
   ```
@@ -57,6 +59,7 @@ This demo packages **Planetary Orchestrator Fabric** as a runnable, checkpointab
     --jobs-high-load 10000 \
     --outage-node mars.gpu-helion
   ```
+  Add `--jobs-blueprint demo/Planetary-Orchestrator-Fabric-v0/config/jobs.blueprint.example.json` to the command above to replay the curated Kardashev workload during the acceptance suite.
   This executes both the 10k-job load trial and the orchestrator kill/resume drill, fails fast if <98% of work completes, and writes a consolidated JSON verdict alongside all mission artifacts.
 6. **Review telemetry in the static mission console** by opening `demo/Planetary-Orchestrator-Fabric-v0/ui/dashboard.html` in your browser and dropping the freshly generated `reports/<label>` folder onto the page. The console renders shard tables, owner command summaries, spillover mermaid diagrams, and ledger invariants instantly—even offline.
 7. **Open the run-specific dashboard** at `demo/Planetary-Orchestrator-Fabric-v0/reports/<label>/dashboard.html` to explore the same data pre-linked to that execution with zero configuration.
@@ -120,6 +123,7 @@ flowchart TD
 | `bin/run-demo.sh` | One-command launcher for the full demo flow. |
 | `bin/run-restart-drill.sh` | Two-phase orchestrator kill/resume drill that stitches checkpoint + resume artifacts. |
 | `config/fabric.example.json` | Declarative definition of shards, nodes, owner policies, checkpoint schedules. |
+| `config/jobs.blueprint.example.json` | Declarative workload blueprint empowering non-technical owners to set the planetary agenda. |
 | `config/owner-commands.example.json` | Sample schedule of owner commands applied mid-run. |
 | `docs/architecture.md` | Deep dive into the architecture with additional diagrams, latency budgets, and ledger mapping. |
 | `docs/owner-control.md` | Owner empowerment manual with pause/update scripts and governance hooks. |
@@ -159,6 +163,7 @@ flowchart TD
 ## Next Steps
 
 - Integrate live blockchain endpoints (mainnet, L2, or planetary rollups) by filling in the placeholders in `config/fabric.example.json`.
+- Clone `config/jobs.blueprint.example.json` to define your own workload mix—adjust shard counts, skills, and durations, then pass the new file via `--jobs-blueprint`.
 - Wire container registries and GPU fleets by connecting the node marketplace to Kubernetes, Nomad, or bare-metal pools.
 - Attach treasury/payment processors via the existing reward engine scripts in `scripts/v2/`.
 - Publish dashboards to IPFS or internal portals by copying the generated HTML + JSON artifacts.

--- a/demo/Planetary-Orchestrator-Fabric-v0/bin/run-restart-drill.sh
+++ b/demo/Planetary-Orchestrator-Fabric-v0/bin/run-restart-drill.sh
@@ -10,6 +10,7 @@ JOBS=10000
 STOP_AFTER=180
 OUTAGE="mars.gpu-helion"
 LABEL=""
+BLUEPRINT=""
 
 usage() {
   cat <<USAGE
@@ -20,6 +21,7 @@ Usage: $(basename "$0") [options]
   --jobs <count>              Total jobs to seed before the drill (default: 10000)
   --stop-after <ticks>        Number of ticks to run before simulating orchestrator shutdown (default: 180)
   --outage <nodeId>           Node ID to mark offline during stage one (default: mars.gpu-helion)
+  --jobs-blueprint <path>     Optional job blueprint JSON applied to both stages
   --label <name>              Label for generated reports (default: resume-drill-<timestamp>)
   -h, --help                  Show this message
 USAGE
@@ -49,6 +51,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --label)
       LABEL="$2"
+      shift 2
+      ;;
+    --jobs-blueprint)
+      BLUEPRINT="$2"
       shift 2
       ;;
     -h|--help)
@@ -87,6 +93,9 @@ fi
 if [[ -n "$OUTAGE" ]]; then
   CMD_STAGE_ONE+=(--simulate-outage "$OUTAGE")
 fi
+if [[ -n "$BLUEPRINT" ]]; then
+  CMD_STAGE_ONE+=(--jobs-blueprint "$BLUEPRINT")
+fi
 "${CMD_STAGE_ONE[@]}"
 
 echo "🔎 Capturing checkpoint path from stage one"
@@ -123,6 +132,9 @@ CMD_STAGE_TWO=(
 )
 if [[ -n "$OWNER_COMMANDS" ]]; then
   CMD_STAGE_TWO+=(--owner-commands "$OWNER_COMMANDS")
+fi
+if [[ -n "$BLUEPRINT" ]]; then
+  CMD_STAGE_TWO+=(--jobs-blueprint "$BLUEPRINT")
 fi
 "${CMD_STAGE_TWO[@]}"
 

--- a/demo/Planetary-Orchestrator-Fabric-v0/config/jobs.blueprint.example.json
+++ b/demo/Planetary-Orchestrator-Fabric-v0/config/jobs.blueprint.example.json
@@ -1,0 +1,65 @@
+{
+  "metadata": {
+    "label": "Kardashev Acceptance Blueprint",
+    "description": "Curated workload spanning Earth, Luna, Mars, and Helios to showcase sharded orchestration.",
+    "author": "Planetary Fabric Owner",
+    "version": "1.0"
+  },
+  "jobs": [
+    {
+      "idPrefix": "earth-finance",
+      "shard": "earth",
+      "skills": ["finance", "compliance"],
+      "duration": 3,
+      "value": 2500,
+      "valueStep": 25,
+      "count": 1200,
+      "note": "High-value regulatory reviews"
+    },
+    {
+      "idPrefix": "earth-logistics",
+      "shard": "earth",
+      "skills": ["logistics", "edge"],
+      "duration": 2,
+      "value": 1800,
+      "valueStep": 10,
+      "count": 800
+    },
+    {
+      "idPrefix": "luna-nav",
+      "shard": "luna",
+      "skills": ["navigation", "observation"],
+      "duration": 4,
+      "value": 2100,
+      "count": 600,
+      "note": "Orbital telemetry harmonisation"
+    },
+    {
+      "idPrefix": "mars-foundry",
+      "shard": "mars",
+      "skills": ["manufacturing", "terraforming"],
+      "duration": 5,
+      "value": 3200,
+      "valueStep": 15,
+      "count": 1400
+    },
+    {
+      "idPrefix": "mars-gpu",
+      "shard": "mars",
+      "skills": ["gpu", "vision", "simulation"],
+      "duration": 6,
+      "value": 3600,
+      "valueStep": 20,
+      "count": 1000,
+      "note": "GPU-heavy inference jobs reroute to Helios on outage"
+    },
+    {
+      "idPrefix": "helios-astronomy",
+      "shard": "helios",
+      "skills": ["gpu", "astronomy"],
+      "duration": 7,
+      "value": 4000,
+      "count": 800
+    }
+  ]
+}

--- a/demo/Planetary-Orchestrator-Fabric-v0/docs/ci.md
+++ b/demo/Planetary-Orchestrator-Fabric-v0/docs/ci.md
@@ -40,6 +40,8 @@ npm run test:planetary-orchestrator-fabric
 npm run demo:planetary-orchestrator-fabric:ci
 # Optional: run the combined acceptance suite locally
 npm run demo:planetary-orchestrator-fabric:acceptance -- --label local-acceptance
+# Optional: replay the curated blueprint during acceptance
+npm run demo:planetary-orchestrator-fabric:acceptance -- --label local-blueprint --jobs-blueprint demo/Planetary-Orchestrator-Fabric-v0/config/jobs.blueprint.example.json
 # Optional: rehearse the restart drill locally
 demo/Planetary-Orchestrator-Fabric-v0/bin/run-restart-drill.sh --label ci-drill
 ```

--- a/demo/Planetary-Orchestrator-Fabric-v0/docs/mission-blueprint.md
+++ b/demo/Planetary-Orchestrator-Fabric-v0/docs/mission-blueprint.md
@@ -9,6 +9,7 @@ This dossier documents the first-principles planning behind the restart-ready up
 3. **Simulation Enhancements** – Persist run metadata (`stopAfterTicks`, early termination reason, resume flag) into `summary.json`, events, and logs.
 4. **Testing & CI Reinforcement** – Expand deterministic tests to cover the stop/resume drill and ensure event streams capture the halt.
 5. **Operator Guidance** – Update docs, dashboards, and quickstarts so owners understand the new controls and audit surfaces.
+6. **Blueprinted Workloads** – Allow non-technical owners to load declarative job blueprints so restart drills replay the same Kardashev mix deterministically.
 
 ## Multi-Angle Verification Matrix
 

--- a/demo/Planetary-Orchestrator-Fabric-v0/src/config-loader.ts
+++ b/demo/Planetary-Orchestrator-Fabric-v0/src/config-loader.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import { resolve } from 'path';
-import { FabricConfig, OwnerCommandSchedule, SpilloverPolicy } from './types';
+import { FabricConfig, JobBlueprint, OwnerCommandSchedule, SpilloverPolicy } from './types';
+import { loadJobBlueprint as loadBlueprint } from './job-blueprint';
 
 function cloneSpilloverPolicies(policies: SpilloverPolicy[] | undefined): SpilloverPolicy[] | undefined {
   if (!policies) {
@@ -78,4 +79,8 @@ export function cloneOwnerCommandSchedule(
     note: schedule.note,
     command: JSON.parse(JSON.stringify(schedule.command)) as OwnerCommandSchedule['command'],
   }));
+}
+
+export async function loadJobBlueprint(path: string): Promise<JobBlueprint> {
+  return loadBlueprint(path);
 }

--- a/demo/Planetary-Orchestrator-Fabric-v0/src/job-blueprint.ts
+++ b/demo/Planetary-Orchestrator-Fabric-v0/src/job-blueprint.ts
@@ -1,0 +1,149 @@
+import { promises as fs } from 'fs';
+import { resolve } from 'path';
+import { z } from 'zod';
+import { FabricConfig, JobDefinition, JobBlueprint, JobBlueprintEntry, ShardConfig } from './types';
+
+const jobEntrySchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    idPrefix: z.string().min(1).optional(),
+    shard: z.string().min(1),
+    requiredSkills: z.array(z.string().min(1)).optional(),
+    skills: z.array(z.string().min(1)).optional(),
+    estimatedDurationTicks: z.number().int().positive().optional(),
+    duration: z.number().int().positive().optional(),
+    value: z.number().positive().optional(),
+    valueStep: z.number().nonnegative().optional(),
+    submissionTick: z.number().int().nonnegative().optional(),
+    count: z.number().int().positive().optional(),
+    note: z.string().optional(),
+  })
+  .refine(
+    (entry) => {
+      if (entry.count && entry.count > 1) {
+        return Boolean(entry.idPrefix || entry.id === undefined);
+      }
+      return true;
+    },
+    {
+      message: 'Entries with count > 1 must omit id or provide idPrefix',
+      path: ['idPrefix'],
+    }
+  );
+
+const jobBlueprintSchema = z.object({
+  metadata: z
+    .object({
+      label: z.string().optional(),
+      description: z.string().optional(),
+      author: z.string().optional(),
+      version: z.string().optional(),
+    })
+    .optional(),
+  jobs: z.array(jobEntrySchema),
+});
+
+function normaliseEntry(entry: z.infer<typeof jobEntrySchema>): JobBlueprintEntry {
+  const requiredSkills = entry.requiredSkills ?? entry.skills ?? ['general'];
+  const estimatedDurationTicks = entry.estimatedDurationTicks ?? entry.duration ?? 1;
+  return {
+    id: entry.id,
+    idPrefix: entry.idPrefix,
+    shard: entry.shard,
+    requiredSkills,
+    estimatedDurationTicks,
+    value: entry.value,
+    valueStep: entry.valueStep,
+    submissionTick: entry.submissionTick,
+    count: entry.count ?? 1,
+    note: entry.note,
+  };
+}
+
+export async function loadJobBlueprint(path: string): Promise<JobBlueprint> {
+  const blueprintPath = resolve(path);
+  const raw = await fs.readFile(blueprintPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  const result = jobBlueprintSchema.parse(parsed);
+  return {
+    metadata: result.metadata,
+    jobs: result.jobs.map(normaliseEntry),
+    source: blueprintPath,
+  };
+}
+
+function ensureShard(config: FabricConfig, shardId: string): ShardConfig {
+  const shard = config.shards.find((entry) => entry.id === shardId);
+  if (!shard) {
+    throw new Error(`Blueprint references unknown shard ${shardId}`);
+  }
+  return shard;
+}
+
+function generateJobId(
+  entry: JobBlueprintEntry,
+  shard: ShardConfig,
+  counters: Map<string, number>
+): string {
+  if (entry.count === 1 && entry.id) {
+    return entry.id;
+  }
+  const prefix = entry.idPrefix ?? entry.id ?? `${shard.id}-job`;
+  const current = counters.get(prefix) ?? 0;
+  counters.set(prefix, current + 1);
+  const suffix = (current + 1).toString().padStart(4, '0');
+  return `${prefix}-${suffix}`;
+}
+
+export function expandJobBlueprint(blueprint: JobBlueprint, config: FabricConfig): JobDefinition[] {
+  const counters = new Map<string, number>();
+  const jobs: JobDefinition[] = [];
+  for (const entry of blueprint.jobs) {
+    const shard = ensureShard(config, entry.shard);
+    const count = entry.count ?? 1;
+    for (let index = 0; index < count; index += 1) {
+      const id = generateJobId(entry, shard, counters);
+      const valueBase = entry.value ?? 1000;
+      const value = valueBase + (entry.valueStep ?? 0) * index;
+      jobs.push({
+        id,
+        shard: shard.id,
+        requiredSkills: entry.requiredSkills.length > 0 ? [...new Set(entry.requiredSkills)] : ['general'],
+        estimatedDurationTicks: Math.max(entry.estimatedDurationTicks ?? 1, 1),
+        value,
+        submissionTick: entry.submissionTick ?? 0,
+      });
+    }
+  }
+  return jobs;
+}
+
+export function countJobsInBlueprint(blueprint: JobBlueprint | undefined): number {
+  if (!blueprint) {
+    return 0;
+  }
+  return blueprint.jobs.reduce((total, entry) => total + (entry.count ?? 1), 0);
+}
+
+export function cloneJobBlueprint(blueprint: JobBlueprint | undefined): JobBlueprint | undefined {
+  if (!blueprint) {
+    return undefined;
+  }
+  return {
+    metadata: blueprint.metadata ? { ...blueprint.metadata } : undefined,
+    source: blueprint.source,
+    jobs: blueprint.jobs.map((entry) => ({
+      id: entry.id,
+      idPrefix: entry.idPrefix,
+      shard: entry.shard,
+      requiredSkills: [...entry.requiredSkills],
+      estimatedDurationTicks: entry.estimatedDurationTicks,
+      value: entry.value,
+      valueStep: entry.valueStep,
+      submissionTick: entry.submissionTick,
+      count: entry.count,
+      note: entry.note,
+    })),
+  };
+}
+

--- a/demo/Planetary-Orchestrator-Fabric-v0/src/types.ts
+++ b/demo/Planetary-Orchestrator-Fabric-v0/src/types.ts
@@ -40,6 +40,32 @@ export interface JobDefinition {
   submissionTick: number;
 }
 
+export interface JobBlueprintEntry {
+  id?: string;
+  idPrefix?: string;
+  shard: ShardId;
+  requiredSkills: string[];
+  estimatedDurationTicks?: number;
+  value?: number;
+  valueStep?: number;
+  submissionTick?: number;
+  count?: number;
+  note?: string;
+}
+
+export interface JobBlueprintMetadata {
+  label?: string;
+  description?: string;
+  author?: string;
+  version?: string;
+}
+
+export interface JobBlueprint {
+  metadata?: JobBlueprintMetadata;
+  jobs: JobBlueprintEntry[];
+  source?: string;
+}
+
 export type JobStatus =
   | "queued"
   | "assigned"
@@ -127,6 +153,8 @@ export interface SimulationOptions {
   ownerCommandSource?: string;
   stopAfterTicks?: number;
   preserveReportDirOnResume?: boolean;
+  jobBlueprint?: JobBlueprint;
+  jobBlueprintSource?: string;
 }
 
 export interface CheckpointData {

--- a/demo/Planetary-Orchestrator-Fabric-v0/ui/dashboard.html
+++ b/demo/Planetary-Orchestrator-Fabric-v0/ui/dashboard.html
@@ -322,6 +322,12 @@
     </section>
 
     <section class="panel">
+      <h2>Job Blueprint</h2>
+      <div id="blueprint-metrics" class="metrics"></div>
+      <pre class="json" id="blueprint-entries-json">Blueprint details will appear after loading telemetry.</pre>
+    </section>
+
+    <section class="panel">
       <h2>Shard Telemetry</h2>
       <table class="data-table" id="shard-table">
         <thead>
@@ -401,6 +407,8 @@
   <script>
     const statusEl = document.getElementById('status');
     const missionMetricsEl = document.getElementById('mission-metrics');
+    const blueprintMetricsEl = document.getElementById('blueprint-metrics');
+    const blueprintEntriesJsonEl = document.getElementById('blueprint-entries-json');
     const shardTableBody = document.querySelector('#shard-table tbody');
     const shardNoteEl = document.getElementById('shard-note');
     const ownerStatusEl = document.getElementById('owner-status');
@@ -460,6 +468,49 @@
           }
         )
         .join('');
+    }
+
+    function renderBlueprint(blueprint = {}, metrics = {}) {
+      if (blueprint && Object.keys(blueprint).length > 0) {
+        const cards = [];
+        const totalJobs = typeof blueprint.totalJobs === 'number' ? blueprint.totalJobs : metrics.jobsSubmitted;
+        if (typeof totalJobs === 'number') {
+          cards.push({ label: 'Total Jobs', value: totalJobs.toLocaleString() });
+        }
+        if (blueprint.metadata?.label) {
+          cards.push({ label: 'Label', value: blueprint.metadata.label });
+        }
+        if (blueprint.metadata?.description) {
+          cards.push({ label: 'Description', value: blueprint.metadata.description });
+        }
+        if (blueprint.metadata?.author) {
+          cards.push({ label: 'Author', value: blueprint.metadata.author });
+        }
+        if (blueprint.metadata?.version) {
+          cards.push({ label: 'Version', value: blueprint.metadata.version });
+        }
+        if (blueprint.source) {
+          cards.push({ label: 'Source', value: blueprint.source });
+        }
+        renderMetrics(blueprintMetricsEl, cards);
+        blueprintEntriesJsonEl.textContent = JSON.stringify(blueprint.entries ?? [], null, 2);
+      } else {
+        renderMetrics(blueprintMetricsEl, [
+          {
+            label: 'Mode',
+            value: 'Procedural',
+            hint: 'No job blueprint supplied; workload generated from shard skills.',
+          },
+        ]);
+        blueprintEntriesJsonEl.textContent = JSON.stringify(
+          {
+            note: 'Provide --jobs-blueprint to attach a declarative workload.',
+            submittedJobs: metrics.jobsSubmitted ?? 0,
+          },
+          null,
+          2
+        );
+      }
     }
 
     function renderShardTable(shards = {}, statistics = {}) {
@@ -690,6 +741,8 @@
           { label: 'Drop Rate', value: dropRate, hint: '<2% target enforced by acceptance autopilot.' },
         ]);
 
+        renderBlueprint(summary.jobBlueprint, metrics);
+
         renderShardTable(summary.shards, summary.shardStatistics || {});
         renderOwnerStatus(summary.ownerState || {
           systemPaused: false,
@@ -826,6 +879,50 @@
         executed: [{ tick: 120 }, { tick: 150 }],
         skippedBeforeResume: [{ tick: 90 }],
         pending: [{ tick: 240 }],
+      },
+      jobBlueprint: {
+        metadata: {
+          label: 'K-II Helios Bridge',
+          description: 'Declarative orchestration of Kardashev-II scale mission streams.',
+          author: 'Planetary Fabric Owner',
+          version: '1.0.0',
+        },
+        source: 'demo/Planetary-Orchestrator-Fabric-v0/config/jobs.blueprint.example.json',
+        totalJobs: 12000,
+        entries: [
+          {
+            shard: 'earth',
+            count: 4200,
+            requiredSkills: ['orchestration', 'capital-markets'],
+            estimatedDurationTicks: 4,
+            value: 1500,
+            note: 'Earth command lattice, sovereign settlements, and capital augmentation.',
+          },
+          {
+            shard: 'luna',
+            count: 2600,
+            requiredSkills: ['logistics', 'relay'],
+            estimatedDurationTicks: 3,
+            value: 1300,
+            note: 'Luna relay grid provisioning & cryogenic logistics support.',
+          },
+          {
+            shard: 'mars',
+            count: 3000,
+            requiredSkills: ['terraforming', 'mining'],
+            estimatedDurationTicks: 6,
+            value: 2100,
+            note: 'Mars regolith transmutation & terraforming initiative.',
+          },
+          {
+            shard: 'helios',
+            count: 2200,
+            requiredSkills: ['fusion', 'solar'],
+            estimatedDurationTicks: 5,
+            value: 2400,
+            note: 'Helios Dyson lattice expansion & antimatter capture arrays.',
+          },
+        ],
       },
       ledger: {
         totals: {


### PR DESCRIPTION
## Summary
- add declarative job blueprint ingestion with CLI, simulation, and acceptance wiring so operators can run curated workloads end-to-end
- document blueprint usage, surface example blueprint assets, and pipe the flag through restart drill automation
- expose job blueprint insights in the static dashboard alongside existing mission telemetry

## Testing
- npm run lint:planetary-orchestrator-fabric
- npm run test:planetary-orchestrator-fabric

------
https://chatgpt.com/codex/tasks/task_e_6901761596788333bd5e3b525ec49a9d