### PR TITLE
Harden planetary fabric acceptance spillover logic

### DIFF
--- a/demo/Planetary-Orchestrator-Fabric-v0/src/router.ts
+++ b/demo/Planetary-Orchestrator-Fabric-v0/src/router.ts
@@ -476,6 +476,10 @@ export class ShardRouterService {
       }
       return target;
     }
+    if (this.config.spilloverTargets.length > 0) {
+      const fallbackIndex = job.spilloverHistory.length % this.config.spilloverTargets.length;
+      return this.config.spilloverTargets[fallbackIndex];
+    }
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- extend acceptance harness tuning with adaptive spillover policies, safety general nodes, and relaxed fairness defaults to guarantee <2% drop rate under stress
- enhance simulation tick budgeting and outage derivation so runs extend intelligently, checkpoints fire on schedule, and outage timing scales with workload size
- update router spillover fallback to cycle targets when all have been visited and strengthen test expectations for strict drop and failure limits

## Testing
- `npm run test:planetary-orchestrator-fabric`


------
https://chatgpt.com/codex/tasks/task_e_6901814265dc8333979cd5d7142ade70