### PR TITLE
Add web telemetry export to Validator Constellation demo

### DIFF
--- a/demo/Validator-Constellation-v0/README.md
+++ b/demo/Validator-Constellation-v0/README.md
@@ -28,10 +28,13 @@ python run_demo.py \
   --commit-blocks 5 \
   --reveal-blocks 6 \
   --slash-non-reveal 0.35 \
-  --output summary.json
+  --output summary.json \
+  --web-artifacts web/data
 ```
 
 This single command spins up the validator constellation, performs VRF committee selection, executes the commit–reveal round with enforced block windows, batches 1,000 job attestations into one ZK proof, fires a Sentinel anomaly, and exports a JSON compliance bundle.  The JSON includes the selected committee, truthful outcome, slashed validator list, paused domains, proof root, gas saved by the batch attestation, the full timeline of the validation round, and a log of owner governance actions applied during the run.
+
+Passing `--web-artifacts web/data` additionally produces `summary.json`, `events.json`, `timeline.json`, and `owner-actions.json` files that the `web/index.html` command deck automatically ingests.  Open the HTML file locally after running the command to see the live metrics and sentinel alert stream updated with your run's telemetry.
 
 You can also run the package directly:
 

--- a/demo/Validator-Constellation-v0/validator_constellation/__init__.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/__init__.py
@@ -27,7 +27,7 @@ from .sentinel import (
     PauseRecord,
     DomainState,
 )
-from .demo_runner import run_validator_constellation_demo
+from .demo_runner import DemoSummary, run_validator_constellation_demo, summary_to_dict, write_web_artifacts
 from .subgraph import SubgraphIndexer, IndexedEvent
 from .governance import OwnerConsole, OwnerAction
 
@@ -57,5 +57,8 @@ __all__ = [
     "IndexedEvent",
     "OwnerConsole",
     "OwnerAction",
+    "DemoSummary",
+    "summary_to_dict",
+    "write_web_artifacts",
     "run_validator_constellation_demo",
 ]

--- a/demo/Validator-Constellation-v0/web/index.html
+++ b/demo/Validator-Constellation-v0/web/index.html
@@ -96,6 +96,35 @@
       .event strong {
         color: var(--accent-2);
       }
+      .event pre {
+        margin: 0.35rem 0 0;
+        white-space: pre-wrap;
+      }
+      .metrics-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+      }
+      .metric {
+        background: rgba(15, 23, 42, 0.6);
+        padding: 1rem;
+        border-radius: 0.75rem;
+        text-align: center;
+        box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.25);
+      }
+      .metric span {
+        display: block;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: rgba(148, 163, 184, 0.85);
+      }
+      .metric strong {
+        display: block;
+        margin-top: 0.35rem;
+        font-size: 1.35rem;
+        color: var(--fg);
+      }
     </style>
     <script>
       mermaid.initialize({ startOnLoad: true, theme: "dark" });
@@ -168,6 +197,12 @@ $ python run_demo.py \
 
     <section class="card-grid">
       <article class="card">
+        <h3>Mission Metrics</h3>
+        <div id="metrics" class="metrics-grid">
+          <p>Awaiting telemetry&hellip;</p>
+        </div>
+      </article>
+      <article class="card">
         <h3>Live Event Feed</h3>
         <div id="events" class="event-log"></div>
       </article>
@@ -188,7 +223,7 @@ $ python run_demo.py \
     </footer>
 
     <script>
-      const EVENT_DATA = [
+      const DEFAULT_EVENTS = [
         {
           type: "ValidatorRegistered",
           payload: {
@@ -265,13 +300,101 @@ $ python run_demo.py \
         },
       ];
 
-      const container = document.getElementById("events");
-      EVENT_DATA.forEach((event) => {
-        const wrapper = document.createElement("div");
-        wrapper.className = "event";
-        wrapper.innerHTML = `<strong>${event.type}</strong><br />${JSON.stringify(event.payload, null, 2)}`;
-        container.appendChild(wrapper);
-      });
+      const DEFAULT_SUMMARY = {
+        committee: {
+          "0xaa00000000000000000000000000000000000001": "atlas.club.agi.eth",
+          "0xaa00000000000000000000000000000000000002": "zephyr.club.agi.eth",
+          "0xaa00000000000000000000000000000000000003": "nova.club.agi.eth",
+        },
+        truthfulOutcome: true,
+        slashedValidators: ["0xaa00000000000000000000000000000000000003"],
+        pausedDomains: ["synthetic-biology"],
+        gasSaved: 218000000,
+      };
+
+      async function fetchJson(path) {
+        const response = await fetch(path, { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch ${path}: ${response.status}`);
+        }
+        return response.json();
+      }
+
+      function renderEvents(events) {
+        const container = document.getElementById("events");
+        if (!container) {
+          return;
+        }
+        container.innerHTML = "";
+        if (!Array.isArray(events) || events.length === 0) {
+          container.innerHTML = "<p>No events captured yet.</p>";
+          return;
+        }
+        events.slice(0, 24).forEach((event) => {
+          const wrapper = document.createElement("div");
+          wrapper.className = "event";
+          const payload = JSON.stringify(event.payload, null, 2);
+          wrapper.innerHTML = `<strong>${event.type}</strong><br /><pre>${payload}</pre>`;
+          container.appendChild(wrapper);
+        });
+      }
+
+      function renderMetrics(summary) {
+        const container = document.getElementById("metrics");
+        if (!container) {
+          return;
+        }
+        const committeeSize = summary.committee ? Object.keys(summary.committee).length : 0;
+        const paused = Array.isArray(summary.pausedDomains) ? summary.pausedDomains.length : 0;
+        const slashed = Array.isArray(summary.slashedValidators) ? summary.slashedValidators.length : 0;
+        const gasSaved = summary.gasSaved || 0;
+        const truthfulOutcome = summary.truthfulOutcome ? "APPROVE" : "REJECT";
+
+        const metrics = [
+          { label: "Validators", value: committeeSize },
+          { label: "Paused Domains", value: paused },
+          { label: "Slashed Validators", value: slashed },
+          {
+            label: "Gas Saved",
+            value: gasSaved ? `${Number(gasSaved).toLocaleString()} gas` : "0",
+          },
+          { label: "Outcome", value: truthfulOutcome },
+        ];
+        container.innerHTML = metrics
+          .map(
+            (metric) => `
+              <div class="metric">
+                <span>${metric.label}</span>
+                <strong>${metric.value}</strong>
+              </div>
+            `,
+          )
+          .join("");
+      }
+
+      async function bootstrap() {
+        let events = DEFAULT_EVENTS;
+        let summary = { ...DEFAULT_SUMMARY };
+        try {
+          const fetchedEvents = await fetchJson("data/events.json");
+          if (Array.isArray(fetchedEvents) && fetchedEvents.length) {
+            events = fetchedEvents;
+          }
+        } catch (error) {
+          console.warn("Using default events:", error);
+        }
+        renderEvents(events);
+
+        try {
+          const fetchedSummary = await fetchJson("data/summary.json");
+          summary = { ...summary, ...fetchedSummary };
+        } catch (error) {
+          console.warn("Using default summary:", error);
+        }
+        renderMetrics(summary);
+      }
+
+      bootstrap();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add JSON export helpers so the demo returns full event feeds and mission telemetry
- extend the CLI and documentation to surface the new `--web-artifacts` workflow for non-technical operators
- refresh the static command deck to ingest generated JSON and display live metrics alongside the event feed
- broaden automated coverage for the new helpers and exports

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Validator-Constellation-v0/tests

------
https://chatgpt.com/codex/tasks/task_e_690213114d1c8333b49fb099a1c39a50