### PR TITLE
Add superintelligence control layer to Economic Power demo

### DIFF
--- a/demo/Economic-Power-v0/README.md
+++ b/demo/Economic-Power-v0/README.md
@@ -43,6 +43,8 @@ Outputs land in `demo/Economic-Power-v0/reports/`:
 - `shock-resilience.json` – fortified shock defence dossier detailing score, drivers, recommendations, and telemetry powering the resilience gauge.
 - `owner-control-supremacy.json` – supremacy ledger fusing coverage, custody, safety mesh, guardrail density, and program coverage into a single index for the owner multi-sig.
 - `owner-control-supremacy.mmd` – mermaid supremacy map wiring coverage surfaces, program categories, and quick commands directly to the multi-sig authority.
+- `super-intelligence.json` – civilisation-scale superintelligence dossier quantifying dominance, supremacy, automation, safety, resilience, and expansion readiness.
+- `super-intelligence.mmd` – mermaid intelligence graph mapping dominance, supremacy, safety, automation, resilience, and expansion flows into the apex superintelligence node.
 
 > **Non-technical quick start** – run `npm run demo:economic-power` then open `demo/Economic-Power-v0/ui/index.html` with any static server (`npx http-server demo/Economic-Power-v0/ui`). The command refreshes `ui/data/default-summary.json`, so the dashboard autoloads the latest generated reports immediately.
 
@@ -130,6 +132,7 @@ The UI inside `demo/Economic-Power-v0/ui/` offers:
 - Shock resilience cockpit rendering the new fortified index, classification chip, driver analysis, and recommended countermeasures.
 - Owner dominion index panel quantifying composite control, safety, and custody readiness with live guardrail and action feed.
 - Owner supremacy mesh quantifying the new supremacy index, guardrail density, and program coverage with a live mermaid map.
+- Superintelligence control layer exposing the civilisation-scale superintelligence index, dominance drivers, command assurances, and a live mermaid contribution graph.
 - Safety mesh diagnostics scoring response readiness, alert channel breadth, circuit breaker posture, command coverage depth, and scripted responses.
 - Governance ledger visual linking custody posture, audit staleness, and alert feed directly from `owner-governance-ledger.json`.
 - Command catalog grid enumerating every deterministic owner program so the operator can launch missions instantly.

--- a/demo/Economic-Power-v0/reports/baseline-summary.json
+++ b/demo/Economic-Power-v0/reports/baseline-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-29T03:07:46.662Z",
+  "executionTimestamp": "2025-10-29T13:30:19.494Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -30,6 +30,7 @@
     "economicDominanceIndex": 0.994,
     "capitalVelocity": 26290.99,
     "globalExpansionReadiness": 0.966,
+    "superIntelligenceIndex": 0.968,
     "shockResilienceScore": 0.98
   },
   "ownerControl": {
@@ -1106,6 +1107,7 @@
       "economicDominanceIndex": 0.994,
       "capitalVelocity": 26290.99,
       "globalExpansionReadiness": 0.966,
+      "superIntelligenceIndex": 0.9681,
       "shockResilienceScore": 0.98
     },
     "commandSequence": [
@@ -1261,6 +1263,32 @@
       "Supremacy absolute – maintain guardrail rehearsals to preserve total control."
     ],
     "mermaid": "graph LR\n  OWNER[\"Owner Multi-Sig • Supremacy 99.7%\"]\n  OWNER --> Coverage[\"Command Coverage 100.0%\"]\n  OWNER --> Custody[\"Custody 100.0%\"]\n  OWNER --> Safety[\"Safety Mesh 97.9%\"]\n  OWNER --> Guardrails[\"Guardrail Coverage 100.0%\"]\n  OWNER --> Response[\"Response 9m\"]\n  Coverage --> Surface_0_jobs[\"Job orchestration 100.0%\"]\n  Coverage --> Surface_1_validators[\"Validator sovereignty 100.0%\"]\n  Coverage --> Surface_2_stablecoinAdapters[\"Stablecoin adapters 100.0%\"]\n  Coverage --> Surface_3_modules[\"Protocol modules 100.0%\"]\n  Coverage --> Surface_4_parameters[\"Parameter overrides 100.0%\"]\n  Coverage --> Surface_5_pause[\"Emergency pause 100.0%\"]\n  Coverage --> Surface_6_resume[\"Emergency resume 100.0%\"]\n  Coverage --> Surface_7_treasury[\"Treasury programs 100.0%\"]\n  Coverage --> Surface_8_orchestrator[\"Orchestrator mesh 100.0%\"]\n  Guardrails --> Program_0_job[\"Job programs 100.0%\"]\n  Guardrails --> Program_1_validator[\"Validator programs 100.0%\"]\n  Guardrails --> Program_2_adapter[\"Adapter programs 100.0%\"]\n  Guardrails --> Program_3_module[\"Module programs 100.0%\"]\n  Guardrails --> Program_4_treasury[\"Treasury programs 100.0%\"]\n  Guardrails --> Program_5_orchestrator[\"Orchestrator programs 100.0%\"]\n  Response --> Pause[\"Pause npm run owner:system-pause\"]\n  Response --> Resume[\"Resume npm run owner:update-all\"]\n"
+  },
+  "superIntelligence": {
+    "index": 0.9681,
+    "classification": "transcendent-dominion",
+    "narrative": "The owner multi-sig directs a civilisation-scale AGI lattice with unstoppable command authority, capital velocity, and risk absorption.",
+    "drivers": [
+      "Economic dominance 99.4% confirming runaway value capture.",
+      "Owner supremacy 99.7% with guardrail coverage 100.0% keeping every lever under direct command.",
+      "Sovereign safety 97.9% across 2 alert channels and 3 emergency contacts.",
+      "Automation mesh 85.2% orchestrating agents without human delay.",
+      "Shock resilience 98.0% ensuring capital velocity persists under failure scenarios."
+    ],
+    "commandAssurance": [
+      "Command coverage 100.0% across 9 sovereign surfaces.",
+      "Program supremacy guarantees 100.0% treasury control and 100.0% orchestrator automation.",
+      "Global expansion readiness 96.6% unlocks immediate replication across jurisdictions."
+    ],
+    "telemetry": {
+      "economicDominanceIndex": 0.994,
+      "ownerSupremacyIndex": 0.9968,
+      "sovereignSafetyScore": 0.979,
+      "automationScore": 0.852,
+      "shockResilienceScore": 0.98,
+      "globalExpansionReadiness": 0.966
+    },
+    "mermaid": "graph LR\n  EconomicDominance[\"Economic Dominance 99.4%\"] --> Apex[\"Superintelligence 96.8%\"]\n  OwnerSupremacy[\"Owner Supremacy 99.7%\"] --> Apex\n  SovereignSafety[\"Sovereign Safety 97.9%\"] --> Apex\n  Automation[\"Automation 85.2%\"] --> Apex\n  ShockResilience[\"Shock Resilience 98.0%\"] --> Apex\n  GlobalExpansion[\"Global Expansion 96.6%\"] --> Apex\n"
   },
   "globalExpansionPlan": [
     {

--- a/demo/Economic-Power-v0/reports/economic-dominance.json
+++ b/demo/Economic-Power-v0/reports/economic-dominance.json
@@ -1,6 +1,6 @@
 {
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-29T03:08:13.547Z",
+  "executionTimestamp": "2025-10-29T13:30:19.494Z",
   "dominanceIndex": 0.994,
   "capitalVelocity": 26290.99,
   "roiMultiplier": 3.28,

--- a/demo/Economic-Power-v0/reports/global-expansion-plan.md
+++ b/demo/Economic-Power-v0/reports/global-expansion-plan.md
@@ -1,7 +1,7 @@
 # Global Expansion Autopilot Plan
 
 Scenario: AGIJobs Economic Power Launch
-Generated 2025-10-29T03:08:13.547Z • Dominance 99.4%
+Generated 2025-10-29T13:30:19.494Z • Dominance 99.4%
 
 ## Phase I – Testnet Supremacy
 

--- a/demo/Economic-Power-v0/reports/owner-autopilot.json
+++ b/demo/Economic-Power-v0/reports/owner-autopilot.json
@@ -14,6 +14,7 @@
     "economicDominanceIndex": 0.994,
     "capitalVelocity": 26290.99,
     "globalExpansionReadiness": 0.966,
+    "superIntelligenceIndex": 0.9681,
     "shockResilienceScore": 0.98
   },
   "commandSequence": [

--- a/demo/Economic-Power-v0/reports/owner-command-plan.md
+++ b/demo/Economic-Power-v0/reports/owner-command-plan.md
@@ -1,6 +1,6 @@
 # Owner Command Playbook
 
-Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/29/2025, 3:08:13 AM (UTC)
+Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/29/2025, 1:30:19 PM (UTC)
 
 Command coverage: 100.0% — Owner multi-sig holds deterministic runbooks for every critical surface.
 

--- a/demo/Economic-Power-v0/reports/summary.json
+++ b/demo/Economic-Power-v0/reports/summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-29T03:08:13.547Z",
+  "executionTimestamp": "2025-10-29T13:30:19.494Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -30,6 +30,7 @@
     "economicDominanceIndex": 0.994,
     "capitalVelocity": 26290.99,
     "globalExpansionReadiness": 0.966,
+    "superIntelligenceIndex": 0.968,
     "shockResilienceScore": 0.98
   },
   "ownerControl": {
@@ -1106,6 +1107,7 @@
       "economicDominanceIndex": 0.994,
       "capitalVelocity": 26290.99,
       "globalExpansionReadiness": 0.966,
+      "superIntelligenceIndex": 0.9681,
       "shockResilienceScore": 0.98
     },
     "commandSequence": [
@@ -1261,6 +1263,32 @@
       "Supremacy absolute – maintain guardrail rehearsals to preserve total control."
     ],
     "mermaid": "graph LR\n  OWNER[\"Owner Multi-Sig • Supremacy 99.7%\"]\n  OWNER --> Coverage[\"Command Coverage 100.0%\"]\n  OWNER --> Custody[\"Custody 100.0%\"]\n  OWNER --> Safety[\"Safety Mesh 97.9%\"]\n  OWNER --> Guardrails[\"Guardrail Coverage 100.0%\"]\n  OWNER --> Response[\"Response 9m\"]\n  Coverage --> Surface_0_jobs[\"Job orchestration 100.0%\"]\n  Coverage --> Surface_1_validators[\"Validator sovereignty 100.0%\"]\n  Coverage --> Surface_2_stablecoinAdapters[\"Stablecoin adapters 100.0%\"]\n  Coverage --> Surface_3_modules[\"Protocol modules 100.0%\"]\n  Coverage --> Surface_4_parameters[\"Parameter overrides 100.0%\"]\n  Coverage --> Surface_5_pause[\"Emergency pause 100.0%\"]\n  Coverage --> Surface_6_resume[\"Emergency resume 100.0%\"]\n  Coverage --> Surface_7_treasury[\"Treasury programs 100.0%\"]\n  Coverage --> Surface_8_orchestrator[\"Orchestrator mesh 100.0%\"]\n  Guardrails --> Program_0_job[\"Job programs 100.0%\"]\n  Guardrails --> Program_1_validator[\"Validator programs 100.0%\"]\n  Guardrails --> Program_2_adapter[\"Adapter programs 100.0%\"]\n  Guardrails --> Program_3_module[\"Module programs 100.0%\"]\n  Guardrails --> Program_4_treasury[\"Treasury programs 100.0%\"]\n  Guardrails --> Program_5_orchestrator[\"Orchestrator programs 100.0%\"]\n  Response --> Pause[\"Pause npm run owner:system-pause\"]\n  Response --> Resume[\"Resume npm run owner:update-all\"]\n"
+  },
+  "superIntelligence": {
+    "index": 0.9681,
+    "classification": "transcendent-dominion",
+    "narrative": "The owner multi-sig directs a civilisation-scale AGI lattice with unstoppable command authority, capital velocity, and risk absorption.",
+    "drivers": [
+      "Economic dominance 99.4% confirming runaway value capture.",
+      "Owner supremacy 99.7% with guardrail coverage 100.0% keeping every lever under direct command.",
+      "Sovereign safety 97.9% across 2 alert channels and 3 emergency contacts.",
+      "Automation mesh 85.2% orchestrating agents without human delay.",
+      "Shock resilience 98.0% ensuring capital velocity persists under failure scenarios."
+    ],
+    "commandAssurance": [
+      "Command coverage 100.0% across 9 sovereign surfaces.",
+      "Program supremacy guarantees 100.0% treasury control and 100.0% orchestrator automation.",
+      "Global expansion readiness 96.6% unlocks immediate replication across jurisdictions."
+    ],
+    "telemetry": {
+      "economicDominanceIndex": 0.994,
+      "ownerSupremacyIndex": 0.9968,
+      "sovereignSafetyScore": 0.979,
+      "automationScore": 0.852,
+      "shockResilienceScore": 0.98,
+      "globalExpansionReadiness": 0.966
+    },
+    "mermaid": "graph LR\n  EconomicDominance[\"Economic Dominance 99.4%\"] --> Apex[\"Superintelligence 96.8%\"]\n  OwnerSupremacy[\"Owner Supremacy 99.7%\"] --> Apex\n  SovereignSafety[\"Sovereign Safety 97.9%\"] --> Apex\n  Automation[\"Automation 85.2%\"] --> Apex\n  ShockResilience[\"Shock Resilience 98.0%\"] --> Apex\n  GlobalExpansion[\"Global Expansion 96.6%\"] --> Apex\n"
   },
   "globalExpansionPlan": [
     {

--- a/demo/Economic-Power-v0/reports/super-intelligence.json
+++ b/demo/Economic-Power-v0/reports/super-intelligence.json
@@ -1,0 +1,26 @@
+{
+  "index": 0.9681,
+  "classification": "transcendent-dominion",
+  "narrative": "The owner multi-sig directs a civilisation-scale AGI lattice with unstoppable command authority, capital velocity, and risk absorption.",
+  "drivers": [
+    "Economic dominance 99.4% confirming runaway value capture.",
+    "Owner supremacy 99.7% with guardrail coverage 100.0% keeping every lever under direct command.",
+    "Sovereign safety 97.9% across 2 alert channels and 3 emergency contacts.",
+    "Automation mesh 85.2% orchestrating agents without human delay.",
+    "Shock resilience 98.0% ensuring capital velocity persists under failure scenarios."
+  ],
+  "commandAssurance": [
+    "Command coverage 100.0% across 9 sovereign surfaces.",
+    "Program supremacy guarantees 100.0% treasury control and 100.0% orchestrator automation.",
+    "Global expansion readiness 96.6% unlocks immediate replication across jurisdictions."
+  ],
+  "telemetry": {
+    "economicDominanceIndex": 0.994,
+    "ownerSupremacyIndex": 0.9968,
+    "sovereignSafetyScore": 0.979,
+    "automationScore": 0.852,
+    "shockResilienceScore": 0.98,
+    "globalExpansionReadiness": 0.966
+  },
+  "mermaid": "graph LR\n  EconomicDominance[\"Economic Dominance 99.4%\"] --> Apex[\"Superintelligence 96.8%\"]\n  OwnerSupremacy[\"Owner Supremacy 99.7%\"] --> Apex\n  SovereignSafety[\"Sovereign Safety 97.9%\"] --> Apex\n  Automation[\"Automation 85.2%\"] --> Apex\n  ShockResilience[\"Shock Resilience 98.0%\"] --> Apex\n  GlobalExpansion[\"Global Expansion 96.6%\"] --> Apex\n"
+}

--- a/demo/Economic-Power-v0/reports/super-intelligence.mmd
+++ b/demo/Economic-Power-v0/reports/super-intelligence.mmd
@@ -1,0 +1,7 @@
+graph LR
+  EconomicDominance["Economic Dominance 99.4%"] --> Apex["Superintelligence 96.8%"]
+  OwnerSupremacy["Owner Supremacy 99.7%"] --> Apex
+  SovereignSafety["Sovereign Safety 97.9%"] --> Apex
+  Automation["Automation 85.2%"] --> Apex
+  ShockResilience["Shock Resilience 98.0%"] --> Apex
+  GlobalExpansion["Global Expansion 96.6%"] --> Apex

--- a/demo/Economic-Power-v0/scripts/ownerAutopilot.ts
+++ b/demo/Economic-Power-v0/scripts/ownerAutopilot.ts
@@ -184,6 +184,9 @@ export function renderAutopilotBrief(brief: AutopilotBrief): string {
       brief.telemetry.economicDominanceIndex,
     )}`,
   );
+  lines.push(
+    `- Superintelligence index: ${formatPercent(brief.telemetry.superIntelligenceIndex)}`,
+  );
   lines.push(`- Capital velocity: ${brief.telemetry.capitalVelocity.toFixed(2)} AGI/h`);
   lines.push(
     `- Global expansion readiness: ${formatPercent(brief.telemetry.globalExpansionReadiness)}`,

--- a/demo/Economic-Power-v0/scripts/runDemo.ts
+++ b/demo/Economic-Power-v0/scripts/runDemo.ts
@@ -238,6 +238,7 @@ type OwnerAutopilot = {
     economicDominanceIndex: number;
     capitalVelocity: number;
     globalExpansionReadiness: number;
+    superIntelligenceIndex: number;
     shockResilienceScore: number;
   };
   commandSequence: OwnerAutopilotCommand[];
@@ -337,6 +338,29 @@ type OwnerControlSupremacy = {
   mermaid: string;
 };
 
+type SuperIntelligenceClassification =
+  | 'transcendent-dominion'
+  | 'planetary-dominant'
+  | 'ascendant'
+  | 'formative';
+
+type SuperIntelligenceReport = {
+  index: number;
+  classification: SuperIntelligenceClassification;
+  narrative: string;
+  drivers: string[];
+  commandAssurance: string[];
+  telemetry: {
+    economicDominanceIndex: number;
+    ownerSupremacyIndex: number;
+    sovereignSafetyScore: number;
+    automationScore: number;
+    shockResilienceScore: number;
+    globalExpansionReadiness: number;
+  };
+  mermaid: string;
+};
+
 type Summary = {
   scenarioId: string;
   title: string;
@@ -369,6 +393,7 @@ type Summary = {
     economicDominanceIndex: number;
     capitalVelocity: number;
     globalExpansionReadiness: number;
+    superIntelligenceIndex: number;
     shockResilienceScore: number;
   };
   ownerControl: {
@@ -411,6 +436,7 @@ type Summary = {
   ownerAutopilot: OwnerAutopilot;
   ownerDominion: OwnerDominionReport;
   ownerControlSupremacy: OwnerControlSupremacy;
+  superIntelligence: SuperIntelligenceReport;
   globalExpansionPlan: GlobalExpansionPhase[];
   shockResilience: ShockResilienceReport;
 };
@@ -886,6 +912,7 @@ function buildOwnerAutopilot(summary: Summary, scenario: Scenario): OwnerAutopil
       economicDominanceIndex: summary.metrics.economicDominanceIndex,
       capitalVelocity: summary.metrics.capitalVelocity,
       globalExpansionReadiness: summary.metrics.globalExpansionReadiness,
+      superIntelligenceIndex: summary.metrics.superIntelligenceIndex,
       shockResilienceScore: summary.metrics.shockResilienceScore,
     },
     commandSequence: sequence,
@@ -1226,6 +1253,104 @@ function buildOwnerControlSupremacy(summary: Summary): OwnerControlSupremacy {
     signals,
     recommendedActions,
     mermaid,
+  };
+}
+
+function classifySuperIntelligence(index: number): {
+  classification: SuperIntelligenceClassification;
+  summary: string;
+} {
+  if (index >= 0.96) {
+    return {
+      classification: 'transcendent-dominion',
+      summary:
+        'The owner multi-sig directs a civilisation-scale AGI lattice with unstoppable command authority, capital velocity, and risk absorption.',
+    };
+  }
+  if (index >= 0.9) {
+    return {
+      classification: 'planetary-dominant',
+      summary:
+        'Automation, safety mesh, and treasury firepower already surpass planetary demand – only incremental guardrails remain before total transcendence.',
+    };
+  }
+  if (index >= 0.75) {
+    return {
+      classification: 'ascendant',
+      summary:
+        'The engine is accelerating toward unstoppable scale; expand scripted coverage and validator depth to eliminate the remaining choke points.',
+    };
+  }
+  return {
+    classification: 'formative',
+    summary:
+      'Foundational loops are online, but the owner must authorise additional guardrails, automation, and custody to unlock superintelligent leverage.',
+  };
+}
+
+function buildSuperIntelligence(summary: Summary): SuperIntelligenceReport {
+  const metrics = summary.metrics;
+  const supremacyIndex = summary.ownerControlSupremacy.index;
+  const weights = {
+    economicDominance: 0.2,
+    ownerSupremacy: 0.2,
+    sovereignSafety: 0.18,
+    automation: 0.14,
+    shockResilience: 0.14,
+    globalExpansion: 0.08,
+    sovereignControl: 0.06,
+  } as const;
+
+  const indexRaw =
+    metrics.economicDominanceIndex * weights.economicDominance +
+    supremacyIndex * weights.ownerSupremacy +
+    metrics.sovereignSafetyScore * weights.sovereignSafety +
+    metrics.automationScore * weights.automation +
+    metrics.shockResilienceScore * weights.shockResilience +
+    metrics.globalExpansionReadiness * weights.globalExpansion +
+    metrics.sovereignControlScore * weights.sovereignControl;
+  const index = Number(Math.min(1, Math.max(0, indexRaw)).toFixed(4));
+  const { classification, summary: narrative } = classifySuperIntelligence(index);
+
+  const drivers = [
+    `Economic dominance ${(metrics.economicDominanceIndex * 100).toFixed(1)}% confirming runaway value capture.`,
+    `Owner supremacy ${(supremacyIndex * 100).toFixed(1)}% with guardrail coverage ${(summary.ownerControlSupremacy.guardrailCoverage * 100).toFixed(1)}% keeping every lever under direct command.`,
+    `Sovereign safety ${(metrics.sovereignSafetyScore * 100).toFixed(1)}% across ${summary.sovereignSafetyMesh.alertChannels.length} alert channels and ${summary.sovereignSafetyMesh.emergencyContacts.length} emergency contacts.`,
+    `Automation mesh ${(metrics.automationScore * 100).toFixed(1)}% orchestrating agents without human delay.`,
+    `Shock resilience ${(metrics.shockResilienceScore * 100).toFixed(1)}% ensuring capital velocity persists under failure scenarios.`,
+  ];
+
+  const commandAssurance = [
+    `Command coverage ${(summary.ownerCommandPlan.commandCoverage * 100).toFixed(1)}% across ${Object.keys(summary.ownerCommandPlan.coverageDetail).length} sovereign surfaces.`,
+    `Program supremacy guarantees ${(summary.ownerControlSupremacy.programCoverage.treasury * 100).toFixed(1)}% treasury control and ${(summary.ownerControlSupremacy.programCoverage.orchestrator * 100).toFixed(1)}% orchestrator automation.`,
+    `Global expansion readiness ${(metrics.globalExpansionReadiness * 100).toFixed(1)}% unlocks immediate replication across jurisdictions.`,
+  ];
+
+  const mermaidLines = [
+    'graph LR',
+    `  EconomicDominance["Economic Dominance ${(metrics.economicDominanceIndex * 100).toFixed(1)}%"] --> Apex["Superintelligence ${(index * 100).toFixed(1)}%"]`,
+    `  OwnerSupremacy["Owner Supremacy ${(supremacyIndex * 100).toFixed(1)}%"] --> Apex`,
+    `  SovereignSafety["Sovereign Safety ${(metrics.sovereignSafetyScore * 100).toFixed(1)}%"] --> Apex`,
+    `  Automation["Automation ${(metrics.automationScore * 100).toFixed(1)}%"] --> Apex`,
+    `  ShockResilience["Shock Resilience ${(metrics.shockResilienceScore * 100).toFixed(1)}%"] --> Apex`,
+    `  GlobalExpansion["Global Expansion ${(metrics.globalExpansionReadiness * 100).toFixed(1)}%"] --> Apex`,
+  ];
+
+  return {
+    index,
+    classification,
+    narrative,
+    drivers,
+    commandAssurance,
+    telemetry: {
+      economicDominanceIndex: metrics.economicDominanceIndex,
+      ownerSupremacyIndex: supremacyIndex,
+      sovereignSafetyScore: metrics.sovereignSafetyScore,
+      automationScore: metrics.automationScore,
+      shockResilienceScore: metrics.shockResilienceScore,
+      globalExpansionReadiness: metrics.globalExpansionReadiness,
+    },
+    mermaid: `${mermaidLines.join('\n')}\n`,
   };
 }
 
@@ -2391,6 +2516,7 @@ function synthesiseSummary(
       economicDominanceIndex: dominanceIndex,
       capitalVelocity,
       globalExpansionReadiness,
+      superIntelligenceIndex: 0,
       shockResilienceScore: shockResilience.score,
     },
     ownerControl: {
@@ -2453,6 +2579,7 @@ function synthesiseSummary(
         economicDominanceIndex: dominanceIndex,
         capitalVelocity,
         globalExpansionReadiness,
+        superIntelligenceIndex: 0,
         shockResilienceScore: shockResilience.score,
       },
       commandSequence: [],
@@ -2488,6 +2615,22 @@ function synthesiseSummary(
       },
       signals: [],
       recommendedActions: [],
+      mermaid: '',
+    },
+    superIntelligence: {
+      index: 0,
+      classification: 'formative',
+      narrative: 'Superintelligence index pending computation.',
+      drivers: [],
+      commandAssurance: [],
+      telemetry: {
+        economicDominanceIndex: dominanceIndex,
+        ownerSupremacyIndex: 0,
+        sovereignSafetyScore: sovereignSafetyMesh.safetyScore,
+        automationScore: automationCoverage,
+        shockResilienceScore: shockResilience.score,
+        globalExpansionReadiness,
+      },
       mermaid: '',
     },
     globalExpansionPlan: [],
@@ -2784,6 +2927,11 @@ export async function runScenario(
   summary.metrics.ownerControlSupremacyIndex = Number(
     summary.ownerControlSupremacy.index.toFixed(3),
   );
+  summary.superIntelligence = buildSuperIntelligence(summary);
+  summary.metrics.superIntelligenceIndex = Number(
+    summary.superIntelligence.index.toFixed(3),
+  );
+  summary.ownerAutopilot.telemetry.superIntelligenceIndex = summary.superIntelligence.index;
   summary.globalExpansionPlan = buildGlobalExpansionPlan(summary, workingScenario);
   return summary;
 }
@@ -2905,6 +3053,14 @@ async function writeOutputs(
     `${summary.ownerControlSupremacy.mermaid.trimEnd()}\n`,
   );
   await fs.writeFile(
+    path.join(outputDir, 'super-intelligence.json'),
+    JSON.stringify(summary.superIntelligence, null, 2),
+  );
+  await fs.writeFile(
+    path.join(outputDir, 'super-intelligence.mmd'),
+    `${summary.superIntelligence.mermaid.trimEnd()}\n`,
+  );
+  await fs.writeFile(
     path.join(outputDir, 'shock-resilience.json'),
     JSON.stringify(summary.shockResilience, null, 2),
   );
@@ -2952,6 +3108,7 @@ function compareWithBaseline(summary: Summary, baselinePath: string): void {
     'economicDominanceIndex',
     'capitalVelocity',
     'globalExpansionReadiness',
+    'superIntelligenceIndex',
     'shockResilienceScore',
   ];
   const tolerance = 0.05;

--- a/demo/Economic-Power-v0/test/economic_power_demo.test.ts
+++ b/demo/Economic-Power-v0/test/economic_power_demo.test.ts
@@ -75,6 +75,20 @@ test('economic power simulation produces deterministic metrics', async () => {
     summary.metrics.shockResilienceScore >= 0.95,
     'Shock resilience score should confirm impregnable defence posture',
   );
+  assert(
+    summary.metrics.superIntelligenceIndex >= 0.95,
+    'Superintelligence index should prove civilisation-scale leverage',
+  );
+  assert.equal(
+    summary.superIntelligence.classification,
+    'transcendent-dominion',
+    'Superintelligence classification should confirm transcendent dominion',
+  );
+  assert(summary.superIntelligence.mermaid.includes('graph LR'));
+  assert(
+    summary.superIntelligence.commandAssurance.length >= 3,
+    'Command assurances should enumerate decisive owner programs',
+  );
 
   const ownerParameters = summary.ownerControl.controls.map((control) => control.parameter);
   for (const control of scenario.owner.controls) {

--- a/demo/Economic-Power-v0/ui/data/default-summary.json
+++ b/demo/Economic-Power-v0/ui/data/default-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-29T03:07:46.662Z",
+  "executionTimestamp": "2025-10-29T13:30:19.494Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,
@@ -30,6 +30,7 @@
     "economicDominanceIndex": 0.994,
     "capitalVelocity": 26290.99,
     "globalExpansionReadiness": 0.966,
+    "superIntelligenceIndex": 0.968,
     "shockResilienceScore": 0.98
   },
   "ownerControl": {
@@ -1106,6 +1107,7 @@
       "economicDominanceIndex": 0.994,
       "capitalVelocity": 26290.99,
       "globalExpansionReadiness": 0.966,
+      "superIntelligenceIndex": 0.9681,
       "shockResilienceScore": 0.98
     },
     "commandSequence": [
@@ -1261,6 +1263,32 @@
       "Supremacy absolute – maintain guardrail rehearsals to preserve total control."
     ],
     "mermaid": "graph LR\n  OWNER[\"Owner Multi-Sig • Supremacy 99.7%\"]\n  OWNER --> Coverage[\"Command Coverage 100.0%\"]\n  OWNER --> Custody[\"Custody 100.0%\"]\n  OWNER --> Safety[\"Safety Mesh 97.9%\"]\n  OWNER --> Guardrails[\"Guardrail Coverage 100.0%\"]\n  OWNER --> Response[\"Response 9m\"]\n  Coverage --> Surface_0_jobs[\"Job orchestration 100.0%\"]\n  Coverage --> Surface_1_validators[\"Validator sovereignty 100.0%\"]\n  Coverage --> Surface_2_stablecoinAdapters[\"Stablecoin adapters 100.0%\"]\n  Coverage --> Surface_3_modules[\"Protocol modules 100.0%\"]\n  Coverage --> Surface_4_parameters[\"Parameter overrides 100.0%\"]\n  Coverage --> Surface_5_pause[\"Emergency pause 100.0%\"]\n  Coverage --> Surface_6_resume[\"Emergency resume 100.0%\"]\n  Coverage --> Surface_7_treasury[\"Treasury programs 100.0%\"]\n  Coverage --> Surface_8_orchestrator[\"Orchestrator mesh 100.0%\"]\n  Guardrails --> Program_0_job[\"Job programs 100.0%\"]\n  Guardrails --> Program_1_validator[\"Validator programs 100.0%\"]\n  Guardrails --> Program_2_adapter[\"Adapter programs 100.0%\"]\n  Guardrails --> Program_3_module[\"Module programs 100.0%\"]\n  Guardrails --> Program_4_treasury[\"Treasury programs 100.0%\"]\n  Guardrails --> Program_5_orchestrator[\"Orchestrator programs 100.0%\"]\n  Response --> Pause[\"Pause npm run owner:system-pause\"]\n  Response --> Resume[\"Resume npm run owner:update-all\"]\n"
+  },
+  "superIntelligence": {
+    "index": 0.9681,
+    "classification": "transcendent-dominion",
+    "narrative": "The owner multi-sig directs a civilisation-scale AGI lattice with unstoppable command authority, capital velocity, and risk absorption.",
+    "drivers": [
+      "Economic dominance 99.4% confirming runaway value capture.",
+      "Owner supremacy 99.7% with guardrail coverage 100.0% keeping every lever under direct command.",
+      "Sovereign safety 97.9% across 2 alert channels and 3 emergency contacts.",
+      "Automation mesh 85.2% orchestrating agents without human delay.",
+      "Shock resilience 98.0% ensuring capital velocity persists under failure scenarios."
+    ],
+    "commandAssurance": [
+      "Command coverage 100.0% across 9 sovereign surfaces.",
+      "Program supremacy guarantees 100.0% treasury control and 100.0% orchestrator automation.",
+      "Global expansion readiness 96.6% unlocks immediate replication across jurisdictions."
+    ],
+    "telemetry": {
+      "economicDominanceIndex": 0.994,
+      "ownerSupremacyIndex": 0.9968,
+      "sovereignSafetyScore": 0.979,
+      "automationScore": 0.852,
+      "shockResilienceScore": 0.98,
+      "globalExpansionReadiness": 0.966
+    },
+    "mermaid": "graph LR\n  EconomicDominance[\"Economic Dominance 99.4%\"] --> Apex[\"Superintelligence 96.8%\"]\n  OwnerSupremacy[\"Owner Supremacy 99.7%\"] --> Apex\n  SovereignSafety[\"Sovereign Safety 97.9%\"] --> Apex\n  Automation[\"Automation 85.2%\"] --> Apex\n  ShockResilience[\"Shock Resilience 98.0%\"] --> Apex\n  GlobalExpansion[\"Global Expansion 96.6%\"] --> Apex\n"
   },
   "globalExpansionPlan": [
     {

--- a/demo/Economic-Power-v0/ui/index.html
+++ b/demo/Economic-Power-v0/ui/index.html
@@ -124,6 +124,40 @@
         </div>
       </section>
 
+      <section id="superintelligence-panel" class="panel" aria-labelledby="superintelligence-heading">
+        <div class="panel-header">
+          <h2 id="superintelligence-heading">Superintelligence control layer</h2>
+          <p>
+            Composite gauge proving the AGI lattice operates as a civilisation-scale economic intelligence under full owner
+            command.
+          </p>
+        </div>
+        <div class="superintelligence-grid">
+          <article class="superintelligence-card" aria-label="Superintelligence score">
+            <h3>Superintelligence posture</h3>
+            <p id="superintelligence-score" class="superintelligence-score">—</p>
+            <span id="superintelligence-classification" class="superintelligence-chip">Awaiting data</span>
+            <p id="superintelligence-narrative" class="narrative"></p>
+            <p id="superintelligence-telemetry" class="superintelligence-telemetry"></p>
+          </article>
+          <article class="superintelligence-card" aria-label="Drivers">
+            <h3>Dominance drivers</h3>
+            <ul id="superintelligence-drivers" class="superintelligence-list"></ul>
+          </article>
+          <article class="superintelligence-card" aria-label="Command assurances">
+            <h3>Command assurances</h3>
+            <ul id="superintelligence-assurance" class="superintelligence-list"></ul>
+          </article>
+        </div>
+        <div class="mermaid-wrapper">
+          <div
+            id="mermaid-superintelligence"
+            class="mermaid"
+            aria-label="Superintelligence contribution diagram"
+          ></div>
+        </div>
+      </section>
+
       <section class="panel" aria-labelledby="command-catalog-heading">
         <div class="panel-header">
           <h2 id="command-catalog-heading">Command catalog supremacy</h2>

--- a/demo/Economic-Power-v0/ui/script.js
+++ b/demo/Economic-Power-v0/ui/script.js
@@ -94,6 +94,13 @@ const metricMap = [
     description: 'Composite dominance index fusing ROI, automation, and sovereign control.',
   },
   {
+    id: 'superIntelligenceIndex',
+    label: 'Superintelligence Index',
+    formatter: (value) => `${(value * 100).toFixed(1)}%`,
+    description:
+      'Composite gauge fusing dominance, supremacy, automation, safety, resilience, and global expansion readiness.',
+  },
+  {
     id: 'capitalVelocity',
     label: 'Capital Velocity',
     formatter: (value) => `${value.toFixed(2)} AGI/h`,
@@ -351,6 +358,69 @@ function renderProgramTable(tableId, programs) {
     `;
     table.append(row);
   }
+}
+
+function renderSuperIntelligence(summary) {
+  const report = summary.superIntelligence || {
+    index: 0,
+    classification: 'formative',
+    narrative: 'Superintelligence telemetry unavailable.',
+    drivers: [],
+    commandAssurance: [],
+    telemetry: {
+      economicDominanceIndex: 0,
+      ownerSupremacyIndex: 0,
+      sovereignSafetyScore: 0,
+      automationScore: 0,
+      shockResilienceScore: 0,
+      globalExpansionReadiness: 0,
+    },
+  };
+
+  const scoreEl = document.getElementById('superintelligence-score');
+  const classificationEl = document.getElementById('superintelligence-classification');
+  const narrativeEl = document.getElementById('superintelligence-narrative');
+  const driversList = document.getElementById('superintelligence-drivers');
+  const assuranceList = document.getElementById('superintelligence-assurance');
+  const telemetryEl = document.getElementById('superintelligence-telemetry');
+
+  if (!scoreEl || !classificationEl || !narrativeEl || !driversList || !assuranceList || !telemetryEl) {
+    return;
+  }
+
+  scoreEl.textContent = `${(report.index * 100).toFixed(1)}%`;
+  const chipLabel = report.classification.replace(/-/g, ' ');
+  classificationEl.textContent = chipLabel;
+  classificationEl.className = `superintelligence-chip superintelligence-${report.classification}`;
+  narrativeEl.textContent = report.narrative;
+
+  driversList.innerHTML = '';
+  if (report.drivers.length === 0) {
+    const li = document.createElement('li');
+    li.textContent = 'No drivers published – run the demo to compute the superintelligence profile.';
+    driversList.append(li);
+  } else {
+    for (const driver of report.drivers) {
+      const li = document.createElement('li');
+      li.textContent = driver;
+      driversList.append(li);
+    }
+  }
+
+  assuranceList.innerHTML = '';
+  if (report.commandAssurance.length === 0) {
+    const li = document.createElement('li');
+    li.textContent = 'No command assurances published.';
+    assuranceList.append(li);
+  } else {
+    for (const assurance of report.commandAssurance) {
+      const li = document.createElement('li');
+      li.textContent = assurance;
+      assuranceList.append(li);
+    }
+  }
+
+  telemetryEl.textContent = `Telemetry: Dominance ${(report.telemetry.economicDominanceIndex * 100).toFixed(1)}% • Supremacy ${(report.telemetry.ownerSupremacyIndex * 100).toFixed(1)}% • Safety ${(report.telemetry.sovereignSafetyScore * 100).toFixed(1)}% • Automation ${(report.telemetry.automationScore * 100).toFixed(1)}% • Resilience ${(report.telemetry.shockResilienceScore * 100).toFixed(1)}% • Expansion ${(report.telemetry.globalExpansionReadiness * 100).toFixed(1)}%`;
 }
 
 function renderCommandCatalog(summary) {
@@ -830,6 +900,7 @@ async function renderMermaid(summary) {
   const timeline = document.getElementById('mermaid-timeline');
   const command = document.getElementById('mermaid-command');
   const supremacy = document.getElementById('mermaid-supremacy');
+  const superintelligence = document.getElementById('mermaid-superintelligence');
   const nodes = [];
   if (flow) {
     flow.textContent = summary.mermaidFlow;
@@ -846,6 +917,10 @@ async function renderMermaid(summary) {
   if (supremacy && summary.ownerControlSupremacy?.mermaid) {
     supremacy.textContent = summary.ownerControlSupremacy.mermaid;
     nodes.push(supremacy);
+  }
+  if (superintelligence && summary.superIntelligence?.mermaid) {
+    superintelligence.textContent = summary.superIntelligence.mermaid;
+    nodes.push(superintelligence);
   }
   if (nodes.length > 0) {
     await mermaid.run({ nodes });
@@ -895,13 +970,14 @@ function renderAutopilot(summary) {
       economicDominanceIndex: 0,
       capitalVelocity: 0,
       globalExpansionReadiness: 0,
+      superIntelligenceIndex: 0,
       shockResilienceScore: 0,
     },
     commandSequence: [],
   };
   missionEl.textContent = autopilot.mission;
   cadenceEl.textContent = `${autopilot.cadenceHours.toFixed(1)}h cadence`;
-  dominanceEl.textContent = `${(autopilot.telemetry.economicDominanceIndex * 100).toFixed(1)}% dominance • ${autopilot.telemetry.capitalVelocity.toFixed(2)} AGI/h • ${(autopilot.telemetry.globalExpansionReadiness * 100).toFixed(1)}% readiness • ${(autopilot.telemetry.shockResilienceScore * 100).toFixed(1)}% shock resilience`;
+  dominanceEl.textContent = `${(autopilot.telemetry.economicDominanceIndex * 100).toFixed(1)}% dominance • ${(autopilot.telemetry.superIntelligenceIndex * 100).toFixed(1)}% superintelligence • ${autopilot.telemetry.capitalVelocity.toFixed(2)} AGI/h • ${(autopilot.telemetry.globalExpansionReadiness * 100).toFixed(1)}% readiness • ${(autopilot.telemetry.shockResilienceScore * 100).toFixed(1)}% shock resilience`;
   guardrailList.innerHTML = '';
   for (const guardrail of autopilot.guardrails) {
     const li = document.createElement('li');
@@ -974,6 +1050,7 @@ async function bootstrap(dataPath = defaultDataPath) {
   renderMetricCards(summary);
   renderOwnerTable(summary);
   renderOwnerSupremacy(summary);
+  renderSuperIntelligence(summary);
   renderOwnerDominion(summary);
   renderCommandCatalog(summary);
   renderAssignments(summary);
@@ -1030,6 +1107,7 @@ async function renderSummary(summary) {
   renderMetricCards(summary);
   renderOwnerTable(summary);
   renderOwnerSupremacy(summary);
+  renderSuperIntelligence(summary);
   renderOwnerDominion(summary);
   renderCommandCatalog(summary);
   renderAssignments(summary);

--- a/demo/Economic-Power-v0/ui/styles.css
+++ b/demo/Economic-Power-v0/ui/styles.css
@@ -396,6 +396,97 @@ main {
   color: var(--text-secondary);
 }
 
+.superintelligence-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.superintelligence-card {
+  background: rgba(7, 13, 26, 0.78);
+  border: 1px solid rgba(139, 92, 246, 0.35);
+  border-radius: 1.2rem;
+  padding: 1.25rem;
+  box-shadow: 0 20px 35px rgba(76, 29, 149, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.superintelligence-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #c4b5fd;
+}
+
+.superintelligence-score {
+  font-size: 2.4rem;
+  font-weight: 700;
+  color: #ede9fe;
+}
+
+.superintelligence-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(139, 92, 246, 0.45);
+  background: rgba(139, 92, 246, 0.22);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.superintelligence-chip.superintelligence-transcendent-dominion {
+  background: rgba(34, 197, 94, 0.25);
+  border-color: rgba(34, 197, 94, 0.6);
+  color: #ecfdf5;
+}
+
+.superintelligence-chip.superintelligence-planetary-dominant {
+  background: rgba(59, 130, 246, 0.25);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: #dbeafe;
+}
+
+.superintelligence-chip.superintelligence-ascendant {
+  background: rgba(250, 204, 21, 0.24);
+  border-color: rgba(250, 204, 21, 0.55);
+  color: #fef3c7;
+}
+
+.superintelligence-chip.superintelligence-formative {
+  background: rgba(248, 113, 113, 0.24);
+  border-color: rgba(248, 113, 113, 0.6);
+  color: #fee2e2;
+}
+
+.superintelligence-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.superintelligence-list li {
+  background: rgba(124, 58, 237, 0.15);
+  border-left: 3px solid rgba(124, 58, 237, 0.6);
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.85rem;
+  font-size: 0.9rem;
+  color: rgba(237, 233, 254, 0.9);
+}
+
+.superintelligence-telemetry {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(224, 231, 255, 0.8);
+}
+
 .quick-actions p {
   margin: 0.35rem 0;
   color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- compute a civilisation-scale superintelligence index with classification, JSON/Mermaid outputs, and baseline updates for the Economic Power scenario
- expose the new superintelligence telemetry through the CLI, autopilot briefings, reports, and deterministic tests
- extend the Economic Power UI with a dedicated superintelligence control layer, metric card, and styling for non-technical operators

## Testing
- npm run demo:economic-power
- npm run test:economic-power


------
https://chatgpt.com/codex/tasks/task_e_690213c0a0e883338cd55ad715d2195c