### PR TITLE
Enhance Huxley–Gödel Machine demo overrides and CI coverage

### DIFF
--- a/.github/workflows/demo-huxley-godel-machine.yml
+++ b/.github/workflows/demo-huxley-godel-machine.yml
@@ -1,0 +1,36 @@
+name: demo-huxley-godel-machine
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "demo/Huxley-Godel-Machine-v0/**"
+      - ".github/workflows/demo-huxley-godel-machine.yml"
+      - "Makefile"
+  pull_request:
+    paths:
+      - "demo/Huxley-Godel-Machine-v0/**"
+      - ".github/workflows/demo-huxley-godel-machine.yml"
+      - "Makefile"
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+      - name: Run unit tests
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+        run: pytest demo/Huxley-Godel-Machine-v0/tests -q
+      - name: Run demo with fast overrides
+        run: |
+          python demo/Huxley-Godel-Machine-v0/run_demo.py \
+            --set simulation.evaluation_latency=[0.0,0.0] \
+            --set simulation.expansion_latency=[0.0,0.0] \
+            --output-dir demo/Huxley-Godel-Machine-v0/artifacts-ci
+          cat demo/Huxley-Godel-Machine-v0/artifacts-ci/summary.txt

--- a/demo/Huxley-Godel-Machine-v0/README.md
+++ b/demo/Huxley-Godel-Machine-v0/README.md
@@ -19,6 +19,19 @@ open demo/Huxley-Godel-Machine-v0/web/index.html  # optional interactive dashboa
 
 The script produces console analytics, `artifacts/hgm_run.json`, and `artifacts/summary.txt`. The web dashboard automatically visualizes the newest run.
 
+### Live parameter overrides (no JSON editing required)
+
+The contract owner can now retune the machine directly from the CLI:
+
+```bash
+python demo/Huxley-Godel-Machine-v0/run_demo.py \
+  --set engine.tau=2.6 \
+  --set sentinel.min_roi=1.35 \
+  --set simulation.evaluation_latency=[0.0,0.0]
+```
+
+Each `--set section.key=value` instruction auto-coerces to the existing type, supporting scalars, lists, and booleans. Overrides work alongside custom JSON config files, so every safety rail and economic knob stays under instant human control.
+
 ## System architecture at a glance
 
 ```mermaid
@@ -59,6 +72,19 @@ flowchart TD
     H -->|ROI dip| K[Risk-off mode]
     J --> C
     K --> C
+```
+
+```mermaid
+sequenceDiagram
+    participant Owner as Contract Owner
+    participant CLI as run_demo.py --set
+    participant Loader as Config Loader
+    participant Engine as HGM Engine
+
+    Owner->>CLI: Issue overrides (--set ...)
+    CLI->>Loader: Parse & coerce values
+    Loader->>Engine: Inject refreshed parameters
+    Engine-->>Owner: Telemetry + safeguarded execution
 ```
 
 ## Configuration power tools

--- a/demo/Huxley-Godel-Machine-v0/hgm_demo/config.py
+++ b/demo/Huxley-Godel-Machine-v0/hgm_demo/config.py
@@ -1,10 +1,12 @@
 """Configuration helpers for the Huxley–Gödel Machine demo."""
 from __future__ import annotations
 
+import ast
+import copy
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, MutableMapping, Sequence, Tuple
 
 
 @dataclass(frozen=True)
@@ -46,10 +48,13 @@ class Config:
         return float(low), float(high)
 
 
+def _load_raw_config(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text())
+
+
 def load_config(path: Path) -> Config:
     """Load the demo configuration from ``path``."""
-    data = json.loads(path.read_text())
-    return Config(data)
+    return Config(_load_raw_config(path))
 
 
 DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "hgm_config.json"
@@ -57,3 +62,66 @@ DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "hgm_conf
 
 def load_default_config() -> Config:
     return load_config(DEFAULT_CONFIG_PATH)
+
+
+def _parse_override_value(value: str) -> Any:
+    try:
+        return ast.literal_eval(value)
+    except (ValueError, SyntaxError):
+        lowered = value.strip().lower()
+        if lowered in {"true", "false"}:
+            return lowered == "true"
+        return value
+
+
+def _coerce_type(template: Any, new_value: Any) -> Any:
+    if isinstance(template, bool):
+        if isinstance(new_value, str):
+            return new_value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(new_value)
+    if isinstance(template, int) and not isinstance(template, bool):
+        if isinstance(new_value, bool):
+            return int(new_value)
+        if isinstance(new_value, (int, float)):
+            return int(new_value)
+        try:
+            return int(str(new_value))
+        except ValueError as exc:
+            raise ValueError(f"Cannot coerce value {new_value!r} to int") from exc
+    if isinstance(template, float):
+        if isinstance(new_value, (int, float)):
+            return float(new_value)
+        try:
+            return float(str(new_value))
+        except ValueError as exc:
+            raise ValueError(f"Cannot coerce value {new_value!r} to float") from exc
+    return new_value
+
+
+def _apply_override(data: MutableMapping[str, Any], override: str) -> None:
+    if "=" not in override:
+        raise ValueError(f"Invalid override '{override}'. Expected format section.key=value")
+    path_str, raw_value = override.split("=", 1)
+    keys = [part.strip() for part in path_str.split(".") if part.strip()]
+    if not keys:
+        raise ValueError(f"Invalid override path in '{override}'")
+    cursor: MutableMapping[str, Any] = data
+    for key in keys[:-1]:
+        value = cursor.get(key)
+        if not isinstance(value, MutableMapping):
+            raise ValueError(f"Unknown configuration path '{path_str}'")
+        cursor = value
+    leaf = keys[-1]
+    if leaf not in cursor:
+        raise ValueError(f"Unknown configuration key '{path_str}'")
+    parsed_value = _parse_override_value(raw_value)
+    cursor[leaf] = _coerce_type(cursor[leaf], parsed_value)
+
+
+def load_config_with_overrides(path: Path | None, overrides: Sequence[str]) -> Config:
+    """Load configuration and apply user-provided overrides."""
+
+    raw = copy.deepcopy(_load_raw_config(path or DEFAULT_CONFIG_PATH))
+    for override in overrides:
+        _apply_override(raw, override)
+    return Config(raw)

--- a/demo/Huxley-Godel-Machine-v0/tests/test_config.py
+++ b/demo/Huxley-Godel-Machine-v0/tests/test_config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from hgm_demo.config import DEFAULT_CONFIG_PATH, load_config_with_overrides
+
+
+def test_override_scalar_value() -> None:
+    config = load_config_with_overrides(DEFAULT_CONFIG_PATH, ["engine.tau=3.2"])
+    assert config.engine["tau"] == pytest.approx(3.2)
+
+
+def test_override_list_value() -> None:
+    config = load_config_with_overrides(
+        DEFAULT_CONFIG_PATH,
+        ["simulation.evaluation_latency=[0.0, 0.0]"],
+    )
+    assert config.simulation["evaluation_latency"] == [0.0, 0.0]
+
+
+def test_override_invalid_key_raises() -> None:
+    with pytest.raises(ValueError):
+        load_config_with_overrides(DEFAULT_CONFIG_PATH, ["engine.unknown=1"])

--- a/demo/Huxley-Godel-Machine-v0/tests/test_sentinel.py
+++ b/demo/Huxley-Godel-Machine-v0/tests/test_sentinel.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import random
+
+from hgm_demo.engine import EngineParameters, HGMEngine
+from hgm_demo.sentinel import Sentinel, SentinelSettings
+from hgm_demo.structures import AgentNode, EconomicLedger
+
+
+def make_engine() -> HGMEngine:
+    params = EngineParameters(tau=1.0, alpha=1.2, epsilon=0.05, max_agents=8, max_actions=50)
+    engine = HGMEngine(params=params, rng=random.Random(42))
+    root = AgentNode(agent_id="root", parent_id=None, depth=0, generation=0, quality=0.6)
+    engine.register_root(root)
+    return engine
+
+
+def test_sentinel_toggles_expansion_on_roi_threshold() -> None:
+    engine = make_engine()
+    sentinel = Sentinel(SentinelSettings(min_roi=1.5, max_cost=10_000.0, max_failures_per_agent=5))
+    ledger = EconomicLedger()
+    ledger.record_failure(500.0)
+    sentinel.evaluate(engine=engine, ledger=ledger)
+    assert not engine.allow_expansions
+    ledger.record_success(5000.0, 500.0)
+    sentinel.evaluate(engine=engine, ledger=ledger)
+    assert engine.allow_expansions
+
+
+def test_sentinel_requests_halt_when_budget_exhausted() -> None:
+    engine = make_engine()
+    sentinel = Sentinel(SentinelSettings(min_roi=1.0, max_cost=200.0, max_failures_per_agent=5))
+    ledger = EconomicLedger()
+    ledger.record_failure(200.0)
+    sentinel.evaluate(engine=engine, ledger=ledger)
+    assert sentinel.halt_requested
+
+
+def test_sentinel_prunes_agents_after_failure_streak() -> None:
+    engine = make_engine()
+    sentinel = Sentinel(SentinelSettings(min_roi=0.5, max_cost=10_000.0, max_failures_per_agent=2))
+    child = AgentNode(agent_id="child", parent_id="root", depth=1, generation=1, quality=0.5)
+    engine.register_child("root", child)
+    engine.record_evaluation("child", False)
+    engine.record_evaluation("child", False)
+    sentinel.evaluate(engine=engine, ledger=EconomicLedger())
+    assert "child" in engine.state.pruned_agents


### PR DESCRIPTION
## Summary
- add type-safe configuration override plumbing so operators can retune the HGM demo from the CLI
- document the new control surface and expand automated coverage with config and sentinel unit tests
- wire a dedicated GitHub Actions workflow to run the demo smoke test and unit tests on every PR

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Huxley-Godel-Machine-v0/tests -q
- python demo/Huxley-Godel-Machine-v0/run_demo.py --set simulation.evaluation_latency=[0.0,0.0] --set simulation.expansion_latency=[0.0,0.0] --set engine.max_actions=20 --output-dir demo/Huxley-Godel-Machine-v0/artifacts-test


------
https://chatgpt.com/codex/tasks/task_e_69022180e4348333b474cf3a9bc287d3