### PR TITLE
Refine AGI Alpha Node demo orchestration

### DIFF
--- a/demo/AGI-Alpha-Node-v0/README.md
+++ b/demo/AGI-Alpha-Node-v0/README.md
@@ -98,6 +98,17 @@ The architecture uses deliberate guardrails: nothing activates without ENS verif
 
 ---
 
+## 🔧 Sovereign Operator Controls
+
+- **Config-governed specialists:** Enable or disable domain experts and adjust their risk budgets directly from `config/alpha-node.yaml`.
+- **Full contract address registry:** Provide StakeManager, incentives, treasury, and fee pool addresses for deterministic governance hand-off.
+- **Dual-mode job harvester:** Seamlessly switch between mainnet polling and curated scenario files to rehearse autonomous execution before going live.
+- **Runtime guardrails:** Pausing, governance rotation, and compliance scoring are callable via CLI, interactive console, or automated drills.
+
+These controls ensure the contract owner retains absolute command while delegating routine intelligence to the Alpha Node swarm.
+
+---
+
 ## 📊 Compliance Scorecard Dimensions
 
 | Dimension | Checks |

--- a/demo/AGI-Alpha-Node-v0/alpha_node/config.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import Iterable, List, Optional
 
 import yaml
 
@@ -32,6 +32,9 @@ class SecurityConfig:
 class StakingConfig:
     stake_manager_address: str
     min_stake_wei: int
+    incentives_address: str
+    treasury_address: str
+    fee_pool_address: Optional[str] = None
     reward_tokens: List[RewardToken] = field(default_factory=list)
 
 
@@ -61,6 +64,38 @@ class StorageConfig:
 
 
 @dataclass
+class SpecialistConfig:
+    domain: str
+    name: str
+    description: str
+    risk_limit: float
+    enabled: bool = True
+
+
+def _default_specialists() -> List[SpecialistConfig]:
+    return [
+        SpecialistConfig(
+            domain="finance",
+            name="Finance Strategist",
+            description="Compounds AGIALPHA yields via multi-market orchestration.",
+            risk_limit=0.3,
+        ),
+        SpecialistConfig(
+            domain="biotech",
+            name="Biotech Synthesist",
+            description="Designs synthetic biology breakthroughs on demand.",
+            risk_limit=0.25,
+        ),
+        SpecialistConfig(
+            domain="manufacturing",
+            name="Manufacturing Optimizer",
+            description="Builds hyper-efficient supply chains and production lines.",
+            risk_limit=0.2,
+        ),
+    ]
+
+
+@dataclass
 class AlphaNodeConfig:
     identity: IdentityConfig
     security: SecurityConfig
@@ -68,7 +103,10 @@ class AlphaNodeConfig:
     jobs: JobsConfig
     planner: PlannerConfig = field(default_factory=PlannerConfig)
     metrics: MetricsConfig = field(default_factory=MetricsConfig)
-    storage: StorageConfig = field(default_factory=lambda: StorageConfig(Path("./storage/knowledge.db"), Path("./storage/logs.jsonl")))
+    storage: StorageConfig = field(
+        default_factory=lambda: StorageConfig(Path("./storage/knowledge.db"), Path("./storage/logs.jsonl"))
+    )
+    specialists: List[SpecialistConfig] = field(default_factory=_default_specialists)
 
     @classmethod
     def from_file(cls, path: Path) -> "AlphaNodeConfig":
@@ -79,6 +117,9 @@ class AlphaNodeConfig:
             staking=StakingConfig(
                 stake_manager_address=data["staking"]["stake_manager_address"],
                 min_stake_wei=int(data["staking"]["min_stake_wei"]),
+                incentives_address=data["staking"].get("incentives_address", data["staking"]["stake_manager_address"]),
+                treasury_address=data["staking"].get("treasury_address", data["staking"]["stake_manager_address"]),
+                fee_pool_address=data["staking"].get("fee_pool_address"),
                 reward_tokens=[RewardToken(**token) for token in data["staking"].get("reward_tokens", [])],
             ),
             jobs=JobsConfig(**data["jobs"]),
@@ -88,7 +129,45 @@ class AlphaNodeConfig:
                 knowledge_path=Path(data["storage"]["knowledge_path"]).expanduser(),
                 logs_path=Path(data["storage"]["logs_path"]).expanduser(),
             ),
+            specialists=_load_specialists(data.get("specialists")),
         )
+
+    @classmethod
+    def load(cls, path: Path) -> "AlphaNodeConfig":
+        return cls.from_file(path)
+
+    @property
+    def owner_address(self) -> str:
+        return self.identity.operator_address
+
+    @property
+    def governance_address(self) -> str:
+        return self.identity.governance_address
+
+    @property
+    def rpc_url(self) -> str:
+        return self.identity.rpc_url
+
+    @property
+    def stake_threshold(self) -> int:
+        return int(self.staking.min_stake_wei)
+
+    @property
+    def planning_horizon(self) -> int:
+        return self.planner.search_depth
+
+    @property
+    def exploration_bias(self) -> float:
+        return self.planner.exploration_constant
+
+    @property
+    def job_registry_address(self) -> str:
+        return self.jobs.job_router_address
+
+    def enabled_specialists(self) -> Iterable[SpecialistConfig]:
+        for specialist in self.specialists:
+            if specialist.enabled:
+                yield specialist
 
 
 def _load_yaml(path: Path) -> dict:
@@ -114,3 +193,23 @@ def find_config(custom_path: Optional[str] = None) -> AlphaNodeConfig:
             return AlphaNodeConfig.from_file(candidate)
 
     raise FileNotFoundError("Unable to locate alpha-node configuration file")
+
+
+def _load_specialists(raw: Optional[List[dict]]) -> List[SpecialistConfig]:
+    if not raw:
+        return _default_specialists()
+    specialists: List[SpecialistConfig] = []
+    for entry in raw:
+        try:
+            specialists.append(
+                SpecialistConfig(
+                    domain=entry["domain"],
+                    name=entry.get("name", entry["domain"].title()),
+                    description=entry.get("description", ""),
+                    risk_limit=float(entry.get("risk_limit", 0.3)),
+                    enabled=bool(entry.get("enabled", True)),
+                )
+            )
+        except KeyError as exc:  # pragma: no cover - defensive against malformed configs
+            raise ValueError(f"Invalid specialist configuration: missing {exc!s}") from exc
+    return specialists

--- a/demo/AGI-Alpha-Node-v0/alpha_node/economy.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/economy.py
@@ -69,6 +69,17 @@ class StakeManagerClient:
         _LOGGER.info("Rewards accrued", extra={"amount_wei": amount_wei})
         return self._staking_state
 
+    def withdraw(self, amount_wei: int) -> StakeStatus:
+        if amount_wei <= 0:
+            raise ValueError("Stake withdrawal must be positive")
+        self._staking_state.staked_wei = max(self._staking_state.staked_wei - amount_wei, 0)
+        self._staking_state.last_checkpoint_block = self._web3.eth.block_number
+        _LOGGER.info(
+            "Stake withdrawn",
+            extra={"amount_wei": amount_wei, "remaining_stake": self._staking_state.staked_wei},
+        )
+        return self._staking_state
+
     def claim_rewards(self, destination: str) -> List[RewardTokenState]:
         destination = Web3.to_checksum_address(destination)
         if self._staking_state.rewards_wei == 0:

--- a/demo/AGI-Alpha-Node-v0/alpha_node/jobs.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/jobs.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import random
 from dataclasses import dataclass
-from typing import AsyncIterator, Dict, List
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, Iterable, List, Optional, Union
 
 from web3 import Web3
 
@@ -18,30 +20,113 @@ class JobPayload:
     description: str
     base_reward: float
     risk: float
-    metadata: Dict[str, str]
+    metadata: Dict[str, Any]
+
+    def to_planner_dict(self) -> Dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "description": self.description,
+            "base_reward": self.base_reward,
+            "risk": self.risk,
+            "metadata": dict(self.metadata),
+        }
 
 
 class TaskHarvester:
-    """Polls the JobRouter for new assignments."""
+    """Poll the AGI Jobs marketplace or a local scenario file."""
 
-    def __init__(self, web3: Web3, router_address: str, poll_interval: int = 15) -> None:
-        self._web3 = web3
-        self._router_address = Web3.to_checksum_address(router_address)
+    def __init__(
+        self,
+        source: Union[Web3, str, Path],
+        router_address: Optional[str] = None,
+        poll_interval: int = 15,
+        loop: bool = False,
+    ) -> None:
         self._poll_interval = poll_interval
         self._running = False
+        self._loop = loop
+        self._cursor = 0
+
+        if isinstance(source, Web3):
+            if router_address is None:
+                raise ValueError("router_address is required when harvesting from Web3")
+            self._mode = "web3"
+            self._web3 = source
+            self._router_address = Web3.to_checksum_address(router_address)
+            self._jobs_path = None
+            self._jobs: List[JobPayload] = []
+        else:
+            self._mode = "file"
+            self._web3 = None
+            self._router_address = None
+            self._jobs_path = Path(source)
+            self._jobs = self._load_jobs()
 
     async def stream(self) -> AsyncIterator[JobPayload]:
         self._running = True
         while self._running:
-            await asyncio.sleep(self._poll_interval)
-            job = self._fake_job()
-            _LOGGER.info("Job harvested", extra={"job_id": job.job_id, "reward": job.base_reward})
-            yield job
+            if self._mode == "web3":
+                await asyncio.sleep(self._poll_interval)
+                job = self._fake_job()
+                _LOGGER.info("Job harvested", extra={"job_id": job.job_id, "reward": job.base_reward})
+                yield job
+            else:
+                job = self.next_job()
+                if job is None:
+                    if not self._loop:
+                        break
+                    await asyncio.sleep(self._poll_interval)
+                    continue
+                yield job
+                await asyncio.sleep(self._poll_interval)
 
     def stop(self) -> None:
         self._running = False
 
+    def next_job(self) -> Optional[JobPayload]:
+        if self._mode != "file":
+            raise RuntimeError("next_job is only available in file-backed mode")
+        if not self._jobs:
+            self._jobs = self._load_jobs()
+            self._cursor = 0
+        if not self._jobs:
+            return None
+        if self._cursor >= len(self._jobs):
+            if not self._loop:
+                return None
+            self._jobs = self._load_jobs()
+            self._cursor = 0
+        job = self._jobs[self._cursor]
+        self._cursor += 1
+        return job
+
+    def _load_jobs(self) -> List[JobPayload]:
+        if self._jobs_path is None:
+            return []
+        if not self._jobs_path.exists():
+            _LOGGER.warning("Job scenario file missing", extra={"path": str(self._jobs_path)})
+            return []
+        try:
+            raw: Iterable[Dict[str, Any]] = json.loads(self._jobs_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive path
+            _LOGGER.error("Failed to parse job scenario", extra={"path": str(self._jobs_path), "error": str(exc)})
+            return []
+        jobs: List[JobPayload] = []
+        for entry in raw:
+            job_id = entry.get("job_id") or entry.get("id")
+            if not job_id:
+                continue
+            description = entry.get("description") or "Autonomous alpha generation"
+            base_reward = float(entry.get("base_reward", random.uniform(5.0, 20.0)))
+            risk = float(entry.get("risk", 0.2))
+            metadata = entry.get("metadata") or {}
+            if "domain" not in metadata and entry.get("domain"):
+                metadata["domain"] = entry["domain"]
+            jobs.append(JobPayload(job_id=job_id, description=description, base_reward=base_reward, risk=risk, metadata=metadata))
+        return jobs
+
     def _fake_job(self) -> JobPayload:
+        assert self._mode == "web3"
         job_id = f"job-{self._web3.eth.block_number}-{random.randint(1000, 9999)}"
         description = random.choice(
             [

--- a/demo/AGI-Alpha-Node-v0/alpha_node/metrics.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/metrics.py
@@ -27,6 +27,10 @@ class MetricsExporter:
         self._thread.start()
         _LOGGER.info("Prometheus exporter started", extra={"port": self._port})
 
+    def stop(self) -> None:
+        # prometheus_client does not currently expose a shutdown primitive; we log intent for auditability.
+        _LOGGER.info("Prometheus exporter stop requested", extra={"port": self._port})
+
     def update_compliance(self, score: float) -> None:
         _COMPLIANCE_GAUGE.set(score)
 

--- a/demo/AGI-Alpha-Node-v0/alpha_node/node.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/node.py
@@ -1,4 +1,4 @@
-"""Primary Alpha Node runtime."""
+"""Primary Alpha Node runtime orchestrator."""
 from __future__ import annotations
 
 import json
@@ -6,154 +6,178 @@ import time
 from pathlib import Path
 from typing import Dict, Optional
 
-from .blockchain import BlockchainInteractor, RewardSnapshot, StakeStatus
-from .compliance import ComplianceEngine, ComplianceScore
+from web3 import Web3
+
+from .compliance import ComplianceScorecard, ComplianceScores
 from .config import AlphaNodeConfig
-from .ens import ENSVerifier
+from .economy import StakeManagerClient, StakeStatus
+from .ens import ENSVerificationResult, ENSVerifier
+from .governance import GovernanceState, SystemPauseManager
 from .jobs import TaskHarvester
 from .knowledge import KnowledgeLake
 from .logging_utils import configure_logging, get_logger
 from .metrics import MetricsExporter
-from .planner import MuZeroPlanner
-from .specialists import SpecialistAgent, SpecialistResult, build_specialist
 from .orchestrator import Orchestrator
+from .planner import MuZeroPlanner
+from .specialists import BaseSpecialist, SpecialistResult, build_specialist
 from .state import AlphaNodeState
 
 LOGGER = get_logger(__name__)
 
 
 class AlphaNode:
-    """High-level orchestrator for the demo."""
+    """High-level controller exposing a non-technical operator surface."""
 
-    def __init__(self, config: AlphaNodeConfig, ens_cache: Optional[Path] = None) -> None:
-        configure_logging(config.log_path)
+    def __init__(
+        self,
+        config: AlphaNodeConfig,
+        *,
+        ens_verifier: Optional[ENSVerifier] = None,
+        stake_client: Optional[StakeManagerClient] = None,
+        task_harvester: Optional[TaskHarvester] = None,
+        metrics: Optional[MetricsExporter] = None,
+        pause_manager: Optional[SystemPauseManager] = None,
+        web3: Optional[Web3] = None,
+    ) -> None:
+        configure_logging(config.storage.logs_path)
         self.config = config
         self.state = AlphaNodeState(governance_address=config.governance_address)
-        self.knowledge = KnowledgeLake(config.knowledge_path)
-        self.blockchain = BlockchainInteractor(
-            job_registry_address=config.job_registry_address,
-            stake_manager_address=config.stake_manager_address,
-            incentives_address=config.incentives_address,
-            treasury_address=config.treasury_address,
-            required_stake=config.stake_threshold,
+        self.knowledge = KnowledgeLake(config.storage.knowledge_path)
+        self.web3 = web3 or Web3(Web3.HTTPProvider(config.rpc_url))
+        self.ens = ens_verifier or ENSVerifier(config.rpc_url)
+        self.stake_client = stake_client or StakeManagerClient(
+            self.web3,
+            config.staking.stake_manager_address,
+            int(config.staking.min_stake_wei),
+            [token.__dict__ for token in config.staking.reward_tokens],
         )
-        self.ens = ENSVerifier(config.rpc_url, cache_path=ens_cache)
-        self.compliance = ComplianceEngine(self.state, config.stake_threshold)
-        self.planner = MuZeroPlanner(
-            horizon=config.planning_horizon,
-            exploration_bias=config.exploration_bias,
-            knowledge=self.knowledge,
-        )
-        self.specialists: Dict[str, SpecialistAgent] = {}
-        for spec in config.enabled_specialists():
-            domain = spec.name.lower()
-            self.specialists[domain] = build_specialist(
-                domain=domain,
-                name=spec.name,
-                description=spec.description,
-                risk_limit=spec.risk_limit,
+        governance_state_path = config.storage.logs_path.with_suffix(".governance.json")
+        self.pause_manager = pause_manager or SystemPauseManager(self.web3, governance_state_path)
+        try:
+            self.pause_manager.load()
+        except FileNotFoundError:
+            self.pause_manager.bootstrap(
+                config.owner_address,
+                config.governance_address,
+                config.security.pause_contract,
             )
-        self.orchestrator = Orchestrator(
-            planner=self.planner,
-            specialists=self.specialists,
+        self.state.set_paused(self.pause_manager.state.paused)
+        self.compliance = ComplianceScorecard()
+        self.metrics = metrics or MetricsExporter(config.metrics.prometheus_port)
+        self.planner = MuZeroPlanner(
+            depth=config.planner.search_depth,
+            exploration_constant=config.planner.exploration_constant,
+            learning_rate=config.planner.learning_rate,
             knowledge=self.knowledge,
-            state=self.state,
         )
-        jobs_path = config.knowledge_path.parent / "jobs.json"
-        if not jobs_path.exists():
-            default_jobs = Path(__file__).resolve().parent.parent / "jobs" / "demo_jobs.json"
-            if default_jobs.exists():
-                jobs_path.write_text(default_jobs.read_text(encoding="utf-8"), encoding="utf-8")
-            else:
-                jobs_path.write_text(json.dumps([], indent=2), encoding="utf-8")
-        self.harvester = TaskHarvester(jobs_path, loop=True)
-        self.metrics = MetricsExporter(self.state, config.metrics_port)
+        specialists = self._build_specialists(config)
+        self.orchestrator = Orchestrator(self.planner, self.knowledge, specialists)
+        jobs_path = self._ensure_jobs_file_exists(config.storage.knowledge_path.parent)
+        self.harvester = task_harvester or TaskHarvester(jobs_path, loop=True)
         self.running = False
 
-    def bootstrap(self) -> None:
-        result = self.ens.verify(self.config.ens_domain, self.config.owner_address)
-        self.state.set_ens_verified(result.verified)
-        if not result.verified:
-            raise RuntimeError("ENS verification failed")
-        stake_status = self.blockchain.status(self.config.owner_address)
-        self.state.update_stake(stake_status.staked_amount)
-        self.state.set_slashed_amount(stake_status.slashed_amount)
-        if not stake_status.active:
-            LOGGER.warning(
-                "Stake below threshold | required=%s current=%s",
-                stake_status.required_amount,
-                stake_status.staked_amount,
-            )
-        if self.config.enable_prometheus:
-            self.metrics.start()
-        self.compliance.evaluate()
-        LOGGER.info("Alpha Node bootstrapped | domain=%s", self.config.ens_domain)
+    def bootstrap(self) -> ComplianceScores:
+        """Verify identity, surface initial metrics, and emit a compliance snapshot."""
 
-    def pause(self) -> None:
-        self.state.set_paused(True)
-        LOGGER.warning("System paused by operator")
-
-    def resume(self) -> None:
-        self.state.set_paused(False)
-        LOGGER.info("System resumed by operator")
-
-    def update_governance(self, address: str) -> None:
-        self.state.set_governance_address(address)
-        LOGGER.info("Governance address updated | address=%s", address)
-        self.compliance.evaluate()
-
-    def stake(self, amount: int) -> StakeStatus:
-        status = self.blockchain.stake(self.config.owner_address, amount)
-        self.state.update_stake(status.staked_amount)
-        self.state.set_slashed_amount(status.slashed_amount)
+        ens_result = self.ens.verify(self.config.identity.ens_domain, self.config.owner_address)
+        self.state.set_ens_verified(ens_result.verified)
+        if not ens_result.verified:
+            raise RuntimeError("ENS verification failed; aborting activation")
+        stake_status = self.stake_client.status()
+        self.state.update_stake(stake_status.staked_wei)
+        self.state.set_rewards(stake_status.rewards_wei)
+        self.metrics.start()
+        scores = self._evaluate_compliance(ens_result, stake_status)
         LOGGER.info(
-            "Stake operation | operator=%s staked=%s required=%s",
-            self.config.owner_address,
-            status.staked_amount,
-            status.required_amount,
+            "Alpha Node bootstrapped",
+            extra={
+                "ens_domain": self.config.identity.ens_domain,
+                "stake": stake_status.staked_wei,
+                "compliance": scores.total,
+            },
         )
-        self.compliance.evaluate()
+        return scores
+
+    def pause(self, reason: str = "operator-request") -> GovernanceState:
+        state = self.pause_manager.pause(reason)
+        self.state.set_paused(state.paused)
+        self._evaluate_compliance()
+        LOGGER.warning("System paused", extra={"reason": reason})
+        return state
+
+    def resume(self, note: str = "operator-resume") -> GovernanceState:
+        state = self.pause_manager.resume(note)
+        self.state.set_paused(state.paused)
+        self._evaluate_compliance()
+        LOGGER.info("System resumed", extra={"note": note})
+        return state
+
+    def update_governance(self, address: str, justification: str = "governance-rotation") -> GovernanceState:
+        state = self.pause_manager.rotate_governance(address, justification)
+        self.state.set_governance_address(state.governance_address)
+        self._evaluate_compliance()
+        return state
+
+    def stake(self, amount_wei: int) -> StakeStatus:
+        status = self.stake_client.deposit(amount_wei, self.config.owner_address)
+        self.state.update_stake(status.staked_wei)
+        self.metrics.update_stake(status.staked_wei)
+        self._evaluate_compliance(stake_status=status)
         return status
 
-    def withdraw(self, amount: int) -> StakeStatus:
-        status = self.blockchain.withdraw(self.config.owner_address, amount)
-        self.state.update_stake(status.staked_amount)
-        self.state.set_slashed_amount(status.slashed_amount)
-        LOGGER.info("Stake withdrawal | remaining=%s", status.staked_amount)
-        self.compliance.evaluate()
+    def withdraw(self, amount_wei: int) -> StakeStatus:
+        status = self.stake_client.withdraw(amount_wei)
+        self.state.update_stake(status.staked_wei)
+        self.metrics.update_stake(status.staked_wei)
+        self._evaluate_compliance(stake_status=status)
         return status
 
-    def claim_rewards(self) -> RewardSnapshot:
-        snapshot = self.blockchain.claim_rewards(self.config.owner_address)
-        self.state.set_rewards(snapshot.unclaimed_rewards)
-        LOGGER.info("Rewards claimed | remaining=%s", snapshot.unclaimed_rewards)
-        self.compliance.evaluate()
-        return snapshot
+    def claim_rewards(self) -> Iterable[str]:
+        rewards = self.stake_client.claim_rewards(self.config.owner_address)
+        self.state.set_rewards(0)
+        self.metrics.update_rewards(0)
+        LOGGER.info("Rewards claimed", extra={"tokens": [token.symbol for token in rewards]})
+        self._evaluate_compliance()
+        return [token.symbol for token in rewards]
 
     def run_safety_drill(self) -> None:
-        LOGGER.info("Executing emergency drill")
-        self.pause()
+        LOGGER.info("Running emergency pause drill")
+        self.pause("drill")
         time.sleep(0.1)
         self.state.record_drill()
-        self.resume()
-        self.compliance.evaluate()
+        self.resume("drill-complete")
+        self._evaluate_compliance()
 
-    def compliance_report(self) -> ComplianceScore:
-        return self.compliance.evaluate()
+    def compliance_report(self) -> ComplianceScores:
+        return self._evaluate_compliance()
 
     def run_once(self) -> Optional[SpecialistResult]:
         if self.state.governance.paused:
-            LOGGER.warning("Attempted to run while paused")
+            LOGGER.warning("Skipping execution while paused")
             return None
         job = self.harvester.next_job()
-        if not job:
-            LOGGER.info("No jobs available")
+        if job is None:
+            LOGGER.info("No jobs available for execution")
             return None
-        result = self.orchestrator.execute_job(job)
-        self.blockchain.grant_rewards(self.config.owner_address, int(result.specialist_result.reward_delta))
-        self.state.accrue_rewards(int(result.specialist_result.reward_delta))
-        self.compliance.evaluate()
-        return result.specialist_result
+        outcome = self.orchestrator.execute([job.to_planner_dict()])
+        reward_wei = int(outcome.result.reward_estimate * 1e18)
+        status = self.stake_client.accrue_rewards(reward_wei)
+        self.state.accrue_rewards(reward_wei)
+        self.state.register_completion(job.job_id, success=True)
+        self.metrics.update_rewards(status.rewards_wei)
+        self.metrics.update_stake(status.staked_wei)
+        self.metrics.increment_completions(self.state.ops.completed_jobs)
+        self.state.set_metric("last_reward_wei", reward_wei)
+        self._evaluate_compliance(stake_status=status)
+        LOGGER.info(
+            "Job executed",
+            extra={
+                "job_id": outcome.plan.job_id,
+                "specialist": outcome.result.specialist,
+                "reward_estimate": outcome.result.reward_estimate,
+            },
+        )
+        return outcome.result
 
     def run_forever(self) -> None:
         self.running = True
@@ -161,15 +185,66 @@ class AlphaNode:
         while self.running:
             try:
                 self.run_once()
-            except Exception as exc:
-                LOGGER.exception("Autonomous loop error: %s", exc)
-                self.pause()
-            time.sleep(self.config.job_poll_interval)
+            except Exception as exc:  # pragma: no cover - defensive loop guard
+                LOGGER.exception("Autonomous loop error", exc_info=exc)
+                self.pause("autonomous-error")
+            time.sleep(max(self.config.jobs.poll_interval_seconds, 1))
 
     def shutdown(self) -> None:
         self.running = False
+        self.harvester.stop()
         self.metrics.stop()
         LOGGER.info("Alpha Node shutdown complete")
+
+    def _evaluate_compliance(
+        self,
+        ens_result: Optional[ENSVerificationResult] = None,
+        stake_status: Optional[StakeStatus] = None,
+    ) -> ComplianceScores:
+        ens_snapshot = ens_result or self.ens.verify(self.config.identity.ens_domain, self.config.owner_address)
+        stake_snapshot = stake_status or self.stake_client.status()
+        scores = self.compliance.evaluate(
+            ens_result=ens_snapshot,
+            stake_status=stake_snapshot,
+            governance=self.pause_manager.state,
+            planner_trend=self._planner_trend(),
+            antifragility_checks={
+                "drill": self.state.ops.drills_completed > 0,
+                "pause_resume": not self.pause_manager.state.paused,
+            },
+        )
+        self.state.set_compliance(scores.total)
+        self.metrics.update_compliance(scores.total)
+        return scores
+
+    def _planner_trend(self) -> float:
+        completed = self.state.ops.completed_jobs
+        return min(1.0, 0.6 + completed * 0.05)
+
+    def _build_specialists(self, config: AlphaNodeConfig) -> Dict[str, BaseSpecialist]:
+        specialists: Dict[str, BaseSpecialist] = {}
+        for spec in config.enabled_specialists():
+            specialist = build_specialist(spec.domain, self.knowledge)
+            specialist.name = spec.name  # type: ignore[attr-defined]
+            specialists[spec.domain.lower()] = specialist
+        if not specialists:
+            # Fallback to default roster to keep the node productive.
+            for spec in config.specialists:
+                specialist = build_specialist(spec.domain, self.knowledge)
+                specialists[spec.domain.lower()] = specialist
+        return specialists
+
+    def _ensure_jobs_file_exists(self, directory: Path) -> Path:
+        directory.mkdir(parents=True, exist_ok=True)
+        jobs_path = directory / "jobs.json"
+        if jobs_path.exists():
+            return jobs_path
+        default_jobs = Path(__file__).resolve().parent.parent / "jobs" / "demo_jobs.json"
+        payload = json.dumps([], indent=2)
+        if default_jobs.exists():
+            payload = default_jobs.read_text(encoding="utf-8")
+        jobs_path.write_text(payload, encoding="utf-8")
+        return jobs_path
 
 
 __all__ = ["AlphaNode"]

--- a/demo/AGI-Alpha-Node-v0/alpha_node/specialists/__init__.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/specialists/__init__.py
@@ -1,8 +1,32 @@
-"""Specialist agent registry."""
+"""Specialist agent registry and factory helpers."""
+from __future__ import annotations
+
+from typing import Dict
+
+from ..knowledge import KnowledgeLake
 from .base import BaseSpecialist, SpecialistResult
 from .finance import FinanceStrategist
 from .biotech import BiotechSynthesist
 from .manufacturing import ManufacturingOptimizer
+
+_REGISTRY: Dict[str, type[BaseSpecialist]] = {
+    "finance": FinanceStrategist,
+    "biotech": BiotechSynthesist,
+    "manufacturing": ManufacturingOptimizer,
+}
+
+
+def build_specialist(domain: str, knowledge: KnowledgeLake) -> BaseSpecialist:
+    """Instantiate a specialist for the requested domain."""
+
+    key = domain.lower()
+    try:
+        specialist_cls = _REGISTRY[key]
+    except KeyError as exc:  # pragma: no cover - defensive path
+        raise ValueError(f"Unsupported specialist domain: {domain}") from exc
+    specialist = specialist_cls(knowledge)
+    return specialist
+
 
 __all__ = [
     "BaseSpecialist",
@@ -10,4 +34,5 @@ __all__ = [
     "FinanceStrategist",
     "BiotechSynthesist",
     "ManufacturingOptimizer",
+    "build_specialist",
 ]

--- a/demo/AGI-Alpha-Node-v0/config/example.alpha-node.yaml
+++ b/demo/AGI-Alpha-Node-v0/config/example.alpha-node.yaml
@@ -12,8 +12,11 @@ security:
   pause_contract: "0x000000000000000000000000000000000000c0DE"
 
 staking:
-  stake_manager_address: "0x0000000000000000000000000000000000005TaK"
+  stake_manager_address: "0x0000000000000000000000000000000000005a0c"
   min_stake_wei: "1000000000000000000000"
+  incentives_address: "0x0000000000000000000000000000000000001ace"
+  treasury_address: "0x0000000000000000000000000000000000007eaa"
+  fee_pool_address: "0x000000000000000000000000000000000000fee1"
   reward_tokens:
     - symbol: "AGIALPHA"
       address: "0x000000000000000000000000000000000000A610"
@@ -34,3 +37,17 @@ metrics:
 storage:
   knowledge_path: "./storage/knowledge.db"
   logs_path: "./storage/logs.jsonl"
+
+specialists:
+  - domain: "finance"
+    name: "Finance Strategist"
+    description: "Synthesises sovereign-grade capital flows and reinvestment flywheels."
+    risk_limit: 0.3
+  - domain: "biotech"
+    name: "Biotech Synthesist"
+    description: "Designs breakthrough compounds with autonomous lab orchestration."
+    risk_limit: 0.25
+  - domain: "manufacturing"
+    name: "Manufacturing Optimizer"
+    description: "Tunes supply chains and robotic factories for compound throughput."
+    risk_limit: 0.2

--- a/demo/AGI-Alpha-Node-v0/jobs/demo_jobs.json
+++ b/demo/AGI-Alpha-Node-v0/jobs/demo_jobs.json
@@ -1,20 +1,36 @@
 [
   {
-    "id": "FIN-001",
-    "domain": "finance",
-    "strategies": ["treasury-optimizer", "yield-strategy"],
-    "payload": {"capital_multiplier": 2.4}
+    "job_id": "FIN-001",
+    "description": "Deploy a sovereign treasury optimizer that compounds AGIALPHA liquidity across cross-chain markets.",
+    "base_reward": 18.5,
+    "risk": 0.18,
+    "metadata": {
+      "domain": "finance",
+      "strategies": ["treasury-optimizer", "yield-strategy"],
+      "capital_multiplier": 2.4
+    }
   },
   {
-    "id": "BIO-042",
-    "domain": "biotech",
-    "strategies": ["synthesis-flow", "bio-risk-buffer"],
-    "payload": {"synthesis_efficiency": 1.8}
+    "job_id": "BIO-042",
+    "description": "Synthesize next-generation antimicrobial compound using autonomous wet lab orchestration.",
+    "base_reward": 22.1,
+    "risk": 0.22,
+    "metadata": {
+      "domain": "biotech",
+      "strategies": ["synthesis-flow", "bio-risk-buffer"],
+      "synthesis_efficiency": 1.8
+    }
   },
   {
-    "id": "MAN-777",
-    "domain": "manufacturing",
-    "strategies": ["digital-twin", "lean-hyperloop"],
-    "payload": {"throughput": 220, "waste_reduction": 0.22}
+    "job_id": "MAN-777",
+    "description": "Optimise hyper-scale robotics manufacturing line with digital twin feedback loops.",
+    "base_reward": 16.9,
+    "risk": 0.15,
+    "metadata": {
+      "domain": "manufacturing",
+      "strategies": ["digital-twin", "lean-hyperloop"],
+      "throughput": 220,
+      "waste_reduction": 0.22
+    }
   }
 ]

--- a/demo/AGI-Alpha-Node-v0/tests/test_config.py
+++ b/demo/AGI-Alpha-Node-v0/tests/test_config.py
@@ -18,8 +18,10 @@ security:
   emergency_contact: ops@example
   pause_contract: "0x000000000000000000000000000000000000c0DE"
 staking:
-  stake_manager_address: "0x0000000000000000000000000000000000005TaK"
+  stake_manager_address: "0x0000000000000000000000000000000000005a0c"
   min_stake_wei: 1000
+  incentives_address: "0x0000000000000000000000000000000000001ace"
+  treasury_address: "0x0000000000000000000000000000000000007eaa"
   reward_tokens:
     - symbol: AGIALPHA
       address: "0x000000000000000000000000000000000000A610"
@@ -35,14 +37,24 @@ metrics:
 storage:
   knowledge_path: "./knowledge.db"
   logs_path: "./logs.jsonl"
+specialists:
+  - domain: finance
+    name: Finance Strategist
+    description: Unlocks capital efficiency.
+    risk_limit: 0.3
+  - domain: biotech
+    name: Biotech Synthesist
+    description: Synthesises breakthrough compounds.
+    risk_limit: 0.2
 """,
         encoding="utf-8",
     )
-    config = AlphaNodeConfig.from_file(cfg)
+    config = AlphaNodeConfig.load(cfg)
     assert config.identity.ens_domain == "demo.alpha.node.agi.eth"
     assert config.staking.reward_tokens[0].symbol == "AGIALPHA"
     assert config.metrics.prometheus_port == 8000
     assert config.storage.knowledge_path.name == "knowledge.db"
+    assert len(list(config.enabled_specialists())) == 2
 
 
 def test_config_missing(tmp_path: Path) -> None:

--- a/demo/AGI-Alpha-Node-v0/tests/test_jobs.py
+++ b/demo/AGI-Alpha-Node-v0/tests/test_jobs.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from alpha_node.jobs import TaskHarvester
+
+
+def test_task_harvester_file_mode(tmp_path: Path) -> None:
+    jobs = tmp_path / "jobs.json"
+    jobs.write_text(
+        """
+[
+  {"job_id": "FIN-001", "description": "Finance job", "base_reward": 10, "risk": 0.1, "metadata": {"domain": "finance"}}
+]
+""",
+        encoding="utf-8",
+    )
+    harvester = TaskHarvester(jobs, loop=False)
+    first = harvester.next_job()
+    assert first is not None
+    assert first.job_id == "FIN-001"
+    assert harvester.next_job() is None
+
+
+def test_task_harvester_loop(tmp_path: Path) -> None:
+    jobs = tmp_path / "jobs.json"
+    jobs.write_text(
+        """
+[
+  {"job_id": "BIO-001", "description": "Biotech job", "base_reward": 9, "risk": 0.2, "metadata": {"domain": "biotech"}}
+]
+""",
+        encoding="utf-8",
+    )
+    harvester = TaskHarvester(jobs, loop=True)
+    first = harvester.next_job()
+    second = harvester.next_job()
+    assert first is not None and second is not None
+    assert second.job_id == first.job_id

--- a/demo/AGI-Alpha-Node-v0/tests/test_node.py
+++ b/demo/AGI-Alpha-Node-v0/tests/test_node.py
@@ -1,11 +1,23 @@
 from pathlib import Path
 
-from web3 import Web3
-
 from alpha_node.compliance import ComplianceScorecard
+from alpha_node.config import (
+    AlphaNodeConfig,
+    IdentityConfig,
+    JobsConfig,
+    MetricsConfig,
+    PlannerConfig,
+    RewardToken,
+    SecurityConfig,
+    SpecialistConfig,
+    StakingConfig,
+    StorageConfig,
+)
 from alpha_node.economy import StakeManagerClient
 from alpha_node.ens import ENSVerificationResult
 from alpha_node.governance import GovernanceState, SystemPauseManager
+from alpha_node.jobs import TaskHarvester
+from alpha_node.node import AlphaNode
 
 
 class FakeEth:
@@ -62,3 +74,101 @@ def test_compliance_integration(tmp_path: Path) -> None:
         antifragility_checks={"drill": True, "pause_resume": True},
     )
     assert scores.total > 0.8
+
+
+class StubENSVerifier:
+    def verify(self, domain: str, owner: str) -> ENSVerificationResult:
+        return ENSVerificationResult(domain=domain, expected_owner=owner, resolved_owner=owner, verified=True)
+
+
+class StubMetrics:
+    def __init__(self) -> None:
+        self.started = False
+        self.last_compliance = 0.0
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.started = False
+
+    def update_compliance(self, score: float) -> None:
+        self.last_compliance = score
+
+    def update_stake(self, stake: int) -> None:
+        self.last_stake = stake
+
+    def update_rewards(self, rewards: int) -> None:
+        self.last_rewards = rewards
+
+    def increment_completions(self, total: int) -> None:
+        self.last_total = total
+
+
+def test_alpha_node_run_cycle(tmp_path: Path) -> None:
+    job_file = tmp_path / "jobs.json"
+    job_file.write_text(
+        """
+[
+  {
+    "job_id": "FIN-001",
+    "description": "Deploy treasury flywheel",
+    "base_reward": 12.5,
+    "risk": 0.18,
+    "metadata": {"domain": "finance"}
+  }
+]
+""",
+        encoding="utf-8",
+    )
+    config = AlphaNodeConfig(
+        identity=IdentityConfig(
+            ens_domain="demo.alpha.node.agi.eth",
+            operator_address="0x000000000000000000000000000000000000dEaD",
+            governance_address="0x000000000000000000000000000000000000bEEF",
+            rpc_url="http://localhost",
+        ),
+        security=SecurityConfig(emergency_contact="ops@example", pause_contract="0x000000000000000000000000000000000000c0de"),
+        staking=StakingConfig(
+            stake_manager_address="0x0000000000000000000000000000000000005a0c",
+            min_stake_wei=1_000,
+            incentives_address="0x0000000000000000000000000000000000001ace",
+            treasury_address="0x0000000000000000000000000000000000007eaa",
+            reward_tokens=[RewardToken(symbol="AGIALPHA", address="0x000000000000000000000000000000000000A610")],
+        ),
+        jobs=JobsConfig(job_router_address="0x0000000000000000000000000000000000000B55", poll_interval_seconds=1),
+        planner=PlannerConfig(search_depth=3, exploration_constant=1.1, learning_rate=0.2),
+        metrics=MetricsConfig(prometheus_port=0, dashboard_port=0),
+        storage=StorageConfig(
+            knowledge_path=(tmp_path / "knowledge.db"),
+            logs_path=(tmp_path / "logs.jsonl"),
+        ),
+        specialists=[
+            SpecialistConfig(domain="finance", name="Finance Strategist", description="", risk_limit=0.3),
+        ],
+    )
+    stake_client = StakeManagerClient(
+        FakeWeb3(),
+        config.staking.stake_manager_address,
+        config.staking.min_stake_wei,
+        [token.__dict__ for token in config.staking.reward_tokens],
+    )
+    pause_manager = SystemPauseManager(FakeWeb3(), tmp_path / "gov.json")
+    pause_manager.bootstrap(config.owner_address, config.governance_address, config.security.pause_contract)
+    metrics = StubMetrics()
+    node = AlphaNode(
+        config=config,
+        ens_verifier=StubENSVerifier(),
+        stake_client=stake_client,
+        task_harvester=TaskHarvester(job_file, loop=False),
+        metrics=metrics,
+        pause_manager=pause_manager,
+        web3=FakeWeb3(),
+    )
+
+    node.bootstrap()
+    node.stake(config.staking.min_stake_wei)
+    result = node.run_once()
+    assert result is not None
+    assert node.state.ops.completed_jobs == 1
+    assert metrics.last_compliance > 0


### PR DESCRIPTION
## Summary
- expand the AGI Alpha Node configuration schema with governance-ready contract addresses and specialist toggles, and refresh the example/template data
- rebuild the runtime orchestration stack with dual-mode job harvesting, specialist coordination, richer compliance evaluation, and updated CLI/console tooling
- add scenario fixtures and tests covering the new task harvester and end-to-end Alpha Node execution flow

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q demo/AGI-Alpha-Node-v0/tests`


------
https://chatgpt.com/codex/tasks/task_e_69021fe4c3ac8333bafe5749d5f8d267