### PR TITLE
Add scenario-driven validator constellation orchestrator

### DIFF
--- a/demo/Validator-Constellation-v0/README.md
+++ b/demo/Validator-Constellation-v0/README.md
@@ -36,6 +36,14 @@ This single command spins up the validator constellation, performs VRF committee
 
 Passing `--web-artifacts web/data` additionally produces `summary.json`, `events.json`, `timeline.json`, and `owner-actions.json` files that the `web/index.html` command deck automatically ingests.  Open the HTML file locally after running the command to see the live metrics and sentinel alert stream updated with your run's telemetry.
 
+To replay the Kardashev-ready YAML scenario that ships with the repository, simply point the CLI to the configuration file:
+
+```bash
+python run_demo.py --scenario config/stellar-scenario.yaml --seed mission-42
+```
+
+The scenario runner ingests the ENS registry, validator committee, sentinel anomalies, owner actions, and governance deltas defined in the YAML and emits the same comprehensive summary artefacts—no code edits required.
+
 You can also run the package directly:
 
 ```bash

--- a/demo/Validator-Constellation-v0/tests/test_scenario_runner.py
+++ b/demo/Validator-Constellation-v0/tests/test_scenario_runner.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from validator_constellation.demo_runner import run_validator_constellation_scenario
+
+
+def test_yaml_scenario_execution():
+    scenario_path = Path(__file__).resolve().parent.parent / "config" / "stellar-scenario.yaml"
+    summary = run_validator_constellation_scenario(scenario_path, seed_override="mission-42")
+
+    assert summary.scenario_name == "stellar-sentinel-constellation"
+    assert summary.committee_signature == "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    assert not summary.batch_proof_root.startswith("0x")  # hashed string without prefix
+    assert summary.gas_saved > 0
+    assert summary.sentinel_alerts, "expected sentinel alerts from scenario anomalies"
+    assert summary.domain_events, "expected domain pause/resume events to be recorded"
+    assert summary.entropy_sources is not None and "onChainEntropy" in summary.entropy_sources
+    assert summary.verifying_key == "0xf1f2f3f4f5f6f7f8f9fafbfcfdfeff00112233445566778899aabbccddeeff0011"
+    assert summary.context.get("operator") == "Non-technical mission director"
+    assert any(action["action"] == "treasury-distribution" for action in summary.owner_actions)

--- a/demo/Validator-Constellation-v0/validator_constellation/__init__.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/__init__.py
@@ -27,7 +27,13 @@ from .sentinel import (
     PauseRecord,
     DomainState,
 )
-from .demo_runner import DemoSummary, run_validator_constellation_demo, summary_to_dict, write_web_artifacts
+from .demo_runner import (
+    DemoSummary,
+    run_validator_constellation_demo,
+    run_validator_constellation_scenario,
+    summary_to_dict,
+    write_web_artifacts,
+)
 from .subgraph import SubgraphIndexer, IndexedEvent
 from .governance import OwnerConsole, OwnerAction
 
@@ -61,4 +67,5 @@ __all__ = [
     "summary_to_dict",
     "write_web_artifacts",
     "run_validator_constellation_demo",
+    "run_validator_constellation_scenario",
 ]

--- a/demo/Validator-Constellation-v0/validator_constellation/demo_runner.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/demo_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
@@ -15,7 +16,8 @@ from .sentinel import AgentAction, DomainPauseController, SentinelMonitor, Senti
 from .staking import StakeManager
 from .subgraph import SubgraphIndexer
 from .vrf import VRFCoordinator
-from .zk_batch import JobResult, ZKBatchAttestor
+from .zk_batch import BatchProof, JobResult, ZKBatchAttestor
+from .scenario import ScenarioAgent, ScenarioSpec, load_scenario
 
 
 @dataclass(slots=True)
@@ -33,6 +35,12 @@ class DemoSummary:
     sentinel_alerts: List[Dict[str, object]]
     domain_events: List[Dict[str, object]]
     event_feed: List[Dict[str, object]]
+    scenario_name: Optional[str] = None
+    scenario_description: Optional[str] = None
+    committee_signature: Optional[str] = None
+    context: Optional[Dict[str, object]] = None
+    entropy_sources: Optional[Dict[str, object]] = None
+    verifying_key: Optional[str] = None
 
 
 def _json_default(value: object) -> object:
@@ -56,6 +64,12 @@ def summary_to_dict(summary: DemoSummary) -> Dict[str, object]:
         "sentinelAlerts": summary.sentinel_alerts,
         "domainEvents": summary.domain_events,
         "eventFeed": summary.event_feed,
+        "scenarioName": summary.scenario_name,
+        "scenarioDescription": summary.scenario_description,
+        "committeeSignature": summary.committee_signature,
+        "context": summary.context,
+        "entropySources": summary.entropy_sources,
+        "verifyingKey": summary.verifying_key,
     }
 
 
@@ -85,6 +99,80 @@ def write_web_artifacts(summary: DemoSummary, output_dir: Path) -> Dict[str, Pat
         "timeline": timeline_path,
         "owner_actions": owner_actions_path,
     }
+
+
+def _build_summary(
+    *,
+    event_bus: EventBus,
+    domain_pause: DomainPauseController,
+    owner_console: OwnerConsole,
+    sentinel: SentinelMonitor,
+    committee: Dict[str, str],
+    truthful_outcome: bool,
+    round_result: bool,
+    batch_proof: BatchProof,
+    gas_saved: int,
+    timeline: Dict[str, Optional[int]],
+    committee_signature: Optional[str] = None,
+    scenario_name: Optional[str] = None,
+    scenario_description: Optional[str] = None,
+    context: Optional[Dict[str, object]] = None,
+    entropy_sources: Optional[Dict[str, object]] = None,
+    verifying_key: Optional[str] = None,
+) -> DemoSummary:
+    slashed = [event.payload["address"] for event in event_bus.find("ValidatorSlashed")]
+    sentinel_alerts = [
+        {
+            "domain": event.payload.get("domain"),
+            "rule": event.payload.get("rule"),
+            "reason": event.payload.get("reason"),
+            "severity": event.payload.get("severity"),
+        }
+        for event in event_bus.find("SentinelAlert")
+    ]
+    domain_pauses = [
+        {
+            "domain": event.payload.get("domain"),
+            "reason": event.payload.get("reason"),
+            "triggeredBy": event.payload.get("triggeredBy"),
+            "timestamp": event.payload.get("timestamp"),
+        }
+        for event in event_bus.find("DomainPaused")
+    ]
+    event_feed = [
+        {
+            "id": index + 1,
+            "type": event.type,
+            "payload": event.payload,
+            "timestamp": event.timestamp.isoformat(),
+        }
+        for index, event in enumerate(event_bus.events)
+    ]
+
+    return DemoSummary(
+        committee=committee,
+        truthful_outcome=truthful_outcome,
+        round_result=round_result,
+        slashed_validators=slashed,
+        paused_domains=sorted(domain_pause.paused_domains.keys()),
+        batch_proof_root=batch_proof.batch_root,
+        gas_saved=gas_saved,
+        indexed_events=len(event_bus.events),
+        timeline=timeline,
+        owner_actions=[
+            {"operator": action.operator, "action": action.action, "details": action.details}
+            for action in owner_console.actions
+        ],
+        sentinel_alerts=sentinel_alerts,
+        domain_events=domain_pauses,
+        event_feed=event_feed,
+        scenario_name=scenario_name,
+        scenario_description=scenario_description,
+        committee_signature=committee_signature,
+        context=context,
+        entropy_sources=entropy_sources,
+        verifying_key=verifying_key,
+    )
 
 
 def run_validator_constellation_demo(
@@ -251,57 +339,388 @@ def run_validator_constellation_demo(
         for i in range(1, min(job_target, config.batch_proof_capacity) + 1)
     ]
     proof = batcher.create_batch_proof(jobs)
-
-    slashed = [event.payload["address"] for event in event_bus.find("ValidatorSlashed")]
     finalized_event = next(event_bus.find("RoundFinalized"), None)
-    timeline = finalized_event.payload.get("timeline") if finalized_event else {}
-
-    domain_pauses = [
-        {
-            "domain": event.payload["domain"],
-            "reason": event.payload["reason"],
-            "triggeredBy": event.payload.get("triggeredBy"),
-            "timestamp": event.payload.get("timestamp"),
-        }
-        for event in event_bus.find("DomainPaused")
-    ]
-
-    sentinel_alerts = [
-        {
-            "domain": event.payload["domain"],
-            "rule": event.payload.get("rule", ""),
-            "reason": event.payload["reason"],
-            "severity": event.payload.get("severity", ""),
-        }
-        for event in event_bus.find("SentinelAlert")
-    ]
-
-    event_feed = [
-        {
-            "id": index + 1,
-            "type": event.type,
-            "payload": event.payload,
-            "timestamp": event.timestamp.isoformat(),
-        }
-        for index, event in enumerate(event_bus.events)
-    ]
-
-    return DemoSummary(
+    timeline = dict(finalized_event.payload.get("timeline") if finalized_event else {})
+    return _build_summary(
+        event_bus=event_bus,
+        domain_pause=domain_pause,
+        owner_console=owner_console,
+        sentinel=sentinel,
         committee=committee,
         truthful_outcome=truthful_outcome,
         round_result=round_result,
-        slashed_validators=slashed,
-        paused_domains=sorted(domain_pause.paused_domains.keys()),
-        batch_proof_root=proof.batch_root,
+        batch_proof=proof,
         gas_saved=batcher.estimate_gas_saved(len(jobs)),
-        indexed_events=len(event_bus.events),
-        timeline=dict(timeline or {}),
-        owner_actions=[
-            {"operator": action.operator, "action": action.action, "details": action.details}
-            for action in owner_console.actions
+        timeline=timeline,
+    )
+
+
+def run_validator_constellation_scenario(
+    scenario_path: Path | str,
+    *,
+    seed_override: Optional[str] = None,
+    truthful_override: Optional[bool] = None,
+) -> DemoSummary:
+    spec = load_scenario(scenario_path)
+    config = SystemConfig()
+
+    event_bus = EventBus()
+    SubgraphIndexer(event_bus)
+    stake_manager = StakeManager(event_bus, config.owner_address)
+    if spec.base_setup.treasury_address:
+        stake_manager.set_treasury_recipient(spec.base_setup.treasury_address)
+
+    if spec.domains:
+        domain_definitions = [
+            {
+                "domain": domain.id,
+                "human_name": domain.human_name,
+                "budget_limit": domain.budget_limit,
+                "unsafe_opcodes": domain.unsafe_opcodes,
+                "allowed_targets": domain.allowed_targets,
+                "max_calldata_bytes": domain.max_calldata_bytes,
+                "forbidden_selectors": domain.forbidden_selectors,
+            }
+            for domain in spec.domains
+        ]
+    else:
+        domain_definitions = [
+            {
+                "domain": "synthetic-biology",
+                "human_name": "Synthetic Biology AGI Lab",
+                "budget_limit": Decimal("1000000"),
+                "unsafe_opcodes": ["SELFDESTRUCT", "DELEGATECALL"],
+                "allowed_targets": ["vault.sentinel.agi"],
+                "max_calldata_bytes": 4096,
+                "forbidden_selectors": ["0xd0e30db0"],
+            }
+        ]
+    domain_pause = DomainPauseController(event_bus, domains=domain_definitions)
+
+    sentinel_ratio = spec.base_setup.sentinel_grace_ratio or 0.05
+    sentinel = SentinelMonitor(
+        pause_controller=domain_pause,
+        event_bus=event_bus,
+        budget_grace_ratio=sentinel_ratio,
+        custom_rules=[
+            SentinelRule(
+                name="RISK_SPIKE",
+                description="Agent risk score exceeded threshold",
+                predicate=lambda action, _state: isinstance(action.metadata.get("riskScore"), (int, float))
+                and action.metadata["riskScore"] > 90,
+                severity="HIGH",
+            )
         ],
-        sentinel_alerts=sentinel_alerts,
-        domain_events=domain_pauses,
-        event_feed=event_feed,
+    )
+    owner_console = OwnerConsole(
+        owner_address=config.owner_address,
+        config=config,
+        pause_controller=domain_pause,
+        stake_manager=stake_manager,
+        event_bus=event_bus,
+        sentinel=sentinel,
+    )
+
+    if spec.base_setup.sentinel_grace_ratio is not None:
+        owner_console.update_sentinel(config.owner_address, budget_grace_ratio=spec.base_setup.sentinel_grace_ratio)
+
+    key_mapping = {
+        "commitPhaseBlocks": "commit_phase_blocks",
+        "revealPhaseBlocks": "reveal_phase_blocks",
+        "slashFractionNonReveal": "slash_fraction_non_reveal",
+        "slashFractionIncorrectVote": "slash_fraction_incorrect_vote",
+        "committeeSize": "committee_size",
+        "batchProofCapacity": "batch_proof_capacity",
+        "ownerAddress": "owner_address",
+    }
+
+    governance_updates: Dict[str, object] = {}
+    committee_override = spec.base_setup.governance.get("committeeSize")
+    if committee_override is not None:
+        config.committee_size = int(committee_override)
+        governance_updates["committee_size"] = int(committee_override)
+    commit_blocks = spec.base_setup.governance.get("commitPhaseBlocks")
+    if commit_blocks is not None:
+        governance_updates["commit_phase_blocks"] = int(commit_blocks)
+    reveal_blocks = spec.base_setup.governance.get("revealPhaseBlocks")
+    if reveal_blocks is not None:
+        governance_updates["reveal_phase_blocks"] = int(reveal_blocks)
+    slash_penalty = spec.base_setup.governance.get("slashPenaltyBps")
+    if slash_penalty is not None:
+        penalty_fraction = max(float(slash_penalty), 0.0) / 10_000
+        governance_updates["slash_fraction_incorrect_vote"] = penalty_fraction
+        governance_updates["slash_fraction_non_reveal"] = max(config.slash_fraction_non_reveal, penalty_fraction)
+    non_reveal_penalty = spec.base_setup.governance.get("nonRevealPenaltyBps")
+    if non_reveal_penalty is not None:
+        governance_updates["slash_fraction_non_reveal"] = max(float(non_reveal_penalty), 0.0) / 10_000
+    quorum_percentage = spec.base_setup.governance.get("quorumPercentage")
+    if quorum_percentage is not None:
+        committee_base = governance_updates.get("committee_size", config.committee_size)
+        quorum_value = max(1, math.ceil(float(quorum_percentage) * committee_base / 100))
+        governance_updates["quorum"] = quorum_value
+    if governance_updates:
+        owner_console.update_config(config.owner_address, **governance_updates)
+
+    identity = ENSIdentityVerifier(
+        allowed_validator_roots=config.allowed_validator_roots,
+        allowed_agent_roots=config.allowed_agent_roots,
+        allowed_node_roots=config.allowed_node_roots,
+        blacklist=config.blacklist,
+    )
+
+    ens_to_address: Dict[str, str] = {}
+    address_to_ens: Dict[str, str] = {}
+    ens_registry = set()
+
+    validators = spec.validators
+    if not validators:
+        raise ValueError("Scenario must include at least one validator definition")
+
+    for validator in validators:
+        ens = validator.ens.lower()
+        address = validator.address.lower()
+        proof = identity.sign(ens, address)
+        identity.verify_validator(address, proof)
+        stake_manager.register_validator(address, ens, validator.stake)
+        ens_to_address[ens] = address
+        address_to_ens[address] = ens
+        ens_registry.add(ens)
+
+    agents_by_ens: Dict[str, ScenarioAgent] = {}
+    agent_budgets: Dict[str, Decimal] = {}
+    for agent in spec.agents:
+        ens = agent.ens.lower()
+        address = agent.address.lower()
+        proof = identity.sign(ens, address)
+        identity.verify_agent(address, proof)
+        agents_by_ens[ens] = agent
+        agent_budgets[ens] = agent.budget
+        ens_registry.add(ens)
+
+    for node in spec.nodes:
+        proof = identity.sign(node.ens.lower(), node.address.lower())
+        identity.verify_node(node.address.lower(), proof)
+        ens_registry.add(node.ens.lower())
+
+    seed = seed_override or spec.context.get("seed") or spec.name or "scenario-seed"
+
+    def _vote_from_value(value: object, default: bool) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        text = str(value).strip().upper()
+        return text in {"APPROVE", "TRUE", "YES", "1"}
+
+    truthful_outcome = truthful_override if truthful_override is not None else _vote_from_value(
+        spec.job.truthful_vote,
+        True,
+    )
+
+    vrf = VRFCoordinator(stake_manager, domain=spec.job.domain_id)
+    committee_addresses = vrf.select_committee(seed, config.committee_size)
+    committee = {address: address_to_ens[address] for address in committee_addresses}
+
+    round_engine = CommitRevealRound(
+        round_id=f"scenario-round-{spec.job.round_id}",
+        committee=committee,
+        config=config,
+        stake_manager=stake_manager,
+        event_bus=event_bus,
+        truthful_outcome=truthful_outcome,
+    )
+
+    vote_overrides: Dict[str, bool] = {}
+    for ens, vote in spec.overrides.vote_by_ens.items():
+        address = ens_to_address.get(ens.lower())
+        if address:
+            vote_overrides[address] = _vote_from_value(vote, truthful_outcome)
+    for address, vote in spec.overrides.vote_by_address.items():
+        vote_overrides[address.lower()] = _vote_from_value(vote, truthful_outcome)
+
+    non_reveal: set[str] = set()
+    for identifier in spec.overrides.non_reveal_validators:
+        normalized = identifier.lower()
+        non_reveal.add(ens_to_address.get(normalized, normalized))
+
+    salts = {address: f"salt::{index}" for index, address in enumerate(committee.keys(), start=1)}
+    for address in committee:
+        vote = vote_overrides.get(address, truthful_outcome)
+        round_engine.commit(address, vote, salts[address])
+
+    round_engine.force_reveal_phase()
+    for address in committee:
+        if address in non_reveal:
+            continue
+        vote = vote_overrides.get(address, truthful_outcome)
+        round_engine.reveal(address, vote, salts[address])
+
+    round_engine.advance_blocks(config.reveal_phase_blocks)
+    round_result = round_engine.finalize()
+
+    entropy_sources: Dict[str, object] = {}
+    if spec.base_setup.on_chain_entropy:
+        entropy_sources["onChainEntropy"] = spec.base_setup.on_chain_entropy
+    if spec.base_setup.recent_beacon:
+        entropy_sources["recentBeacon"] = spec.base_setup.recent_beacon
+
+    block_number = 100
+    for anomaly in spec.anomalies:
+        agent_ens = anomaly.payload.get("agentEns")
+        if not agent_ens:
+            continue
+        agent = agents_by_ens.get(str(agent_ens).lower())
+        if not agent:
+            continue
+        budget = agent_budgets.get(agent.ens.lower(), agent.budget)
+        metadata = {"budget": float(budget)}
+        if anomaly.payload.get("budgetOverride") is not None:
+            metadata["budget"] = float(Decimal(str(anomaly.payload["budgetOverride"])))
+        if anomaly.payload.get("description"):
+            metadata["description"] = anomaly.payload["description"]
+        amount_value = anomaly.payload.get("amount", anomaly.payload.get("spend", budget))
+        spend_amount = float(Decimal(str(amount_value)))
+        domain_id = anomaly.payload.get("domainId", agent.domain_id)
+        action = AgentAction(
+            agent=agent.ens,
+            domain=str(domain_id),
+            spend=spend_amount,
+            call=str(anomaly.payload.get("description", anomaly.kind.replace("-", " "))),
+            metadata=metadata,
+            opcode=(str(anomaly.payload.get("opcode"))).upper() if anomaly.kind == "unsafe-opcode" else None,
+            target=anomaly.payload.get("target"),
+            calldata_bytes=int(anomaly.payload.get("calldataBytes", anomaly.payload.get("calldata_bytes", 0)))
+            if anomaly.kind == "calldata-spike"
+            else None,
+            function_selector=str(anomaly.payload.get("selector")) if anomaly.kind == "forbidden-selector" else None,
+            block_number=block_number,
+            agent_address=agent.address.lower(),
+        )
+        if anomaly.kind != "calldata-spike":
+            maybe_size = anomaly.payload.get("calldataBytes") or anomaly.payload.get("calldata_bytes")
+            if maybe_size is not None:
+                action.metadata["calldataBytes"] = int(maybe_size)
+        sentinel.evaluate(action)
+        block_number += 1
+
+    zk_key = spec.base_setup.verifying_key or "scenario-proof"
+
+    if spec.owner_actions.update_sentinel:
+        ratio = spec.owner_actions.update_sentinel.get("budgetGraceRatio")
+        if ratio is not None:
+            owner_console.update_sentinel(config.owner_address, budget_grace_ratio=float(ratio))
+
+    for update in spec.owner_actions.update_domain_safety:
+        owner_console.update_domain_policy(
+            config.owner_address,
+            update["domainId"],
+            human_name=update.get("humanName"),
+            budget_limit=update.get("budgetLimit"),
+            unsafe_opcodes=update.get("unsafeOpcodes"),
+            allowed_targets=update.get("allowedTargets"),
+            max_calldata_bytes=update.get("maxCalldataBytes"),
+            forbidden_selectors=update.get("forbiddenSelectors"),
+        )
+
+    for pause in spec.owner_actions.pause_domains:
+        owner_console.pause_domain(
+            config.owner_address,
+            pause["domainId"],
+            reason=pause.get("reason", "scenario-pause"),
+        )
+
+    for resume in spec.owner_actions.resume_domains:
+        owner_console.resume_domain(config.owner_address, resume["domainId"])
+
+    for budget_update in spec.owner_actions.set_agent_budgets:
+        ens = budget_update.get("ens")
+        if not ens:
+            continue
+        budget_value = Decimal(str(budget_update.get("budget", 0)))
+        agent_budgets[ens.lower()] = budget_value
+        owner_console.record_custom_action(
+            action="agent-budget-update",
+            details={"ens": ens, "budget": float(budget_value)},
+        )
+
+    if spec.owner_actions.update_entropy:
+        if spec.owner_actions.update_entropy.get("onChainEntropy"):
+            entropy_sources["onChainEntropy"] = spec.owner_actions.update_entropy["onChainEntropy"]
+        if spec.owner_actions.update_entropy.get("recentBeacon"):
+            entropy_sources["recentBeacon"] = spec.owner_actions.update_entropy["recentBeacon"]
+        event_bus.publish(
+            "EntropyUpdated",
+            {"owner": config.owner_address, **entropy_sources},
+        )
+        owner_console.record_custom_action(action="entropy-update", details=dict(entropy_sources))
+
+    if spec.owner_actions.update_zk_key:
+        zk_key = spec.owner_actions.update_zk_key
+        owner_console.record_custom_action(action="zk-key-rotated", details={"verifyingKey": zk_key})
+
+    if spec.owner_actions.update_governance:
+        normalized = {
+            key_mapping.get(key, key): value
+            for key, value in spec.owner_actions.update_governance.items()
+        }
+        owner_console.update_config(config.owner_address, **normalized)
+
+    for distribution in spec.owner_actions.distribute_treasury:
+        amount_value = distribution.get("amount")
+        if amount_value is None and distribution.get("percentageBps") is not None:
+            balance = stake_manager.get_treasury_balance()
+            amount_value = (balance * Decimal(distribution["percentageBps"]) / Decimal(10_000)).quantize(Decimal("0.0000000001"))
+        if amount_value is None:
+            continue
+        owner_console.distribute_treasury(
+            config.owner_address,
+            distribution["recipient"],
+            amount=amount_value,
+            note=distribution.get("note"),
+        )
+
+    if spec.owner_actions.rotate_ens_registry.get("leaves"):
+        leaves = spec.owner_actions.rotate_ens_registry["leaves"]
+        for leaf in leaves:
+            ens_registry.add(str(leaf.get("ens", "")).lower())
+        owner_console.record_custom_action(
+            action="ens-registry-rotation",
+            details={
+                "mode": spec.owner_actions.rotate_ens_registry.get("mode", "append"),
+                "leaves": leaves,
+            },
+        )
+
+    batcher = ZKBatchAttestor(config)
+    job_count = min(spec.job.count, config.batch_proof_capacity)
+    jobs = [
+        JobResult(
+            job_id=f"{spec.job.domain_id}-job-{index}",
+            outcome_hash=f"outcome::{index % 2}",
+            execution_digest=f"digest::{index}",
+        )
+        for index in range(1, job_count + 1)
+    ]
+    proof = batcher.create_batch_proof(jobs, circuit_hash=zk_key)
+    finalized_event = next(event_bus.find("RoundFinalized"), None)
+    timeline = dict(finalized_event.payload.get("timeline") if finalized_event else {})
+
+    return _build_summary(
+        event_bus=event_bus,
+        domain_pause=domain_pause,
+        owner_console=owner_console,
+        sentinel=sentinel,
+        committee=committee,
+        truthful_outcome=truthful_outcome,
+        round_result=round_result,
+        batch_proof=proof,
+        gas_saved=batcher.estimate_gas_saved(len(jobs)),
+        timeline=timeline,
+        committee_signature=spec.job.committee_signature,
+        scenario_name=spec.name,
+        scenario_description=spec.description,
+        context=spec.context,
+        entropy_sources=entropy_sources if entropy_sources else None,
+        verifying_key=zk_key,
     )
 

--- a/demo/Validator-Constellation-v0/validator_constellation/scenario.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/scenario.py
@@ -1,0 +1,257 @@
+"""Scenario loader for the Validator Constellation demo."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import yaml
+
+
+def _as_decimal(value: object) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("Cannot convert empty string to Decimal")
+        return Decimal(cleaned)
+    raise TypeError(f"Unsupported numeric type: {type(value).__name__}")
+
+
+@dataclass(slots=True)
+class ScenarioDomain:
+    id: str
+    human_name: str
+    budget_limit: Decimal
+    unsafe_opcodes: List[str] = field(default_factory=list)
+    allowed_targets: List[str] = field(default_factory=list)
+    max_calldata_bytes: int = 0
+    forbidden_selectors: List[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ScenarioValidator:
+    ens: str
+    address: str
+    stake: Decimal
+
+
+@dataclass(slots=True)
+class ScenarioAgent:
+    ens: str
+    address: str
+    domain_id: str
+    budget: Decimal
+
+
+@dataclass(slots=True)
+class ScenarioNode:
+    ens: str
+    address: str
+
+
+@dataclass(slots=True)
+class ScenarioJob:
+    domain_id: str
+    round_id: int
+    truthful_vote: str
+    committee_signature: Optional[str]
+    count: int
+
+
+@dataclass(slots=True)
+class ScenarioOverrides:
+    vote_by_ens: Dict[str, str] = field(default_factory=dict)
+    vote_by_address: Dict[str, str] = field(default_factory=dict)
+    non_reveal_validators: List[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ScenarioBase:
+    verifying_key: Optional[str]
+    sentinel_grace_ratio: Optional[float]
+    on_chain_entropy: Optional[str]
+    recent_beacon: Optional[str]
+    treasury_address: Optional[str]
+    governance: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ScenarioOwnerActions:
+    update_sentinel: Dict[str, object] = field(default_factory=dict)
+    update_domain_safety: List[Dict[str, object]] = field(default_factory=list)
+    pause_domains: List[Dict[str, object]] = field(default_factory=list)
+    resume_domains: List[Dict[str, object]] = field(default_factory=list)
+    set_agent_budgets: List[Dict[str, object]] = field(default_factory=list)
+    update_entropy: Dict[str, object] = field(default_factory=dict)
+    update_zk_key: Optional[str] = None
+    update_governance: Dict[str, object] = field(default_factory=dict)
+    distribute_treasury: List[Dict[str, object]] = field(default_factory=list)
+    rotate_ens_registry: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ScenarioAnomaly:
+    kind: str
+    payload: Dict[str, object]
+
+
+@dataclass(slots=True)
+class ScenarioSpec:
+    name: Optional[str]
+    description: Optional[str]
+    base_setup: ScenarioBase
+    domains: List[ScenarioDomain]
+    validators: List[ScenarioValidator]
+    agents: List[ScenarioAgent]
+    nodes: List[ScenarioNode]
+    job: ScenarioJob
+    overrides: ScenarioOverrides
+    anomalies: List[ScenarioAnomaly]
+    owner_actions: ScenarioOwnerActions
+    context: Dict[str, object]
+
+
+def _parse_domains(items: Iterable[Dict[str, object]] | None) -> List[ScenarioDomain]:
+    domains: List[ScenarioDomain] = []
+    for item in items or []:
+        domains.append(
+            ScenarioDomain(
+                id=str(item["id"]),
+                human_name=str(item.get("humanName", item.get("human_name", item["id"]))),
+                budget_limit=_as_decimal(item.get("budgetLimit", item.get("budget_limit", 0))),
+                unsafe_opcodes=list(item.get("unsafeOpcodes", item.get("unsafe_opcodes", []))),
+                allowed_targets=list(item.get("allowedTargets", item.get("allowed_targets", []))),
+                max_calldata_bytes=int(item.get("maxCalldataBytes", item.get("max_calldata_bytes", 0))),
+                forbidden_selectors=list(item.get("forbiddenSelectors", item.get("forbidden_selectors", []))),
+            )
+        )
+    return domains
+
+
+def _parse_validators(items: Iterable[Dict[str, object]] | None) -> List[ScenarioValidator]:
+    validators: List[ScenarioValidator] = []
+    for item in items or []:
+        validators.append(
+            ScenarioValidator(
+                ens=str(item["ens"]),
+                address=str(item["address"]),
+                stake=_as_decimal(item.get("stake", 0)),
+            )
+        )
+    return validators
+
+
+def _parse_agents(items: Iterable[Dict[str, object]] | None) -> List[ScenarioAgent]:
+    agents: List[ScenarioAgent] = []
+    for item in items or []:
+        agents.append(
+            ScenarioAgent(
+                ens=str(item["ens"]),
+                address=str(item["address"]),
+                domain_id=str(item.get("domainId", item.get("domain_id"))),
+                budget=_as_decimal(item.get("budget", 0)),
+            )
+        )
+    return agents
+
+
+def _parse_nodes(items: Iterable[Dict[str, object]] | None) -> List[ScenarioNode]:
+    nodes: List[ScenarioNode] = []
+    for item in items or []:
+        nodes.append(
+            ScenarioNode(ens=str(item["ens"]), address=str(item["address"]))
+        )
+    return nodes
+
+
+def _parse_job(payload: Dict[str, object]) -> ScenarioJob:
+    truthful = str(payload.get("truthfulVote", payload.get("truthful_vote", "APPROVE")))
+    return ScenarioJob(
+        domain_id=str(payload.get("domainId", payload.get("domain_id", "synthetic-biology"))),
+        round_id=int(payload.get("round", payload.get("roundId", 1))),
+        truthful_vote=truthful,
+        committee_signature=payload.get("committeeSignature"),
+        count=int(payload.get("count", payload.get("jobCount", 1_000))),
+    )
+
+
+def _parse_overrides(payload: Optional[Dict[str, object]]) -> ScenarioOverrides:
+    if not payload:
+        return ScenarioOverrides()
+    return ScenarioOverrides(
+        vote_by_ens={str(k): str(v) for k, v in (payload.get("voteByEns", {}) or {}).items()},
+        vote_by_address={str(k): str(v) for k, v in (payload.get("voteByAddress", {}) or {}).items()},
+        non_reveal_validators=[str(item) for item in payload.get("nonRevealValidators", [])],
+    )
+
+
+def _parse_base(payload: Optional[Dict[str, object]]) -> ScenarioBase:
+    payload = payload or {}
+    governance = dict(payload.get("governance", {}))
+    return ScenarioBase(
+        verifying_key=payload.get("verifyingKey"),
+        sentinel_grace_ratio=(
+            float(payload["sentinelGraceRatio"])
+            if "sentinelGraceRatio" in payload and payload["sentinelGraceRatio"] is not None
+            else None
+        ),
+        on_chain_entropy=payload.get("onChainEntropy"),
+        recent_beacon=payload.get("recentBeacon"),
+        treasury_address=payload.get("treasuryAddress"),
+        governance=governance,
+    )
+
+
+def _parse_owner_actions(payload: Optional[Dict[str, object]]) -> ScenarioOwnerActions:
+    payload = payload or {}
+    return ScenarioOwnerActions(
+        update_sentinel=dict(payload.get("updateSentinel", {})),
+        update_domain_safety=list(payload.get("updateDomainSafety", [])),
+        pause_domains=list(payload.get("pauseDomains", [])),
+        resume_domains=list(payload.get("resumeDomains", [])),
+        set_agent_budgets=list(payload.get("setAgentBudgets", [])),
+        update_entropy=dict(payload.get("updateEntropy", {})),
+        update_zk_key=payload.get("updateZkKey"),
+        update_governance=dict(payload.get("updateGovernance", {})),
+        distribute_treasury=list(payload.get("distributeTreasury", [])),
+        rotate_ens_registry=dict(payload.get("rotateEnsRegistry", {})),
+    )
+
+
+def _parse_anomalies(items: Iterable[Dict[str, object]] | None) -> List[ScenarioAnomaly]:
+    anomalies: List[ScenarioAnomaly] = []
+    for item in items or []:
+        anomalies.append(ScenarioAnomaly(kind=str(item.get("kind")), payload=dict(item)))
+    return anomalies
+
+
+def load_scenario(path: Path | str) -> ScenarioSpec:
+    """Load a scenario specification from YAML."""
+
+    raw_path = Path(path)
+    data = yaml.safe_load(raw_path.read_text())
+    if not isinstance(data, dict):
+        raise TypeError("Scenario file must contain a mapping at the root")
+
+    base = _parse_base(data.get("baseSetup"))
+    spec = ScenarioSpec(
+        name=data.get("name"),
+        description=data.get("description"),
+        base_setup=base,
+        domains=_parse_domains(data.get("domains")),
+        validators=_parse_validators(data.get("validators")),
+        agents=_parse_agents(data.get("agents")),
+        nodes=_parse_nodes(data.get("nodes")),
+        job=_parse_job(data.get("job", {})),
+        overrides=_parse_overrides(data.get("overrides")),
+        anomalies=_parse_anomalies(data.get("anomalies")),
+        owner_actions=_parse_owner_actions(data.get("ownerActions")),
+        context=dict(data.get("context", {})),
+    )
+    return spec

--- a/demo/Validator-Constellation-v0/validator_constellation/subgraph.py
+++ b/demo/Validator-Constellation-v0/validator_constellation/subgraph.py
@@ -35,6 +35,9 @@ class SubgraphIndexer:
             "DomainSafetyUpdated",
             "DomainRegistered",
             "SentinelConfigUpdated",
+            "TreasuryDistributed",
+            "EntropyUpdated",
+            "OwnerActionRecorded",
         }
         if event.type in indexed_types:
             self.events.append(


### PR DESCRIPTION
## Summary
- add a YAML-driven scenario runner for the Validator Constellation demo, including a new scenario loader and CLI flag
- extend governance, staking, and subgraph modules with treasury distribution, custom owner action logging, and scenario metadata export
- document the scenario workflow and add regression coverage for scenario execution

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Validator-Constellation-v0/tests
- npm run test:validator-constellation

------
https://chatgpt.com/codex/tasks/task_e_69022e1932c48333b1ec6700713fdc35