### PR TITLE
Add deterministic verification to Economic Power demo

### DIFF
--- a/demo/Economic-Power-v0/README.md
+++ b/demo/Economic-Power-v0/README.md
@@ -49,6 +49,8 @@ Outputs land in `demo/Economic-Power-v0/reports/`:
 - `owner-control-drills.md` – markdown briefing distilling focus surfaces, directives, and drill catalogue for non-technical operator reviews.
 - `super-intelligence.json` – civilisation-scale superintelligence dossier quantifying dominance, supremacy, automation, safety, resilience, and expansion readiness.
 - `super-intelligence.mmd` – mermaid intelligence graph mapping dominance, supremacy, safety, automation, resilience, and expansion flows into the apex superintelligence node.
+- `deterministic-proof.json` – dual-run hash proof capturing metrics, command coverage, autonomy mesh, and safety mesh fingerprints for audit-grade determinism.
+- `deterministic-verification.json` – verification ledger confirming both runs align and surfacing any mismatches for immediate triage.
 
 > **Non-technical quick start** – run `npm run demo:economic-power` then open `demo/Economic-Power-v0/ui/index.html` with any static server (`npx http-server demo/Economic-Power-v0/ui`). The command refreshes `ui/data/default-summary.json`, so the dashboard autoloads the latest generated reports immediately.
 
@@ -124,6 +126,7 @@ The UI inside `demo/Economic-Power-v0/ui/` offers:
 
 - Metric cards covering ROI, net yield, validator confidence, throughput, and treasury position.
 - Economic power verification grid surfacing every assertion outcome, severity badge, and supporting evidence.
+- Deterministic verification cockpit exposing dual-run hash proofs and mismatch telemetry for instant audit confidence.
 - Expanded metrics for **Stability Index** and **Owner Command Coverage** quantifying how completely the multi-sig governs the stack.
 - Command coverage detail table translating `owner-command-checklist.json` into per-surface readiness so non-technical operators can see exactly which levers are scripted.
 - Sovereign control gauge mirroring the custody score produced in CI alongside a live on-chain module inventory.
@@ -159,6 +162,7 @@ The GitHub workflow `.github/workflows/demo-economic-power.yml` enforces:
 1. `npm run demo:economic-power:ci` – builds fresh reports and compares metrics against the canonical baseline (±5% tolerance).
 2. `npm run test:economic-power` – validates scheduling, ROI, and owner matrix logic.
 3. Assertion pass rate locked at **100%** – deviations fail CI immediately, guaranteeing the verification deck always passes in PRs and on `main`.
+4. Deterministic proof comparison – `verifyDeterminism` replays the scenario and fails immediately on any hash divergence.
 
 This guarantees a **fully green v2 CI gate**. Pull requests and `main` share identical guard-rails, preventing regressions before production promotion.
 

--- a/demo/Economic-Power-v0/reports/deterministic-proof.json
+++ b/demo/Economic-Power-v0/reports/deterministic-proof.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0",
+  "scenarioId": "economic-power-v0-baseline",
+  "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+  "generatedAt": "2025-02-01T00:00:00.000Z",
+  "executionTimestamp": "2025-10-29T16:03:22.335Z",
+  "summaryHash": "2f268e2baf8b1388f63709368580fa0b2efefd67cf8a09f83bff0abef8055189",
+  "metricsHash": "c5bd52c8a1d99c651c0bfc5a2a9fca6105566f480be2834e56df7fcb7607b18c",
+  "assignmentsHash": "d87b8b92c996cea3c93d854964242154ea38cd96e8aa2418d005c0c5e845def6",
+  "commandCoverageHash": "6f79ff1d64ea9cc89e6acf7b3a7214667be2cb0653f8273fb003d6c123a16ded",
+  "autopilotHash": "80ff45cb6361aebbe7ff228e9ff733cd509599b427ce9d7cdd91b415b7596f94",
+  "governanceLedgerHash": "06947ff6d5a4f00e881c02c14cb7701c0c4f3ec10e2e12557b9fbec3d68d5d2a",
+  "assertionsHash": "34996c1d42540539eec71bef4328694a098843ba21cb27138864c71331fe858c",
+  "treasuryTrajectoryHash": "75dcb4a87d1abf30e5b600467a850c37c46f5f848bbb704812775233c5af5227",
+  "sovereignSafetyMeshHash": "f3a1f06ec804ab8688982a5a76ad7d7c14ef9e3ec3ead8c661b50c104597e8a8",
+  "superIntelligenceHash": "e6c022f0558a81deac88a85f8c4e8271eff4e75bf281be2686c5c49edba5feb4"
+}

--- a/demo/Economic-Power-v0/reports/deterministic-verification.json
+++ b/demo/Economic-Power-v0/reports/deterministic-verification.json
@@ -1,0 +1,39 @@
+{
+  "version": "1.0",
+  "matches": true,
+  "mismatches": [],
+  "proof": {
+    "version": "1.0",
+    "scenarioId": "economic-power-v0-baseline",
+    "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+    "generatedAt": "2025-02-01T00:00:00.000Z",
+    "executionTimestamp": "2025-10-29T16:03:22.335Z",
+    "summaryHash": "2f268e2baf8b1388f63709368580fa0b2efefd67cf8a09f83bff0abef8055189",
+    "metricsHash": "c5bd52c8a1d99c651c0bfc5a2a9fca6105566f480be2834e56df7fcb7607b18c",
+    "assignmentsHash": "d87b8b92c996cea3c93d854964242154ea38cd96e8aa2418d005c0c5e845def6",
+    "commandCoverageHash": "6f79ff1d64ea9cc89e6acf7b3a7214667be2cb0653f8273fb003d6c123a16ded",
+    "autopilotHash": "80ff45cb6361aebbe7ff228e9ff733cd509599b427ce9d7cdd91b415b7596f94",
+    "governanceLedgerHash": "06947ff6d5a4f00e881c02c14cb7701c0c4f3ec10e2e12557b9fbec3d68d5d2a",
+    "assertionsHash": "34996c1d42540539eec71bef4328694a098843ba21cb27138864c71331fe858c",
+    "treasuryTrajectoryHash": "75dcb4a87d1abf30e5b600467a850c37c46f5f848bbb704812775233c5af5227",
+    "sovereignSafetyMeshHash": "f3a1f06ec804ab8688982a5a76ad7d7c14ef9e3ec3ead8c661b50c104597e8a8",
+    "superIntelligenceHash": "e6c022f0558a81deac88a85f8c4e8271eff4e75bf281be2686c5c49edba5feb4"
+  },
+  "verificationProof": {
+    "version": "1.0",
+    "scenarioId": "economic-power-v0-baseline",
+    "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+    "generatedAt": "2025-02-01T00:00:00.000Z",
+    "executionTimestamp": "2025-10-29T16:03:22.351Z",
+    "summaryHash": "2f268e2baf8b1388f63709368580fa0b2efefd67cf8a09f83bff0abef8055189",
+    "metricsHash": "c5bd52c8a1d99c651c0bfc5a2a9fca6105566f480be2834e56df7fcb7607b18c",
+    "assignmentsHash": "d87b8b92c996cea3c93d854964242154ea38cd96e8aa2418d005c0c5e845def6",
+    "commandCoverageHash": "6f79ff1d64ea9cc89e6acf7b3a7214667be2cb0653f8273fb003d6c123a16ded",
+    "autopilotHash": "80ff45cb6361aebbe7ff228e9ff733cd509599b427ce9d7cdd91b415b7596f94",
+    "governanceLedgerHash": "06947ff6d5a4f00e881c02c14cb7701c0c4f3ec10e2e12557b9fbec3d68d5d2a",
+    "assertionsHash": "34996c1d42540539eec71bef4328694a098843ba21cb27138864c71331fe858c",
+    "treasuryTrajectoryHash": "75dcb4a87d1abf30e5b600467a850c37c46f5f848bbb704812775233c5af5227",
+    "sovereignSafetyMeshHash": "f3a1f06ec804ab8688982a5a76ad7d7c14ef9e3ec3ead8c661b50c104597e8a8",
+    "superIntelligenceHash": "e6c022f0558a81deac88a85f8c4e8271eff4e75bf281be2686c5c49edba5feb4"
+  }
+}

--- a/demo/Economic-Power-v0/reports/economic-dominance.json
+++ b/demo/Economic-Power-v0/reports/economic-dominance.json
@@ -1,6 +1,6 @@
 {
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-29T14:19:34.347Z",
+  "executionTimestamp": "2025-10-29T16:03:22.335Z",
   "dominanceIndex": 0.994,
   "capitalVelocity": 26290.99,
   "roiMultiplier": 3.28,

--- a/demo/Economic-Power-v0/reports/global-expansion-plan.md
+++ b/demo/Economic-Power-v0/reports/global-expansion-plan.md
@@ -1,7 +1,7 @@
 # Global Expansion Autopilot Plan
 
 Scenario: AGIJobs Economic Power Launch
-Generated 2025-10-29T14:19:34.347Z • Dominance 99.4%
+Generated 2025-10-29T16:03:22.335Z • Dominance 99.4%
 
 ## Phase I – Testnet Supremacy
 

--- a/demo/Economic-Power-v0/reports/owner-command-plan.md
+++ b/demo/Economic-Power-v0/reports/owner-command-plan.md
@@ -1,6 +1,6 @@
 # Owner Command Playbook
 
-Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/29/2025, 2:19:34 PM (UTC)
+Generated for analysis window 2/1/2025, 12:00:00 AM • executed 10/29/2025, 4:03:22 PM (UTC)
 
 Command coverage: 100.0% — Owner multi-sig holds deterministic runbooks for every critical surface.
 

--- a/demo/Economic-Power-v0/reports/summary.json
+++ b/demo/Economic-Power-v0/reports/summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-29T14:19:34.347Z",
+  "executionTimestamp": "2025-10-29T16:03:22.335Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,

--- a/demo/Economic-Power-v0/ui/data/default-summary.json
+++ b/demo/Economic-Power-v0/ui/data/default-summary.json
@@ -3,7 +3,7 @@
   "title": "AGIJobs Economic Power Launch",
   "generatedAt": "2025-02-01T00:00:00.000Z",
   "analysisTimestamp": "2025-02-01T00:00:00.000Z",
-  "executionTimestamp": "2025-10-29T14:19:13.757Z",
+  "executionTimestamp": "2025-10-29T16:03:22.335Z",
   "metrics": {
     "totalJobs": 5,
     "totalAgents": 4,

--- a/demo/Economic-Power-v0/ui/data/deterministic-proof.json
+++ b/demo/Economic-Power-v0/ui/data/deterministic-proof.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0",
+  "scenarioId": "economic-power-v0-baseline",
+  "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+  "generatedAt": "2025-02-01T00:00:00.000Z",
+  "executionTimestamp": "2025-10-29T16:03:22.335Z",
+  "summaryHash": "2f268e2baf8b1388f63709368580fa0b2efefd67cf8a09f83bff0abef8055189",
+  "metricsHash": "c5bd52c8a1d99c651c0bfc5a2a9fca6105566f480be2834e56df7fcb7607b18c",
+  "assignmentsHash": "d87b8b92c996cea3c93d854964242154ea38cd96e8aa2418d005c0c5e845def6",
+  "commandCoverageHash": "6f79ff1d64ea9cc89e6acf7b3a7214667be2cb0653f8273fb003d6c123a16ded",
+  "autopilotHash": "80ff45cb6361aebbe7ff228e9ff733cd509599b427ce9d7cdd91b415b7596f94",
+  "governanceLedgerHash": "06947ff6d5a4f00e881c02c14cb7701c0c4f3ec10e2e12557b9fbec3d68d5d2a",
+  "assertionsHash": "34996c1d42540539eec71bef4328694a098843ba21cb27138864c71331fe858c",
+  "treasuryTrajectoryHash": "75dcb4a87d1abf30e5b600467a850c37c46f5f848bbb704812775233c5af5227",
+  "sovereignSafetyMeshHash": "f3a1f06ec804ab8688982a5a76ad7d7c14ef9e3ec3ead8c661b50c104597e8a8",
+  "superIntelligenceHash": "e6c022f0558a81deac88a85f8c4e8271eff4e75bf281be2686c5c49edba5feb4"
+}

--- a/demo/Economic-Power-v0/ui/data/deterministic-verification.json
+++ b/demo/Economic-Power-v0/ui/data/deterministic-verification.json
@@ -1,0 +1,39 @@
+{
+  "version": "1.0",
+  "matches": true,
+  "mismatches": [],
+  "proof": {
+    "version": "1.0",
+    "scenarioId": "economic-power-v0-baseline",
+    "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+    "generatedAt": "2025-02-01T00:00:00.000Z",
+    "executionTimestamp": "2025-10-29T16:03:22.335Z",
+    "summaryHash": "2f268e2baf8b1388f63709368580fa0b2efefd67cf8a09f83bff0abef8055189",
+    "metricsHash": "c5bd52c8a1d99c651c0bfc5a2a9fca6105566f480be2834e56df7fcb7607b18c",
+    "assignmentsHash": "d87b8b92c996cea3c93d854964242154ea38cd96e8aa2418d005c0c5e845def6",
+    "commandCoverageHash": "6f79ff1d64ea9cc89e6acf7b3a7214667be2cb0653f8273fb003d6c123a16ded",
+    "autopilotHash": "80ff45cb6361aebbe7ff228e9ff733cd509599b427ce9d7cdd91b415b7596f94",
+    "governanceLedgerHash": "06947ff6d5a4f00e881c02c14cb7701c0c4f3ec10e2e12557b9fbec3d68d5d2a",
+    "assertionsHash": "34996c1d42540539eec71bef4328694a098843ba21cb27138864c71331fe858c",
+    "treasuryTrajectoryHash": "75dcb4a87d1abf30e5b600467a850c37c46f5f848bbb704812775233c5af5227",
+    "sovereignSafetyMeshHash": "f3a1f06ec804ab8688982a5a76ad7d7c14ef9e3ec3ead8c661b50c104597e8a8",
+    "superIntelligenceHash": "e6c022f0558a81deac88a85f8c4e8271eff4e75bf281be2686c5c49edba5feb4"
+  },
+  "verificationProof": {
+    "version": "1.0",
+    "scenarioId": "economic-power-v0-baseline",
+    "analysisTimestamp": "2025-02-01T00:00:00.000Z",
+    "generatedAt": "2025-02-01T00:00:00.000Z",
+    "executionTimestamp": "2025-10-29T16:03:22.351Z",
+    "summaryHash": "2f268e2baf8b1388f63709368580fa0b2efefd67cf8a09f83bff0abef8055189",
+    "metricsHash": "c5bd52c8a1d99c651c0bfc5a2a9fca6105566f480be2834e56df7fcb7607b18c",
+    "assignmentsHash": "d87b8b92c996cea3c93d854964242154ea38cd96e8aa2418d005c0c5e845def6",
+    "commandCoverageHash": "6f79ff1d64ea9cc89e6acf7b3a7214667be2cb0653f8273fb003d6c123a16ded",
+    "autopilotHash": "80ff45cb6361aebbe7ff228e9ff733cd509599b427ce9d7cdd91b415b7596f94",
+    "governanceLedgerHash": "06947ff6d5a4f00e881c02c14cb7701c0c4f3ec10e2e12557b9fbec3d68d5d2a",
+    "assertionsHash": "34996c1d42540539eec71bef4328694a098843ba21cb27138864c71331fe858c",
+    "treasuryTrajectoryHash": "75dcb4a87d1abf30e5b600467a850c37c46f5f848bbb704812775233c5af5227",
+    "sovereignSafetyMeshHash": "f3a1f06ec804ab8688982a5a76ad7d7c14ef9e3ec3ead8c661b50c104597e8a8",
+    "superIntelligenceHash": "e6c022f0558a81deac88a85f8c4e8271eff4e75bf281be2686c5c49edba5feb4"
+  }
+}

--- a/demo/Economic-Power-v0/ui/index.html
+++ b/demo/Economic-Power-v0/ui/index.html
@@ -33,6 +33,35 @@
         <div id="assertion-grid" class="assertion-grid" role="list" aria-describedby="assertion-heading"></div>
       </section>
 
+      <section id="deterministic-panel" class="panel" aria-labelledby="deterministic-heading">
+        <div class="panel-header">
+          <h2 id="deterministic-heading">Deterministic verification</h2>
+          <p>Dual-run hash proofs confirm unstoppable reproducibility across every economic surface.</p>
+        </div>
+        <div class="deterministic-grid">
+          <article class="deterministic-card" aria-label="Verification status">
+            <h3>Status</h3>
+            <p id="deterministic-status" class="deterministic-status">Awaiting data</p>
+            <ul id="deterministic-mismatches" class="deterministic-list"></ul>
+          </article>
+          <article class="deterministic-card" aria-label="Hash comparison">
+            <h3>Hash comparison</h3>
+            <div class="table-wrapper">
+              <table id="deterministic-table" aria-label="Deterministic hash comparison">
+                <thead>
+                  <tr>
+                    <th>Surface</th>
+                    <th>Primary</th>
+                    <th>Replay</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </article>
+        </div>
+      </section>
+
       <section class="panel" aria-labelledby="owner-controls-heading">
         <div class="panel-header">
           <h2 id="owner-controls-heading">Owner command authority</h2>

--- a/demo/Economic-Power-v0/ui/styles.css
+++ b/demo/Economic-Power-v0/ui/styles.css
@@ -147,6 +147,67 @@ main {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+.deterministic-grid {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.deterministic-card {
+  background: rgba(8, 16, 32, 0.78);
+  border: 1px solid rgba(110, 231, 255, 0.2);
+  border-radius: 1.2rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  box-shadow: 0 26px 44px rgba(6, 16, 32, 0.6);
+}
+
+.deterministic-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.deterministic-status {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.deterministic-status.deterministic-pass {
+  color: #22c55e;
+}
+
+.deterministic-status.deterministic-fail {
+  color: #f97316;
+}
+
+.deterministic-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+#deterministic-table tbody tr td {
+  font-family: 'Fira Mono', 'Source Code Pro', monospace;
+  font-size: 0.8rem;
+  word-break: break-all;
+}
+
+#deterministic-table tbody tr.mismatch td {
+  background: rgba(248, 113, 113, 0.1);
+  color: #fecaca;
+}
+
 .catalog-grid {
   margin-top: 1.5rem;
   display: grid;


### PR DESCRIPTION
## Summary
- add dual-run deterministic proof generation and verification gating to the Economic Power orchestrator and report writer
- expose deterministic hash artefacts in the UI, ship the new verification panel, and document the additional reports
- extend the simulation test suite to enforce deterministic hashes alongside refreshed report baselines

## Testing
- npm run demo:economic-power:ci
- npm run test:economic-power

------
https://chatgpt.com/codex/tasks/task_e_6902389dcad48333a96c3fb4b066f1b3