### PR TITLE
Fortify AGI Alpha Node demo with ENS autopilot controls

### DIFF
--- a/demo/AGI-Alpha-Node-v0/README.md
+++ b/demo/AGI-Alpha-Node-v0/README.md
@@ -65,17 +65,27 @@ flowchart LR
    python -m alpha_node.cli bootstrap
    ```
    This deposits the minimum stake, validates ENS ownership, and prints a compliance snapshot.
-3. **Run the intelligence engine**:
+3. **Activate with ENS guardrails**:
+   ```bash
+   python -m alpha_node.cli activate
+   ```
+   The CLI enforces that the configured ENS ends with `.alpha.node.agi.eth` and auto tops up stake to the minimum.
+4. **Run the intelligence engine**:
    ```bash
    python -m alpha_node.cli run
    ```
    The planner harvests jobs, delegates to specialists, captures knowledge, and restakes rewards automatically.
-4. **Monitor metrics**:
+5. **Spin the autopilot wealth loops**:
+   ```bash
+   python -m alpha_node.cli autopilot --cycles 5 --safety-interval 2
+   ```
+   Cycles execute MuZero++ planning, restake rewards, and trigger antifragility drills on the configured cadence.
+6. **Monitor metrics**:
    ```bash
    python -m alpha_node.cli metrics
    ```
    Scrape Prometheus metrics from `http://localhost:9101`.
-5. **View compliance & dashboard data**:
+7. **View compliance & dashboard data**:
    ```bash
    python -m alpha_node.cli dashboard
    ```
@@ -87,6 +97,10 @@ flowchart LR
 - `python -m alpha_node.cli resume` — safely resume operations.
 - `python -m alpha_node.cli rotate-governance --address <0x...>` — rotate ownership to a new multisig without downtime.
 - `python -m alpha_node.cli stake-deposit --amount 5000` — top up the treasury stake from operator-controlled wallets.
+- `python -m alpha_node.cli stake-withdraw --amount 2500` — simulate a governance-authorized slash or withdrawal.
+- `python -m alpha_node.cli claim-rewards` — restake rewards when the configured threshold is reached.
+- `python -m alpha_node.cli update-stake-policy --restake-threshold 250` — retune staking economics live.
+- `python -m alpha_node.cli safety-drill` — log a pause/resume drill in the compliance ledger.
 
 ## 🌐 Web dashboard (grandiose operator cockpit)
 
@@ -101,6 +115,7 @@ Open `http://localhost:8090` and paste the JSON payload from `python -m alpha_no
 - Stake, rewards, antifragility, and strategic alpha gauges.
 - Live compliance radar chart (powered by vanilla canvas).
 - Governance audit timeline fed by `state.json`.
+- ENS verification status, stake ledger history, and the latest autopilot wealth cycle summary.
 
 ## 🧪 Production-grade tests
 
@@ -142,6 +157,27 @@ The container auto-initializes state, knowledge lake, and stake ledger, making r
 - `web/` — immersive operator dashboard with hero section, flowcharts, and compliance radar.
 - `tests/` — deterministic pytest coverage for core safety and intelligence components.
 - `Dockerfile`, `Makefile`, `README.md` — deployment guide, automation, and documentation.
+
+## ♞ Autopilot wealth loop anatomy
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant CLI as alpha_node.cli autopilot
+    participant Node as AlphaNode
+    participant Stake as StakeManager
+    participant Ledger as StateStore
+    participant ENS as ENSVerifier
+
+    Operator->>CLI: `python -m alpha_node.cli autopilot --cycles 3`
+    CLI->>Node: activate() & run_once()
+    Node->>ENS: verify `.alpha.node.agi.eth`
+    Node->>Stake: accrue_rewards()
+    Node->>Stake: restake_rewards()
+    Node->>Ledger: append audit + antifragility drill
+    Node-->>CLI: autopilot payload (decisions + compliance)
+    CLI-->>Operator: JSON summary for dashboard ingestion
+```
 
 ## 🧭 Extending to mainnet
 

--- a/demo/AGI-Alpha-Node-v0/alpha_node/config.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/config.py
@@ -19,6 +19,7 @@ class ENSSettings:
     owner_address: str
     provider_url: str | None = None
     expected_resolver: str | None = None
+    required_suffix: str = ".alpha.node.agi.eth"
 
 
 @dataclass(slots=True)
@@ -119,6 +120,7 @@ class AlphaNodeConfig:
                 owner_address=_require("ens", "owner_address"),
                 provider_url=raw["ens"].get("provider_url"),
                 expected_resolver=raw["ens"].get("expected_resolver"),
+                required_suffix=raw["ens"].get("required_suffix", ".alpha.node.agi.eth"),
             ),
             governance=GovernanceSettings(
                 governance_address=_require("governance", "governance_address"),

--- a/demo/AGI-Alpha-Node-v0/alpha_node/ens.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/ens.py
@@ -38,6 +38,16 @@ class ENSVerifier:
         self.offline_registry = offline_registry
 
     def verify(self) -> ENSVerificationResult:
+        suffix = (self.settings.required_suffix or "").lower()
+        if suffix and not self.settings.domain.lower().endswith(suffix):
+            return ENSVerificationResult(
+                domain=self.settings.domain,
+                owner=self.settings.owner_address,
+                resolver=None,
+                verified=False,
+                source="suffix-mismatch",
+            )
+
         if self.settings.provider_url and Web3 is not None:
             try:
                 return self._verify_on_chain()

--- a/demo/AGI-Alpha-Node-v0/config.example.yaml
+++ b/demo/AGI-Alpha-Node-v0/config.example.yaml
@@ -1,6 +1,7 @@
 identity:
   ens_domain: demo.alpha.node.agi.eth
   owner_address: "0x1234567890abcdef1234567890abcdef12345678"
+  required_suffix: ".alpha.node.agi.eth"
 
 governance:
   governance_address: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"

--- a/demo/AGI-Alpha-Node-v0/config.toml
+++ b/demo/AGI-Alpha-Node-v0/config.toml
@@ -3,6 +3,7 @@ domain = "demo.alpha.node.agi.eth"
 owner_address = "0x000000000000000000000000000000000000dEaD"
 provider_url = ""
 expected_resolver = ""
+required_suffix = ".alpha.node.agi.eth"
 
 [governance]
 governance_address = "0x1111111111111111111111111111111111111111"

--- a/demo/AGI-Alpha-Node-v0/tests/conftest.py
+++ b/demo/AGI-Alpha-Node-v0/tests/conftest.py
@@ -1,6 +1,23 @@
+import shutil
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+import pytest
+
+from alpha_node.state import NodeState, StateStore
+
+
+@pytest.fixture()
+def demo_workspace(tmp_path: Path) -> Path:
+    destination = tmp_path / "AGI-Alpha-Node-v0"
+    shutil.copytree(ROOT, destination)
+    state_path = destination / "state.json"
+    store = StateStore(state_path)
+    store.write(NodeState())
+    ledger = destination / "stake_ledger.csv"
+    ledger.write_text("event,amount,total_locked,timestamp\n")
+    return destination

--- a/demo/AGI-Alpha-Node-v0/tests/test_ens.py
+++ b/demo/AGI-Alpha-Node-v0/tests/test_ens.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from alpha_node.config import ENSSettings
+from alpha_node.ens import ENSVerifier
+
+
+def test_suffix_enforced(tmp_path: Path) -> None:
+    registry = tmp_path / "ens.csv"
+    registry.write_text("demo.alpha.node.agi.eth,0xabc\n")
+    settings = ENSSettings(
+        domain="rogue.alpha.agent.agi.eth",
+        owner_address="0xabc",
+        required_suffix=".alpha.node.agi.eth",
+    )
+    verifier = ENSVerifier(settings, registry)
+    result = verifier.verify()
+    assert result.verified is False
+    assert result.source == "suffix-mismatch"
+
+
+def test_offline_registry_success(tmp_path: Path) -> None:
+    registry = tmp_path / "ens.csv"
+    registry.write_text("demo.alpha.node.agi.eth,0xabc\n")
+    settings = ENSSettings(
+        domain="demo.alpha.node.agi.eth",
+        owner_address="0xabc",
+        required_suffix=".alpha.node.agi.eth",
+    )
+    verifier = ENSVerifier(settings, registry)
+    result = verifier.verify()
+    assert result.verified is True
+    assert result.source == "offline"

--- a/demo/AGI-Alpha-Node-v0/tests/test_node_runtime.py
+++ b/demo/AGI-Alpha-Node-v0/tests/test_node_runtime.py
@@ -1,0 +1,36 @@
+import pytest
+
+from alpha_node.config import AlphaNodeConfig
+from alpha_node.node import AlphaNode
+
+
+def test_activation_requires_suffix(demo_workspace):
+    config = AlphaNodeConfig.load(demo_workspace / "config.toml")
+    config.ens.domain = "demo.alpha.agent.agi.eth"
+    node = AlphaNode(config, base_path=demo_workspace)
+    with pytest.raises(ValueError):
+        node.activate()
+
+
+def test_activation_top_up_and_compliance(demo_workspace):
+    config = AlphaNodeConfig.load(demo_workspace / "config.toml")
+    node = AlphaNode(config, base_path=demo_workspace)
+    report = node.activate(auto_top_up=True)
+    assert report.dimensions["identity"].score == 1.0
+    state = node.state_store.read()
+    assert state.stake_locked >= config.stake.minimum_stake
+
+
+def test_autopilot_restakes_rewards(demo_workspace):
+    config = AlphaNodeConfig.load(demo_workspace / "config.toml")
+    node = AlphaNode(config, base_path=demo_workspace)
+    node.stake_manager.deposit(config.stake.minimum_stake)
+    node.state_store.update(
+        stake_locked=config.stake.minimum_stake,
+        total_rewards=config.stake.restake_threshold + 25,
+    )
+    payload = node.autopilot(cycles=1, restake=True, safety_interval=0)
+    assert payload["executed_cycles"] >= 0
+    state = node.state_store.read()
+    assert state.total_rewards == 0.0
+    assert any("autopilot-cycle" in entry for entry in state.audit_log)

--- a/demo/AGI-Alpha-Node-v0/web/index.html
+++ b/demo/AGI-Alpha-Node-v0/web/index.html
@@ -66,8 +66,44 @@ flowchart TD
       </article>
     </section>
 
+    <section class="ens-ledger">
+      <article>
+        <h3>ENS Domain</h3>
+        <p id="ensDomain">–</p>
+      </article>
+      <article>
+        <h3>ENS Owner</h3>
+        <p id="ensOwner">–</p>
+      </article>
+      <article>
+        <h3>Verification Source</h3>
+        <p id="ensSource">–</p>
+      </article>
+    </section>
+
     <section class="chart-section">
       <canvas id="complianceChart" width="400" height="400"></canvas>
+    </section>
+
+    <section class="autopilot-section">
+      <h2>Autopilot Wealth Cycles</h2>
+      <p id="autopilotSummary">No autopilot execution detected yet.</p>
+      <div id="autopilotReports" class="autopilot-grid"></div>
+    </section>
+
+    <section class="stake-ledger">
+      <h2>Stake Ledger</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Event</th>
+            <th>Amount</th>
+            <th>Total Locked</th>
+            <th>Timestamp</th>
+          </tr>
+        </thead>
+        <tbody id="stakeLedger"></tbody>
+      </table>
     </section>
 
     <section class="audit-section">

--- a/demo/AGI-Alpha-Node-v0/web/styles.css
+++ b/demo/AGI-Alpha-Node-v0/web/styles.css
@@ -57,6 +57,21 @@ header h1 {
   text-align: center;
 }
 
+.ens-ledger {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.ens-ledger article {
+  background: rgba(11, 32, 62, 0.72);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: inset 0 0 30px rgba(124, 77, 255, 0.25);
+  text-align: center;
+}
+
 .metrics-grid h3 {
   font-size: 1rem;
   letter-spacing: 0.1em;
@@ -76,6 +91,54 @@ header h1 {
   padding: 2rem;
   background: rgba(7, 22, 44, 0.6);
   border-radius: 20px;
+}
+
+.autopilot-section {
+  margin-top: 3rem;
+  background: rgba(7, 22, 44, 0.75);
+  border-radius: 24px;
+  padding: 2.25rem;
+  box-shadow: 0 24px 64px rgba(74, 208, 255, 0.25);
+}
+
+.autopilot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.autopilot-grid article {
+  background: rgba(4, 18, 38, 0.85);
+  border-radius: 18px;
+  padding: 1.5rem;
+  border: 1px solid rgba(127, 207, 255, 0.3);
+}
+
+.stake-ledger {
+  margin-top: 3rem;
+  background: rgba(7, 22, 44, 0.7);
+  border-radius: 20px;
+  padding: 2rem;
+  overflow-x: auto;
+}
+
+.stake-ledger table {
+  width: 100%;
+  border-collapse: collapse;
+  color: #e3f5ff;
+}
+
+.stake-ledger th,
+.stake-ledger td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(127, 207, 255, 0.2);
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.stake-ledger tr:last-child td {
+  border-bottom: none;
 }
 
 .audit-section {


### PR DESCRIPTION
## Summary
- enforce `.alpha.node.agi.eth` ENS ownership requirements throughout the Alpha Node activation flow and expose a friendlier CLI
- introduce automated wealth-cycle orchestration, stake policy tuning, and detailed dashboard payloads (ENS status, stake ledger, autopilot summaries)
- expand the demo UI and documentation with new controls plus regression tests for ENS verification, activation, and autopilot restaking

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/AGI-Alpha-Node-v0/tests -q


------
https://chatgpt.com/codex/tasks/task_e_69028c806eb08333b924d6585da6cbe6