### PR TITLE
feat(hgm): persist lineage metrics and expose API

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,3 @@
+"""Backend utilities for the AGI Jobs stack."""
+
+__all__ = []

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,194 @@
+"""Database utilities shared by orchestrator and API layers."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional, Sequence
+
+try:  # Optional dependency for production Postgres deployments.
+    import psycopg  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover - psycopg is optional for tests
+    psycopg = None  # type: ignore
+
+
+class DatabaseError(RuntimeError):
+    """Raised when the database backend cannot be initialised."""
+
+
+class Database:
+    """Lightweight connection manager with transactional helpers."""
+
+    def __init__(self, url: str | None = None) -> None:
+        self._url = url or os.environ.get("HGM_DATABASE_URL", "sqlite:///storage/hgm.db")
+        self._driver, self._dsn = self._parse_url(self._url)
+        self._lock = threading.RLock()
+        self._conn = self._connect()
+        self._closed = False
+
+    @staticmethod
+    def _parse_url(url: str) -> tuple[str, str]:
+        url = url.strip()
+        if not url:
+            raise DatabaseError("Empty database URL")
+        if url.startswith("sqlite://"):
+            dsn = url[len("sqlite://"):]
+            if dsn.startswith("/"):
+                # Handle sqlite:////absolute/path.db -> //absolute/path.db
+                while dsn.startswith("//"):
+                    dsn = dsn[1:]
+                if dsn.startswith("/"):
+                    # Absolute path
+                    return "sqlite", dsn
+                return "sqlite", dsn
+            if not dsn:
+                return "sqlite", ":memory:"
+            return "sqlite", dsn
+        if url.startswith("sqlite:") and url.count(":") == 1:
+            return "sqlite", url[len("sqlite:"):]
+        if url.startswith("postgresql://") or url.startswith("postgres://"):
+            if psycopg is None:
+                raise DatabaseError("psycopg is required for PostgreSQL connections")
+            return "postgres", url
+        if ":" not in url and url.endswith(".db"):
+            return "sqlite", url
+        raise DatabaseError(f"Unsupported database URL: {url}")
+
+    def _connect(self):  # type: ignore[override]
+        if self._driver == "sqlite":
+            path = self._dsn
+            if path in {":memory:", "memory"}:
+                conn = sqlite3.connect(":memory:", check_same_thread=False)
+            else:
+                db_path = Path(path)
+                if not db_path.is_absolute():
+                    db_path = Path.cwd() / db_path
+                db_path.parent.mkdir(parents=True, exist_ok=True)
+                conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA foreign_keys = ON")
+            return conn
+        if self._driver == "postgres":
+            assert psycopg is not None  # for type-checkers
+            return psycopg.connect(self._dsn)  # type: ignore[no-any-return]
+        raise DatabaseError(f"Unsupported driver: {self._driver}")
+
+    @property
+    def driver(self) -> str:
+        return self._driver
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._conn.close()
+            self._closed = True
+
+    @contextmanager
+    def transaction(self):  # type: ignore[override]
+        if self._closed:
+            raise DatabaseError("Database connection already closed")
+        with self._lock:
+            cursor = self._conn.cursor()
+            try:
+                yield cursor
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+            finally:
+                cursor.close()
+
+    def run_migrations(self, migrations: Sequence["Migration"], *, table: str = "hgm_schema_migrations") -> None:
+        """Apply migrations sequentially, tracking applied versions."""
+
+        self._ensure_migration_table(table)
+        for migration in migrations:
+            if self._is_applied(migration.version, table):
+                continue
+            with self.transaction() as cur:
+                migration.upgrade(cur, self._driver)
+                placeholder = self.placeholder()
+                cur.execute(
+                    f"INSERT INTO {table} (version, applied_at) VALUES ({placeholder}, {placeholder})",
+                    (migration.version, self._timestamp()),
+                )
+
+    def _ensure_migration_table(self, table: str) -> None:
+        with self.transaction() as cur:
+            if self._driver == "postgres":
+                cur.execute(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {table} (
+                        version TEXT PRIMARY KEY,
+                        applied_at DOUBLE PRECISION NOT NULL
+                    )
+                    """
+                )
+            else:
+                cur.execute(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {table} (
+                        version TEXT PRIMARY KEY,
+                        applied_at REAL NOT NULL
+                    )
+                    """
+                )
+
+    def _is_applied(self, version: str, table: str) -> bool:
+        with self.transaction() as cur:
+            placeholder = self.placeholder()
+            cur.execute(f"SELECT 1 FROM {table} WHERE version = {placeholder}", (version,))
+            return cur.fetchone() is not None
+
+    @staticmethod
+    def _timestamp() -> float:
+        return time.time()
+
+    def placeholder(self) -> str:
+        return "%s" if self._driver == "postgres" else "?"
+
+
+class Migration:
+    """Protocol implemented by concrete migration definitions."""
+
+    version: str
+
+    def upgrade(self, cursor, driver: str) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+_DATABASE_SINGLETON: Optional[Database] = None
+_DATABASE_LOCK = threading.Lock()
+
+
+def get_database(url: str | None = None) -> Database:
+    """Return a process-wide database handle."""
+
+    global _DATABASE_SINGLETON
+    with _DATABASE_LOCK:
+        if _DATABASE_SINGLETON is not None:
+            return _DATABASE_SINGLETON
+        db = Database(url)
+        from backend.migrations import MIGRATIONS
+
+        db.run_migrations(MIGRATIONS)
+        _DATABASE_SINGLETON = db
+        return db
+
+
+def set_database(database: Database | None) -> None:
+    """Override the global database singleton (primarily for tests)."""
+
+    global _DATABASE_SINGLETON
+    with _DATABASE_LOCK:
+        if _DATABASE_SINGLETON is not None and database is not _DATABASE_SINGLETON:
+            _DATABASE_SINGLETON.close()
+        _DATABASE_SINGLETON = database
+
+
+__all__ = ["Database", "DatabaseError", "Migration", "get_database", "set_database"]

--- a/backend/migrations/__init__.py
+++ b/backend/migrations/__init__.py
@@ -1,0 +1,7 @@
+"""Database migrations for backend services."""
+
+from .hgm import MIGRATIONS as HGM_MIGRATIONS
+
+MIGRATIONS = HGM_MIGRATIONS
+
+__all__ = ["MIGRATIONS"]

--- a/backend/migrations/hgm/__init__.py
+++ b/backend/migrations/hgm/__init__.py
@@ -1,0 +1,7 @@
+"""HGM schema migrations."""
+
+from .migration_0001_initial import Migration0001Initial
+
+MIGRATIONS = [Migration0001Initial()]
+
+__all__ = ["MIGRATIONS"]

--- a/backend/migrations/hgm/migration_0001_initial.py
+++ b/backend/migrations/hgm/migration_0001_initial.py
@@ -1,0 +1,136 @@
+"""Initial schema for persisting HGM lineage data."""
+
+from __future__ import annotations
+
+from backend.database import Migration
+
+
+class Migration0001Initial(Migration):
+    version = "0001_initial"
+
+    def upgrade(self, cursor, driver: str) -> None:  # type: ignore[override]
+        if driver == "postgres":
+            statements = [
+                """
+                CREATE TABLE IF NOT EXISTS hgm_runs (
+                    run_id TEXT PRIMARY KEY,
+                    root_agent TEXT NOT NULL,
+                    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    updated_at DOUBLE PRECISION NOT NULL
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS hgm_agents (
+                    run_id TEXT NOT NULL REFERENCES hgm_runs(run_id) ON DELETE CASCADE,
+                    agent_key TEXT NOT NULL,
+                    parent_key TEXT,
+                    depth INTEGER NOT NULL DEFAULT 0,
+                    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    expansion_count DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    clade_success DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    clade_failure DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    updated_at DOUBLE PRECISION NOT NULL,
+                    PRIMARY KEY (run_id, agent_key)
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS hgm_agent_performance (
+                    run_id TEXT NOT NULL,
+                    agent_key TEXT NOT NULL,
+                    visits DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    success_weight DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    failure_weight DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    cmp_mean DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    cmp_variance DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    cmp_weight DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    updated_at DOUBLE PRECISION NOT NULL,
+                    PRIMARY KEY (run_id, agent_key),
+                    FOREIGN KEY (run_id, agent_key) REFERENCES hgm_agents(run_id, agent_key) ON DELETE CASCADE
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS hgm_evaluation_outcomes (
+                    id BIGSERIAL PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    agent_key TEXT NOT NULL,
+                    reward DOUBLE PRECISION NOT NULL,
+                    weight DOUBLE PRECISION NOT NULL,
+                    success BOOLEAN NOT NULL,
+                    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    FOREIGN KEY (run_id, agent_key) REFERENCES hgm_agents(run_id, agent_key) ON DELETE CASCADE
+                )
+                """,
+                "CREATE INDEX IF NOT EXISTS idx_hgm_runs_created_at ON hgm_runs(created_at)",
+                "CREATE INDEX IF NOT EXISTS idx_hgm_agents_parent ON hgm_agents(run_id, parent_key)",
+                "CREATE INDEX IF NOT EXISTS idx_hgm_agents_depth ON hgm_agents(run_id, depth)",
+                "CREATE INDEX IF NOT EXISTS idx_hgm_agent_perf_cmp ON hgm_agent_performance(run_id, cmp_mean)",
+                "CREATE INDEX IF NOT EXISTS idx_hgm_eval_agent ON hgm_evaluation_outcomes(run_id, agent_key, created_at)"
+            ]
+        else:
+            statements = [
+                """
+                CREATE TABLE IF NOT EXISTS hgm_runs (
+                    run_id TEXT PRIMARY KEY,
+                    root_agent TEXT NOT NULL,
+                    metadata TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS hgm_agents (
+                    run_id TEXT NOT NULL REFERENCES hgm_runs(run_id) ON DELETE CASCADE,
+                    agent_key TEXT NOT NULL,
+                    parent_key TEXT,
+                    depth INTEGER NOT NULL DEFAULT 0,
+                    metadata TEXT NOT NULL,
+                    expansion_count REAL NOT NULL DEFAULT 0,
+                    clade_success REAL NOT NULL DEFAULT 0,
+                    clade_failure REAL NOT NULL DEFAULT 0,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (run_id, agent_key)
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS hgm_agent_performance (
+                    run_id TEXT NOT NULL,
+                    agent_key TEXT NOT NULL,
+                    visits REAL NOT NULL DEFAULT 0,
+                    success_weight REAL NOT NULL DEFAULT 0,
+                    failure_weight REAL NOT NULL DEFAULT 0,
+                    cmp_mean REAL NOT NULL DEFAULT 0,
+                    cmp_variance REAL NOT NULL DEFAULT 0,
+                    cmp_weight REAL NOT NULL DEFAULT 0,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (run_id, agent_key),
+                    FOREIGN KEY (run_id, agent_key) REFERENCES hgm_agents(run_id, agent_key) ON DELETE CASCADE
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS hgm_evaluation_outcomes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id TEXT NOT NULL,
+                    agent_key TEXT NOT NULL,
+                    reward REAL NOT NULL,
+                    weight REAL NOT NULL,
+                    success INTEGER NOT NULL,
+                    payload TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    FOREIGN KEY (run_id, agent_key) REFERENCES hgm_agents(run_id, agent_key) ON DELETE CASCADE
+                )
+                """,
+                "CREATE INDEX IF NOT EXISTS idx_hgm_runs_created_at ON hgm_runs(created_at)",
+                "CREATE INDEX IF NOT EXISTS idx_hgm_agents_parent ON hgm_agents(run_id, parent_key)",
+                "CREATE INDEX IF NOT EXISTS idx_hgm_agents_depth ON hgm_agents(run_id, depth)",
+                "CREATE INDEX IF NOT EXISTS idx_hgm_agent_perf_cmp ON hgm_agent_performance(run_id, cmp_mean)",
+                "CREATE INDEX IF NOT EXISTS idx_hgm_eval_agent ON hgm_evaluation_outcomes(run_id, agent_key, created_at)"
+            ]
+        for statement in statements:
+            cursor.execute(statement)
+
+
+__all__ = ["Migration0001Initial"]

--- a/backend/models/hgm.py
+++ b/backend/models/hgm.py
@@ -1,0 +1,516 @@
+"""Persistence models for Hierarchical Generative Machine lineage tracking."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional
+
+from backend.database import Database, get_database
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _serialize(metadata: Optional[Dict[str, Any]]) -> str:
+    if not metadata:
+        return "{}"
+    return json.dumps(metadata, ensure_ascii=False, sort_keys=True)
+
+
+def _deserialize(payload: Any) -> Dict[str, Any]:
+    if payload in (None, "", b""):
+        return {}
+    if isinstance(payload, (bytes, bytearray)):
+        payload = payload.decode("utf-8")
+    try:
+        return json.loads(payload)
+    except Exception:  # pragma: no cover - defensive against corrupted rows
+        LOGGER.warning("Failed to decode metadata payload", exc_info=True)
+        return {}
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.lower() in {"true", "1", "yes"}
+    return False
+
+
+@dataclass(slots=True)
+class HgmRun:
+    run_id: str
+    root_agent: str
+    metadata: Dict[str, Any]
+    created_at: float
+    updated_at: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(slots=True)
+class HgmAgent:
+    run_id: str
+    agent_key: str
+    parent_key: Optional[str]
+    depth: int
+    metadata: Dict[str, Any]
+    expansion_count: float
+    clade_success: float
+    clade_failure: float
+    created_at: float
+    updated_at: float
+
+
+@dataclass(slots=True)
+class HgmAgentPerformance:
+    run_id: str
+    agent_key: str
+    visits: float
+    success_weight: float
+    failure_weight: float
+    cmp_mean: float
+    cmp_variance: float
+    cmp_weight: float
+    updated_at: float
+
+
+@dataclass(slots=True)
+class HgmEvaluationOutcome:
+    id: int
+    run_id: str
+    agent_key: str
+    reward: float
+    weight: float
+    success: bool
+    payload: Dict[str, Any]
+    created_at: float
+
+
+@dataclass(slots=True)
+class LineagePerformance:
+    visits: float
+    success_weight: float
+    failure_weight: float
+    cmp_mean: float
+    cmp_variance: float
+    cmp_weight: float
+
+
+@dataclass(slots=True)
+class LineageNode:
+    agent_key: str
+    parent_key: Optional[str]
+    depth: int
+    metadata: Dict[str, Any]
+    expansion_count: float
+    clade_success: float
+    clade_failure: float
+    performance: LineagePerformance
+    children: List["LineageNode"] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "agentKey": self.agent_key,
+            "parentKey": self.parent_key,
+            "depth": self.depth,
+            "metadata": dict(self.metadata),
+            "expansionCount": self.expansion_count,
+            "cladeSuccess": self.clade_success,
+            "cladeFailure": self.clade_failure,
+            "performance": asdict(self.performance),
+            "children": [child.to_dict() for child in self.children],
+        }
+
+
+class HgmRepository:
+    """Repository coordinating persistence for HGM entities."""
+
+    def __init__(self, database: Database | None = None) -> None:
+        self._db = database or get_database()
+
+    # ------------------------------------------------------------------
+    # Run management
+    def ensure_run(self, run_id: str, root_agent: str, metadata: Optional[Dict[str, Any]] = None) -> HgmRun:
+        now = _now()
+        payload = _serialize(metadata)
+        placeholder = self._db.placeholder()
+        with self._db.transaction() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO hgm_runs (run_id, root_agent, metadata, created_at, updated_at)
+                VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                ON CONFLICT(run_id) DO UPDATE SET
+                    root_agent = excluded.root_agent,
+                    metadata = excluded.metadata,
+                    updated_at = excluded.updated_at
+                """,
+                (run_id, root_agent, payload, now, now),
+            )
+            cur.execute(
+                f"SELECT run_id, root_agent, metadata, created_at, updated_at FROM hgm_runs WHERE run_id = {placeholder}",
+                (run_id,),
+            )
+            row = cur.fetchone()
+        return self._row_to_run(row)
+
+    def list_runs(self) -> List[HgmRun]:
+        with self._db.transaction() as cur:
+            cur.execute(
+                "SELECT run_id, root_agent, metadata, created_at, updated_at FROM hgm_runs ORDER BY created_at DESC"
+            )
+            rows = cur.fetchall()
+        return [self._row_to_run(row) for row in rows or []]
+
+    def get_run(self, run_id: str) -> Optional[HgmRun]:
+        placeholder = self._db.placeholder()
+        with self._db.transaction() as cur:
+            cur.execute(
+                f"SELECT run_id, root_agent, metadata, created_at, updated_at FROM hgm_runs WHERE run_id = {placeholder}",
+                (run_id,),
+            )
+            row = cur.fetchone()
+        return self._row_to_run(row) if row else None
+
+    def delete_run(self, run_id: str) -> None:
+        placeholder = self._db.placeholder()
+        with self._db.transaction() as cur:
+            cur.execute(f"DELETE FROM hgm_runs WHERE run_id = {placeholder}", (run_id,))
+
+    # ------------------------------------------------------------------
+    # Agent helpers
+    def ensure_agent(
+        self,
+        run_id: str,
+        agent_key: str,
+        parent_key: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> HgmAgent:
+        now = _now()
+        placeholder = self._db.placeholder()
+        with self._db.transaction() as cur:
+            depth = 0
+            if parent_key:
+                cur.execute(
+                    f"SELECT depth FROM hgm_agents WHERE run_id = {placeholder} AND agent_key = {placeholder}",
+                    (run_id, parent_key),
+                )
+                parent_row = cur.fetchone()
+                if parent_row is not None:
+                    depth = int(parent_row[0]) + 1
+            cur.execute(
+                f"SELECT run_id, agent_key, parent_key, depth, metadata, expansion_count, clade_success, clade_failure, created_at, updated_at "
+                f"FROM hgm_agents WHERE run_id = {placeholder} AND agent_key = {placeholder}",
+                (run_id, agent_key),
+            )
+            existing = cur.fetchone()
+            payload = _serialize(metadata)
+            if existing is None:
+                cur.execute(
+                    f"""
+                    INSERT INTO hgm_agents (
+                        run_id, agent_key, parent_key, depth, metadata,
+                        expansion_count, clade_success, clade_failure, created_at, updated_at
+                    ) VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, 0, 0, 0, {placeholder}, {placeholder})
+                    """,
+                    (run_id, agent_key, parent_key, depth, payload, now, now),
+                )
+            else:
+                updates: List[str] = []
+                params: List[Any] = []
+                if parent_key is not None and parent_key != existing[2]:
+                    updates.append(f"parent_key = {placeholder}")
+                    params.append(parent_key)
+                if depth != existing[3]:
+                    updates.append(f"depth = {placeholder}")
+                    params.append(depth)
+                if metadata is not None:
+                    updates.append(f"metadata = {placeholder}")
+                    params.append(payload)
+                updates.append(f"updated_at = {placeholder}")
+                params.append(now)
+                params.extend([run_id, agent_key])
+                where_clause = f"WHERE run_id = {placeholder} AND agent_key = {placeholder}"
+                cur.execute(
+                    f"UPDATE hgm_agents SET {', '.join(updates)} {where_clause}",
+                    tuple(params),
+                )
+            cur.execute(
+                f"SELECT run_id, agent_key, parent_key, depth, metadata, expansion_count, clade_success, clade_failure, created_at, updated_at "
+                f"FROM hgm_agents WHERE run_id = {placeholder} AND agent_key = {placeholder}",
+                (run_id, agent_key),
+            )
+            row = cur.fetchone()
+        return self._row_to_agent(row)
+
+    def record_expansion(
+        self,
+        run_id: str,
+        agent_key: str,
+        parent_key: Optional[str],
+        payload: Optional[Dict[str, Any]],
+    ) -> HgmAgent:
+        metadata = dict(payload or {})
+        agent = self.ensure_agent(run_id, agent_key, parent_key, metadata)
+        now = _now()
+        serialized = _serialize(metadata)
+        placeholder = self._db.placeholder()
+        with self._db.transaction() as cur:
+            cur.execute(
+                f"""
+                UPDATE hgm_agents
+                   SET expansion_count = expansion_count + 1,
+                       metadata = {placeholder},
+                       updated_at = {placeholder}
+                 WHERE run_id = {placeholder} AND agent_key = {placeholder}
+                """,
+                (serialized, now, run_id, agent_key),
+            )
+            cur.execute(
+                f"SELECT run_id, agent_key, parent_key, depth, metadata, expansion_count, clade_success, clade_failure, created_at, updated_at "
+                f"FROM hgm_agents WHERE run_id = {placeholder} AND agent_key = {placeholder}",
+                (run_id, agent_key),
+            )
+            row = cur.fetchone()
+        return self._row_to_agent(row)
+
+    # ------------------------------------------------------------------
+    # Evaluation helpers
+    def record_evaluation(self, run_id: str, agent_key: str, payload: Dict[str, Any]) -> None:
+        reward = float(payload.get("reward", 0.0))
+        weight = float(payload.get("weight", 1.0))
+        cmp_payload = payload.get("cmp") or {}
+        cmp_mean = float(cmp_payload.get("mean", reward))
+        cmp_variance = float(cmp_payload.get("variance", 0.0))
+        cmp_weight = float(cmp_payload.get("weight", weight))
+        success_flag = payload.get("success")
+        success = _bool(success_flag) if success_flag is not None else reward >= 0.5
+        success_mass = max(0.0, reward * weight)
+        failure_mass = max(0.0, (1.0 - reward) * weight)
+        now = _now()
+        self.ensure_agent(run_id, agent_key)
+        placeholder = self._db.placeholder()
+        with self._db.transaction() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO hgm_evaluation_outcomes (
+                    run_id, agent_key, reward, weight, success, payload, created_at
+                ) VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                """,
+                (
+                    run_id,
+                    agent_key,
+                    reward,
+                    weight,
+                    1 if success else 0,
+                    _serialize(payload),
+                    now,
+                ),
+            )
+            cur.execute(
+                f"""
+                INSERT INTO hgm_agent_performance (
+                    run_id, agent_key, visits, success_weight, failure_weight, cmp_mean, cmp_variance, cmp_weight, updated_at
+                ) VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                ON CONFLICT(run_id, agent_key) DO UPDATE SET
+                    visits = hgm_agent_performance.visits + {placeholder},
+                    success_weight = hgm_agent_performance.success_weight + {placeholder},
+                    failure_weight = hgm_agent_performance.failure_weight + {placeholder},
+                    cmp_mean = {placeholder},
+                    cmp_variance = {placeholder},
+                    cmp_weight = {placeholder},
+                    updated_at = {placeholder}
+                """,
+                (
+                    run_id,
+                    agent_key,
+                    weight,
+                    success_mass,
+                    failure_mass,
+                    cmp_mean,
+                    cmp_variance,
+                    cmp_weight,
+                    now,
+                    weight,
+                    success_mass,
+                    failure_mass,
+                    cmp_mean,
+                    cmp_variance,
+                    cmp_weight,
+                    now,
+                ),
+            )
+            current = agent_key
+            while current:
+                cur.execute(
+                    f"""
+                    UPDATE hgm_agents
+                       SET clade_success = clade_success + {placeholder},
+                           clade_failure = clade_failure + {placeholder},
+                           updated_at = {placeholder}
+                     WHERE run_id = {placeholder} AND agent_key = {placeholder}
+                    """,
+                    (success_mass, failure_mass, now, run_id, current),
+                )
+                cur.execute(
+                    f"SELECT parent_key FROM hgm_agents WHERE run_id = {placeholder} AND agent_key = {placeholder}",
+                    (run_id, current),
+                )
+                row = cur.fetchone()
+                parent = row[0] if row else None
+                if not parent:
+                    break
+                current = parent
+
+    def list_evaluations(self, run_id: str, agent_key: Optional[str] = None) -> List[HgmEvaluationOutcome]:
+        placeholder = self._db.placeholder()
+        with self._db.transaction() as cur:
+            if agent_key is None:
+                cur.execute(
+                    f"SELECT id, run_id, agent_key, reward, weight, success, payload, created_at FROM hgm_evaluation_outcomes WHERE run_id = {placeholder} ORDER BY created_at",
+                    (run_id,),
+                )
+            else:
+                cur.execute(
+                    f"SELECT id, run_id, agent_key, reward, weight, success, payload, created_at FROM hgm_evaluation_outcomes WHERE run_id = {placeholder} AND agent_key = {placeholder} ORDER BY created_at",
+                    (run_id, agent_key),
+                )
+            rows = cur.fetchall()
+        return [self._row_to_evaluation(row) for row in rows or []]
+
+    # ------------------------------------------------------------------
+    # Lineage traversal
+    def fetch_lineage(self, run_id: str, root_key: Optional[str] = None) -> List[LineageNode]:
+        placeholder = self._db.placeholder()
+        with self._db.transaction() as cur:
+            cur.execute(
+                f"""
+                SELECT a.agent_key, a.parent_key, a.depth, a.metadata, a.expansion_count, a.clade_success, a.clade_failure,
+                       p.visits, p.success_weight, p.failure_weight, p.cmp_mean, p.cmp_variance, p.cmp_weight
+                  FROM hgm_agents AS a
+             LEFT JOIN hgm_agent_performance AS p
+                    ON p.run_id = a.run_id AND p.agent_key = a.agent_key
+                 WHERE a.run_id = {placeholder}
+              ORDER BY a.depth ASC, a.agent_key ASC
+                """,
+                (run_id,),
+            )
+            rows = cur.fetchall()
+        nodes: Dict[str, LineageNode] = {}
+        roots: List[LineageNode] = []
+        for row in rows or []:
+            metadata = _deserialize(row[3])
+            performance = LineagePerformance(
+                visits=float(row[7] or 0.0),
+                success_weight=float(row[8] or 0.0),
+                failure_weight=float(row[9] or 0.0),
+                cmp_mean=float(row[10] or 0.0),
+                cmp_variance=float(row[11] or 0.0),
+                cmp_weight=float(row[12] or 0.0),
+            )
+            node = LineageNode(
+                agent_key=str(row[0]),
+                parent_key=row[1],
+                depth=int(row[2]),
+                metadata=metadata,
+                expansion_count=float(row[4] or 0.0),
+                clade_success=float(row[5] or 0.0),
+                clade_failure=float(row[6] or 0.0),
+                performance=performance,
+            )
+            nodes[node.agent_key] = node
+        for node in nodes.values():
+            if node.parent_key and node.parent_key in nodes:
+                nodes[node.parent_key].children.append(node)
+            else:
+                roots.append(node)
+        if root_key:
+            return [nodes[root_key]] if root_key in nodes else []
+        return roots
+
+    # ------------------------------------------------------------------
+    # Row adapters
+    def _row_to_run(self, row) -> HgmRun:
+        return HgmRun(
+            run_id=row[0],
+            root_agent=row[1],
+            metadata=_deserialize(row[2]),
+            created_at=float(row[3]),
+            updated_at=float(row[4]),
+        )
+
+    def _row_to_agent(self, row) -> HgmAgent:
+        return HgmAgent(
+            run_id=row[0],
+            agent_key=row[1],
+            parent_key=row[2],
+            depth=int(row[3]),
+            metadata=_deserialize(row[4]),
+            expansion_count=float(row[5]),
+            clade_success=float(row[6]),
+            clade_failure=float(row[7]),
+            created_at=float(row[8]),
+            updated_at=float(row[9]),
+        )
+
+    def _row_to_evaluation(self, row) -> HgmEvaluationOutcome:
+        return HgmEvaluationOutcome(
+            id=int(row[0]),
+            run_id=row[1],
+            agent_key=row[2],
+            reward=float(row[3]),
+            weight=float(row[4]),
+            success=bool(row[5]),
+            payload=_deserialize(row[6]),
+            created_at=float(row[7]),
+        )
+
+
+def seed_demo_run(repository: HgmRepository, run_id: str = "demo-run") -> HgmRun:
+    """Populate a small lineage useful for demos and manual testing."""
+
+    repository.delete_run(run_id)
+    run = repository.ensure_run(run_id, "root", {"label": "Demo Root"})
+    repository.ensure_agent(run_id, "root", None, {"label": "Root"})
+    repository.record_expansion(run_id, "root/alpha", "root", {"label": "Alpha"})
+    repository.record_expansion(run_id, "root/beta", "root", {"label": "Beta"})
+    repository.record_expansion(run_id, "root/alpha/deep", "root/alpha", {"label": "Deep"})
+    repository.record_evaluation(
+        run_id,
+        "root/alpha",
+        {"reward": 0.82, "weight": 1.0, "success": True, "cmp": {"weight": 1.0, "mean": 0.82, "variance": 0.0}},
+    )
+    repository.record_evaluation(
+        run_id,
+        "root/alpha/deep",
+        {"reward": 0.91, "weight": 1.0, "success": True, "cmp": {"weight": 1.0, "mean": 0.91, "variance": 0.0}},
+    )
+    repository.record_evaluation(
+        run_id,
+        "root/beta",
+        {"reward": 0.35, "weight": 1.0, "success": False, "cmp": {"weight": 1.0, "mean": 0.35, "variance": 0.0}},
+    )
+    return run
+
+
+__all__ = [
+    "HgmRepository",
+    "HgmRun",
+    "HgmAgent",
+    "HgmAgentPerformance",
+    "HgmEvaluationOutcome",
+    "LineageNode",
+    "LineagePerformance",
+    "seed_demo_run",
+]

--- a/routes/hgm.py
+++ b/routes/hgm.py
@@ -1,0 +1,87 @@
+"""FastAPI router exposing HGM lineage persistence APIs."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+
+from backend.database import get_database
+from backend.models.hgm import HgmRepository, seed_demo_run
+
+try:  # pragma: no cover - align auth with Onebox router when available
+    from .onebox import require_api  # type: ignore
+except (RuntimeError, ImportError):  # pragma: no cover
+    def require_api() -> None:  # type: ignore
+        return None
+
+
+router = APIRouter(prefix="/hgm", tags=["hgm"], dependencies=[Depends(require_api)])
+
+
+def _repository() -> HgmRepository:
+    return HgmRepository(get_database())
+
+
+@router.get("/runs")
+def list_runs(repo: HgmRepository = Depends(_repository)) -> List[Dict[str, Any]]:
+    """Return all known HGM runs ordered by recency."""
+
+    return [run.to_dict() for run in repo.list_runs()]
+
+
+@router.get("/runs/{run_id}")
+def get_run(run_id: str, repo: HgmRepository = Depends(_repository)) -> Dict[str, Any]:
+    run = repo.get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="RUN_NOT_FOUND")
+    return run.to_dict()
+
+
+@router.delete("/runs/{run_id}", status_code=204, response_class=Response)
+def delete_run(run_id: str, repo: HgmRepository = Depends(_repository)) -> Response:
+    repo.delete_run(run_id)
+    return Response(status_code=204)
+
+
+@router.get("/runs/{run_id}/lineage")
+def get_lineage(run_id: str, root: Optional[str] = None, repo: HgmRepository = Depends(_repository)) -> List[Dict[str, Any]]:
+    """Return the lineage tree for the requested run."""
+
+    nodes = repo.fetch_lineage(run_id, root_key=root)
+    if not nodes:
+        if repo.get_run(run_id) is None:
+            raise HTTPException(status_code=404, detail="RUN_NOT_FOUND")
+        return []
+    return [node.to_dict() for node in nodes]
+
+
+@router.post("/runs/demo-seed", status_code=201)
+def seed_demo(repo: HgmRepository = Depends(_repository)) -> Dict[str, Any]:
+    run = seed_demo_run(repo)
+    return run.to_dict()
+
+
+_LINEAGE_PATTERN = re.compile(
+    r"lineage\s*\(\s*runId\s*:\s*\"(?P<run>[^\"]+)\"(?:\s*,\s*root\s*:\s*\"(?P<root>[^\"]+)\")?\s*\)"
+)
+
+
+@router.post("/graphql")
+def graphql(payload: Dict[str, Any], repo: HgmRepository = Depends(_repository)) -> Dict[str, Any]:
+    """Minimal GraphQL endpoint supporting ``lineage`` queries."""
+
+    query = payload.get("query")
+    if not isinstance(query, str):
+        raise HTTPException(status_code=400, detail="INVALID_QUERY")
+    match = _LINEAGE_PATTERN.search(query)
+    if not match:
+        raise HTTPException(status_code=400, detail="UNSUPPORTED_QUERY")
+    run_id = match.group("run")
+    root = match.group("root")
+    data = repo.fetch_lineage(run_id, root_key=root)
+    return {"data": {"lineage": [node.to_dict() for node in data]}}
+
+
+__all__ = ["router"]

--- a/services/meta_api/app/main.py
+++ b/services/meta_api/app/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 
 from orchestrator.analytics import AnalyticsScheduler, AnalyticsEngine, get_cache, run_once
 from routes.analytics import router as analytics_router
+from routes.hgm import router as hgm_router
 from routes.agents import router as agents_router
 from routes.meta_orchestrator import router as meta_router
 from routes.onebox import health_router, router as onebox_router
@@ -34,6 +35,7 @@ def create_app() -> FastAPI:
     app.include_router(meta_router)
     app.include_router(analytics_router)
     app.include_router(agents_router)
+    app.include_router(hgm_router)
 
     scheduler = AnalyticsScheduler(AnalyticsEngine(), get_cache())
 

--- a/tests/backend/test_hgm_repository.py
+++ b/tests/backend/test_hgm_repository.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import math
+
+from backend.database import get_database
+from backend.models.hgm import HgmRepository, seed_demo_run
+
+
+def test_migrations_create_tables() -> None:
+    db = get_database()
+    with db.transaction() as cur:
+        cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'hgm_%'")
+        tables = {row[0] for row in cur.fetchall()}
+    assert {
+        "hgm_runs",
+        "hgm_agents",
+        "hgm_agent_performance",
+        "hgm_evaluation_outcomes",
+        "hgm_schema_migrations",
+    }.issubset(tables)
+
+
+def test_repository_persists_lineage() -> None:
+    repo = HgmRepository(get_database())
+    repo.ensure_run("run-1", "root", {"label": "Root"})
+    repo.ensure_agent("run-1", "root", None, {"label": "Root"})
+    repo.record_expansion("run-1", "root/alpha", "root", {"label": "Alpha"})
+    repo.record_expansion("run-1", "root/beta", "root", {"label": "Beta"})
+    repo.record_evaluation(
+        "run-1",
+        "root/alpha",
+        {"reward": 0.8, "weight": 1.0, "success": True, "cmp": {"weight": 1.0, "mean": 0.8, "variance": 0.0}},
+    )
+    repo.record_evaluation(
+        "run-1",
+        "root/beta",
+        {"reward": 0.3, "weight": 1.0, "success": False, "cmp": {"weight": 1.0, "mean": 0.3, "variance": 0.0}},
+    )
+    lineage = repo.fetch_lineage("run-1")
+    assert len(lineage) == 1
+    root = lineage[0]
+    assert root.agent_key == "root"
+    assert len(root.children) == 2
+    alpha = next(child for child in root.children if child.agent_key.endswith("alpha"))
+    beta = next(child for child in root.children if child.agent_key.endswith("beta"))
+    assert alpha.performance.visits >= 1.0
+    assert beta.performance.visits >= 1.0
+    assert alpha.clade_success > 0
+    assert beta.clade_failure > 0
+    assert root.clade_success >= alpha.clade_success
+    assert root.clade_failure >= beta.clade_failure
+    evaluations = repo.list_evaluations("run-1", "root/alpha")
+    assert evaluations
+    assert evaluations[0].success is True
+
+
+def test_seed_demo_run_populates_sample() -> None:
+    repo = HgmRepository(get_database())
+    seed_demo_run(repo, run_id="demo")
+    lineage = repo.fetch_lineage("demo")
+    assert lineage
+    alpha = next(child for child in lineage[0].children if child.agent_key.endswith("alpha"))
+    assert alpha.children  # deep node present

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Pytest fixtures configuring an isolated HGM database."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("RPC_URL", "http://localhost:8545")
+os.environ.setdefault("AGENT_REGISTRY_OWNER_TOKEN", "test-token")
+
+from backend.database import Database, set_database
+from backend.migrations import MIGRATIONS
+
+
+@pytest.fixture(autouse=True)
+def isolated_hgm_database(tmp_path) -> Iterator[None]:
+    os.environ["HGM_DATABASE_URL"] = "sqlite:///:memory:"
+    database = Database(os.environ["HGM_DATABASE_URL"])
+    database.run_migrations(MIGRATIONS)
+    set_database(database)
+    try:
+        yield
+    finally:
+        database.close()
+        set_database(None)

--- a/tests/routes/test_hgm_routes.py
+++ b/tests/routes/test_hgm_routes.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+
+from fastapi.testclient import TestClient
+
+from backend.database import get_database
+from backend.models.hgm import HgmRepository, seed_demo_run
+from services.meta_api.app.main import create_app
+
+os.environ.setdefault("RPC_URL", "http://localhost:8545")
+os.environ.setdefault("AGENT_REGISTRY_OWNER_TOKEN", "test-token")
+
+
+def test_rest_endpoints_expose_lineage() -> None:
+    repo = HgmRepository(get_database())
+    seed_demo_run(repo, run_id="demo-rest")
+    app = create_app()
+    client = TestClient(app)
+
+    runs = client.get("/hgm/runs").json()
+    assert any(run["run_id"] == "demo-rest" for run in runs)
+
+    lineage = client.get("/hgm/runs/demo-rest/lineage").json()
+    assert lineage
+    assert lineage[0]["agentKey"] == "root"
+
+    seeded = client.post("/hgm/runs/demo-seed").json()
+    assert seeded["run_id"] == "demo-run"
+
+
+def test_graphql_lineage_endpoint() -> None:
+    repo = HgmRepository(get_database())
+    seed_demo_run(repo, run_id="demo-graphql")
+    app = create_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/hgm/graphql",
+        json={"query": '{ lineage(runId: "demo-graphql") { agentKey } }'},
+    )
+    payload = response.json()
+    assert "data" in payload
+    assert payload["data"]["lineage"][0]["agentKey"] == "root"


### PR DESCRIPTION
## Summary
- add database connection utilities plus migrations for new HGM tables
- implement an HgmRepository with lineage traversal helpers and expose them through a dedicated FastAPI router
- hook the HGM workflow callbacks into the repository and cover the behaviour with backend and API tests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/backend tests/routes tests/orchestrator/test_hgm_workflow.py

------
https://chatgpt.com/codex/tasks/task_e_6902a75e49fc83339d36c83290d737c7