### PR TITLE
Add AGIALPHA profile config overrides and validation

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,49 @@
+# Configuration profiles
+
+The repository keeps canonical module manifests under `config/` while allowing
+profile-specific overrides. The **AGIALPHA** profile ships curated defaults for
+high-growth mission (HGM) orchestration, thermostat tuning, and sentinel
+guardrails.
+
+## Directory layout
+
+- `config/*.json` – network-agnostic defaults consumed by scripts and runtime
+  services.
+- `config/agialpha/*.json` – overrides applied when the AGIALPHA profile is
+  active. These files introduce controller targets, agent priors, and budget
+  envelopes tailored for AGIALPHA deployments.
+
+## Activating the AGIALPHA profile
+
+Set `AGIALPHA_PROFILE` to enable the overrides when running scripts or services:
+
+```bash
+export AGIALPHA_PROFILE=agialpha
+```
+
+Truth-y values such as `1`, `true`, or `on` also activate the profile. Any
+false-y value (`0`, `false`, `off`, `none`) disables it. When the variable is
+unset the loaders fall back to the base `config/*.json` files, so non-HGM
+workloads remain unaffected.
+
+### Local development
+
+Run configuration validation and tests with the profile enabled:
+
+```bash
+AGIALPHA_PROFILE=agialpha node scripts/validate-config.js
+AGIALPHA_PROFILE=agialpha pytest tests/config/test_profile_loader.py
+```
+
+### CI/CD pipelines
+
+In GitHub Actions, CircleCI, or similar systems export the variable before
+invoking validation or test jobs:
+
+```bash
+env:
+  AGIALPHA_PROFILE: agialpha
+```
+
+Every pipeline should include the validation script to enforce schema
+constraints for the HGM, thermostat, and sentinel manifests.

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,127 @@
+"""Profile-aware configuration loader utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, Tuple
+
+CONFIG_ROOT = Path(__file__).resolve().parent
+"""Root directory for repository configuration files."""
+
+PROFILE_ENV_VAR = "AGIALPHA_PROFILE"
+"""Environment variable controlling the active configuration profile."""
+
+_DEFAULT_PROFILE = "agialpha"
+_DISABLED_PROFILE_VALUES = {"", "0", "false", "off", "no", "none", "null"}
+_ENABLED_PROFILE_VALUES = {"1", "true", "yes", "on", "enable", "enabled"}
+
+
+def _copy(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _copy(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_copy(item) for item in value]
+    return value
+
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {key: _copy(value) for key, value in base.items()}
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = _copy(value)
+    return result
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _normalise_profile(value: str | None) -> str | None:
+    if value is None:
+        return None
+    candidate = value.strip().lower()
+    if candidate in _DISABLED_PROFILE_VALUES:
+        return None
+    if candidate in _ENABLED_PROFILE_VALUES:
+        return _DEFAULT_PROFILE
+    return candidate or None
+
+
+def _candidate_paths(name: str, *, network: str | None = None) -> Iterable[Path]:
+    if network:
+        yield CONFIG_ROOT / f"{name}.{network}.json"
+    yield CONFIG_ROOT / f"{name}.json"
+
+
+def _profile_candidate_paths(profile: Path, name: str, *, network: str | None = None) -> Iterable[Path]:
+    if network:
+        yield profile / f"{name}.{network}.json"
+    yield profile / f"{name}.json"
+
+
+def resolve_profile(profile: str | None = None) -> Path | None:
+    """Resolve the active profile directory if one is enabled."""
+
+    raw = profile if profile is not None else os.getenv(PROFILE_ENV_VAR)
+    slug = _normalise_profile(raw)
+    if not slug:
+        return None
+    candidate = CONFIG_ROOT / slug
+    if candidate.is_dir():
+        return candidate
+    return None
+
+
+def load_config_with_sources(
+    name: str,
+    *,
+    network: str | None = None,
+    profile: str | None = None,
+) -> Tuple[Dict[str, Any], Tuple[Path, ...]]:
+    """Load configuration merging the active profile overrides."""
+
+    config: Dict[str, Any] = {}
+    sources: list[Path] = []
+
+    for candidate in _candidate_paths(name, network=network):
+        if candidate.exists():
+            config = _load_json(candidate)
+            sources.append(candidate)
+            break
+
+    profile_dir = resolve_profile(profile)
+    if profile_dir is not None:
+        for candidate in _profile_candidate_paths(profile_dir, name, network=network):
+            if candidate.exists():
+                override = _load_json(candidate)
+                config = _deep_merge(config, override) if config else _copy(override)
+                sources.append(candidate)
+                break
+
+    return config, tuple(sources)
+
+
+def load_config(
+    name: str,
+    *,
+    network: str | None = None,
+    profile: str | None = None,
+) -> Dict[str, Any]:
+    """Load configuration for ``name`` with profile-aware overrides."""
+
+    config, _ = load_config_with_sources(name, network=network, profile=profile)
+    return config
+
+
+__all__ = [
+    "CONFIG_ROOT",
+    "PROFILE_ENV_VAR",
+    "load_config",
+    "load_config_with_sources",
+    "resolve_profile",
+]

--- a/config/agialpha/hgm.json
+++ b/config/agialpha/hgm.json
@@ -1,0 +1,26 @@
+{
+  "engine": {
+    "wideningAlpha": 0.6,
+    "minVisitations": 3,
+    "thompsonPrior": 1.15,
+    "seed": null
+  },
+  "budget": {
+    "max": 250000.0,
+    "softRatio": 0.82,
+    "initial": 50000.0
+  },
+  "agents": {
+    "root": "agialpha.root",
+    "priors": {
+      "analysis": 1.05,
+      "execution": 0.95,
+      "validation": 1.1
+    }
+  },
+  "controlTargets": {
+    "roi": 2.0,
+    "successRate": 0.7,
+    "maxFailureRatio": 0.25
+  }
+}

--- a/config/agialpha/sentinel.json
+++ b/config/agialpha/sentinel.json
@@ -1,0 +1,18 @@
+{
+  "roiFloor": 1.35,
+  "roiGracePeriod": 4,
+  "budgetCap": 450000.0,
+  "budgetSoftRatio": 0.85,
+  "failureStreak": {
+    "threshold": 4,
+    "successReset": true
+  },
+  "successThreshold": 0.72,
+  "monitorIntervalSeconds": 0.5,
+  "alertChannels": ["log", "pagerduty"],
+  "controlTargets": {
+    "roi": 2.0,
+    "maxBurnRate": 0.3,
+    "minSuccessRate": 0.65
+  }
+}

--- a/config/agialpha/thermostat.json
+++ b/config/agialpha/thermostat.json
@@ -1,0 +1,38 @@
+{
+  "systemTemperature": "1800000000000000000",
+  "bounds": {
+    "min": "900000000000000000",
+    "max": "3200000000000000000"
+  },
+  "pid": {
+    "kp": "200000000000000000",
+    "ki": "50000000000000000",
+    "kd": "25000000000000000"
+  },
+  "kpiWeights": {
+    "emission": "1",
+    "backlog": "2",
+    "sla": "1"
+  },
+  "integralBounds": {
+    "min": "-500000000000000000",
+    "max": "500000000000000000"
+  },
+  "roleTemperatures": {
+    "agent": "1900000000000000000",
+    "validator": "1700000000000000000"
+  },
+  "controller": {
+    "targetRoi": 2.0,
+    "lowerMargin": 0.12,
+    "upperMargin": 0.18,
+    "roiWindow": 12,
+    "wideningStep": 0.08,
+    "minWideningAlpha": 0.35,
+    "maxWideningAlpha": 1.25,
+    "thompsonStep": 0.12,
+    "minThompsonPrior": 0.5,
+    "maxThompsonPrior": 2.5,
+    "cooldownSteps": 3
+  }
+}

--- a/scripts/validate-config.js
+++ b/scripts/validate-config.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+function readJson(filePath) {
+  const contents = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(contents);
+}
+
+function ensureNumber(label, value, { min, max, allowZero = false } = {}) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+  if (!allowZero && numeric === 0) {
+    throw new Error(`${label} must be non-zero`);
+  }
+  if (min !== undefined && numeric < min) {
+    throw new Error(`${label} must be >= ${min}`);
+  }
+  if (max !== undefined && numeric > max) {
+    throw new Error(`${label} must be <= ${max}`);
+  }
+  return numeric;
+}
+
+function validateSentinel(config) {
+  const issues = [];
+  try {
+    ensureNumber('sentinel.budgetCap', config.budgetCap, { min: 1 });
+  } catch (error) {
+    issues.push(error.message);
+  }
+  try {
+    ensureNumber('sentinel.budgetSoftRatio', config.budgetSoftRatio, {
+      min: 0,
+      max: 1,
+      allowZero: false,
+    });
+  } catch (error) {
+    issues.push(error.message);
+  }
+  try {
+    ensureNumber('sentinel.roiFloor', config.roiFloor, { min: 0 });
+  } catch (error) {
+    issues.push(error.message);
+  }
+  if (!config.controlTargets || typeof config.controlTargets !== 'object') {
+    issues.push('sentinel.controlTargets is required');
+  } else {
+    for (const key of ['roi', 'maxBurnRate', 'minSuccessRate']) {
+      try {
+        ensureNumber(`sentinel.controlTargets.${key}`, config.controlTargets[key], { min: 0 });
+      } catch (error) {
+        issues.push(error.message);
+      }
+    }
+  }
+  return issues;
+}
+
+function validateThermostat(config) {
+  const issues = [];
+  if (!config.controller || typeof config.controller !== 'object') {
+    issues.push('thermostat.controller is required');
+    return issues;
+  }
+  const numericFields = [
+    'targetRoi',
+    'lowerMargin',
+    'upperMargin',
+    'roiWindow',
+    'wideningStep',
+    'minWideningAlpha',
+    'maxWideningAlpha',
+    'thompsonStep',
+    'minThompsonPrior',
+    'maxThompsonPrior',
+    'cooldownSteps',
+  ];
+  for (const field of numericFields) {
+    try {
+      ensureNumber(`thermostat.controller.${field}`, config.controller[field], { min: 0, allowZero: field !== 'targetRoi' && field !== 'roiWindow' });
+    } catch (error) {
+      issues.push(error.message);
+    }
+  }
+  return issues;
+}
+
+function validateHgm(config) {
+  const issues = [];
+  if (!config.budget || typeof config.budget !== 'object') {
+    issues.push('hgm.budget is required');
+  } else {
+    for (const field of ['max', 'softRatio', 'initial']) {
+      try {
+        ensureNumber(`hgm.budget.${field}`, config.budget[field], {
+          min: field === 'softRatio' ? 0 : 1,
+          max: field === 'softRatio' ? 1 : undefined,
+          allowZero: field === 'softRatio',
+        });
+      } catch (error) {
+        issues.push(error.message);
+      }
+    }
+  }
+  if (!config.agents || typeof config.agents !== 'object') {
+    issues.push('hgm.agents is required');
+  } else if (!config.agents.priors || typeof config.agents.priors !== 'object') {
+    issues.push('hgm.agents.priors is required');
+  } else {
+    const priors = config.agents.priors;
+    for (const [role, value] of Object.entries(priors)) {
+      try {
+        ensureNumber(`hgm.agents.priors.${role}`, value, { min: 0 });
+      } catch (error) {
+        issues.push(error.message);
+      }
+    }
+  }
+  if (!config.controlTargets || typeof config.controlTargets !== 'object') {
+    issues.push('hgm.controlTargets is required');
+  } else {
+    for (const key of ['roi', 'successRate', 'maxFailureRatio']) {
+      try {
+        ensureNumber(`hgm.controlTargets.${key}`, config.controlTargets[key], { min: 0 });
+      } catch (error) {
+        issues.push(error.message);
+      }
+    }
+  }
+  return issues;
+}
+
+function main() {
+  const profileDir = path.join(__dirname, '..', 'config', 'agialpha');
+  const errors = [];
+  try {
+    const sentinel = readJson(path.join(profileDir, 'sentinel.json'));
+    errors.push(...validateSentinel(sentinel));
+  } catch (error) {
+    errors.push(`Unable to read sentinel profile config: ${error.message}`);
+  }
+  try {
+    const thermostat = readJson(path.join(profileDir, 'thermostat.json'));
+    errors.push(...validateThermostat(thermostat));
+  } catch (error) {
+    errors.push(`Unable to read thermostat profile config: ${error.message}`);
+  }
+  try {
+    const hgm = readJson(path.join(profileDir, 'hgm.json'));
+    errors.push(...validateHgm(hgm));
+  } catch (error) {
+    errors.push(`Unable to read hgm profile config: ${error.message}`);
+  }
+
+  if (errors.length > 0) {
+    for (const message of errors) {
+      console.error(`✖ ${message}`);
+    }
+    process.exit(1);
+  }
+  console.log('✓ AGIALPHA profile configuration validated successfully.');
+}
+
+main();

--- a/tests/config/test_profile_loader.py
+++ b/tests/config/test_profile_loader.py
@@ -1,0 +1,61 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from config import CONFIG_ROOT, load_config
+from services.sentinel.config import load_config as load_sentinel_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_sentinel_cache():
+    load_sentinel_config.cache_clear()
+    yield
+    load_sentinel_config.cache_clear()
+
+
+def _read_json(path: Path) -> dict:
+    with path.open('r', encoding='utf-8') as handle:
+        return json.load(handle)
+
+
+def test_defaults_unchanged_when_profile_disabled(monkeypatch):
+    monkeypatch.delenv('AGIALPHA_PROFILE', raising=False)
+    sentinel = load_config('sentinel')
+    baseline = _read_json(CONFIG_ROOT / 'sentinel.json')
+
+    assert sentinel['budgetCap'] == baseline['budgetCap']
+    assert 'controlTargets' not in sentinel
+
+
+def test_profile_overrides_apply_when_enabled(monkeypatch):
+    monkeypatch.setenv('AGIALPHA_PROFILE', 'agialpha')
+    sentinel = load_config('sentinel')
+    assert sentinel['controlTargets']['roi'] == pytest.approx(2.0)
+
+
+def test_falsey_profile_values_disable_overrides(monkeypatch):
+    monkeypatch.setenv('AGIALPHA_PROFILE', '0')
+    sentinel = load_config('sentinel')
+    assert 'controlTargets' not in sentinel
+
+
+def test_hgm_profile_only(monkeypatch):
+    monkeypatch.delenv('AGIALPHA_PROFILE', raising=False)
+    assert load_config('hgm') == {}
+
+    monkeypatch.setenv('AGIALPHA_PROFILE', 'agialpha')
+    hgm_profile = load_config('hgm')
+    assert hgm_profile['budget']['max'] == pytest.approx(250000.0)
+    assert set(hgm_profile['agents']['priors']) == {'analysis', 'execution', 'validation'}
+
+
+def test_sentinel_loader_honours_profile(monkeypatch):
+    monkeypatch.delenv('AGIALPHA_PROFILE', raising=False)
+    config_default = load_sentinel_config()
+    assert config_default.control_targets == {}
+
+    load_sentinel_config.cache_clear()
+    monkeypatch.setenv('AGIALPHA_PROFILE', 'agialpha')
+    config_profile = load_sentinel_config()
+    assert config_profile.control_targets['roi'] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- add a profile-aware configuration loader with AGIALPHA overrides for HGM, thermostat, and sentinel manifests
- extend the sentinel loader to surface control targets and document how to enable the AGIALPHA profile locally and in CI
- ship a validation script plus pytest coverage to ensure profile toggles leave non-HGM defaults untouched

## Testing
- node scripts/validate-config.js
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/config/test_profile_loader.py

------
https://chatgpt.com/codex/tasks/task_e_6902b8a9074c833387acab507e0657ad