### PR TITLE
Fix Open-Endedness demo tests imports

### DIFF
--- a/demo/Open-Endedness-v0/tests/test_controls.py
+++ b/demo/Open-Endedness-v0/tests/test_controls.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import sys
 from pathlib import Path

--- a/demo/Open-Endedness-v0/tests/test_probabilities.py
+++ b/demo/Open-Endedness-v0/tests/test_probabilities.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary
- ensure the Open-Endedness OMNI demo pytest modules import annotations before any other statements
- keep deterministic random seeding helper imports intact so demos remain reproducible

## Testing
- python -m compileall demo/Open-Endedness-v0
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Open-Endedness-v0/tests -q

------
https://chatgpt.com/codex/tasks/task_e_6902ca9a09f08333885f6dd4d60bd89b