### PR TITLE
Add HGM operator documentation and update emergency runbook

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -24,7 +24,7 @@ steps below.
    streaming a short burst of metrics:
    ```bash
    mkdir -p reports/hgm
-   python scripts/thermostat.py watch --dry-run --iterations 12 > reports/hgm/roi-baseline.log
+   python -m scripts.thermostat watch --dry-run --iterations 12 > reports/hgm/roi-baseline.log
    ```
    Archive the output alongside a sentinel snapshot captured with:
    ```bash
@@ -55,7 +55,7 @@ The thermostat provides the first line of defence when ROI deviates from the
 treasury policy described in [`config/agialpha/hgm.json`](config/agialpha/hgm.json).
 
 1. **Adjust concurrency safely.** Preview changes with
-   `python scripts/thermostat.py watch --widening-step 0.08 --max-widening-alpha 1.8 --dry-run`.
+   `python -m scripts.thermostat watch --widening-step 0.08 --max-widening-alpha 1.8 --dry-run`.
    Re-run without `--dry-run` once approved. The controller in
    [`services/thermostat/controller.py`](services/thermostat/controller.py)
    applies updates gradually and enforces cooldowns to prevent oscillation.
@@ -66,7 +66,7 @@ treasury policy described in [`config/agialpha/hgm.json`](config/agialpha/hgm.js
    pauses, inspect [`config/sentinel.json`](config/sentinel.json) and align with
    risk/compliance before issuing overrides.
 4. **Quantify impact.** Re-run the ROI baseline command
-   (`python scripts/thermostat.py watch --dry-run --iterations 12`) after each
+   (`python -m scripts.thermostat watch --dry-run --iterations 12`) after each
    change and compare the logs to prior baselines to estimate ROI lift or
    drawdown. Escalate to finance when variance exceeds 10 %.
 

--- a/docs/hgm/faq.md
+++ b/docs/hgm/faq.md
@@ -41,7 +41,7 @@ JSON snapshot from the `reports/hgm` directory.
 ### ROI looks great — can I safely add more agents?
 Yes, but change one control at a time:
 1. Preview the desired adjustment with
-   `python scripts/thermostat.py watch --widening-step 0.08 --max-widening-alpha 1.8 --dry-run`.
+   `python -m scripts.thermostat watch --widening-step 0.08 --max-widening-alpha 1.8 --dry-run`.
 2. Re-run the same command without `--dry-run` to apply the new targets. The
    controller in [`services/thermostat/controller.py`](../../services/thermostat/controller.py)
    will gradually scale to the requested level.
@@ -78,7 +78,7 @@ The code that manages this lives in
 2. Export ROI events with:
    ```bash
    mkdir -p reports/hgm
-   python scripts/thermostat.py watch --dry-run --iterations 12 > reports/hgm/roi-export.log
+   python -m scripts.thermostat watch --dry-run --iterations 12 > reports/hgm/roi-export.log
    ```
 3. Optionally run the culture rewards calculator in
    [`orchestrator/tools/culture_rewards.py`](../../orchestrator/tools/culture_rewards.py)

--- a/docs/hgm/whitepaper.md
+++ b/docs/hgm/whitepaper.md
@@ -120,7 +120,7 @@ Follow this path to stand up an HGM deployment in a fresh environment.
    [`scripts/thermostat.py`](../../scripts/thermostat.py) to adjust concurrency
    or ROI thresholds. Start with a dry run to preview adjustments:
    ```bash
-   python scripts/thermostat.py watch --target-roi 2.2 --widening-step 0.08 --dry-run
+   python -m scripts.thermostat watch --target-roi 2.2 --widening-step 0.08 --dry-run
    ```
    Re-run without `--dry-run` once satisfied. Changes propagate to the workflow
    through [`services/thermostat/controller.py`](../../services/thermostat/controller.py).


### PR DESCRIPTION
## Summary
- add a whitepaper-style operator guide for the Huxley–Gödel Machine complete with architecture diagrams and ROI guidance
- create a non-technical FAQ and troubleshooting playbook that links to relevant scripts and UI assets
- expand the main runbook with day-one operations, economic lever controls, and references to the new documentation

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_69035cd8fa4c8333a7322b75db2f3bb2