### PR TITLE
Add automated safety rails to AGI Alpha Node demo

### DIFF
--- a/demo/AGI-Alpha-Node-v0/README.md
+++ b/demo/AGI-Alpha-Node-v0/README.md
@@ -64,18 +64,23 @@ flowchart LR
    cd demo/AGI-Alpha-Node-v0
    python -m alpha_node.cli bootstrap
    ```
-   This deposits the minimum stake, validates ENS ownership, and prints a compliance snapshot.
-3. **Run the intelligence engine**:
+   This deposits the minimum stake, validates ENS ownership, and prints a compliance snapshot plus a full safety evaluation.
+3. **Verify the safety rails**:
+   ```bash
+   python -m alpha_node.cli safety
+   ```
+   Confirm ENS ownership, staking status, and pause state before activating the node.
+4. **Run the intelligence engine**:
    ```bash
    python -m alpha_node.cli run
    ```
    The planner harvests jobs, delegates to specialists, captures knowledge, and restakes rewards automatically.
-4. **Monitor metrics**:
+5. **Monitor metrics**:
    ```bash
    python -m alpha_node.cli metrics
    ```
-   Scrape Prometheus metrics from `http://localhost:9101`.
-5. **View compliance & dashboard data**:
+   Scrape Prometheus metrics (compliance score, last safety halt, antifragility, etc.) from `http://localhost:9101`.
+6. **View compliance & dashboard data**:
    ```bash
    python -m alpha_node.cli dashboard
    ```
@@ -87,6 +92,8 @@ flowchart LR
 - `python -m alpha_node.cli resume` — safely resume operations.
 - `python -m alpha_node.cli rotate-governance --address <0x...>` — rotate ownership to a new multisig without downtime.
 - `python -m alpha_node.cli stake-deposit --amount 5000` — top up the treasury stake from operator-controlled wallets.
+- `python -m alpha_node.cli drill` — execute an antifragility pause/resume drill and log the result.
+- `python -m alpha_node.cli safety` — print the latest invariant check (ENS, stake sufficiency, pause reason).
 
 ## 🌐 Web dashboard (grandiose operator cockpit)
 
@@ -108,7 +115,7 @@ Open `http://localhost:8090` and paste the JSON payload from `python -m alpha_no
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/AGI-Alpha-Node-v0/tests
 ```
 
-The suite validates planner convergence, compliance scoring, and governance pause behavior.
+The suite validates planner convergence, compliance scoring, governance pause behavior, and the automated safety rails.
 
 ## 🧰 One-command containerization
 

--- a/demo/AGI-Alpha-Node-v0/alpha_node/cli.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/cli.py
@@ -16,6 +16,7 @@ from .knowledge import KnowledgeLake
 from .metrics import MetricsServer
 from .orchestrator import AlphaOrchestrator, build_specialists
 from .planner import MuZeroPlanner
+from .safety import SafetyController
 from .stake import StakeManager
 from .state import StateStore
 
@@ -42,6 +43,7 @@ def load_environment(config_path: Path) -> dict[str, Any]:
     job_registry = JobRegistry((base_dir / config.jobs.job_source).resolve())
     harvester = TaskHarvester(job_registry, state_store)
     compliance = ComplianceEngine(config.compliance, state_store, stake_manager)
+    safety = SafetyController(state_store, stake_manager, ens_verifier, governance)
     return {
         "config": config,
         "state_store": state_store,
@@ -52,15 +54,25 @@ def load_environment(config_path: Path) -> dict[str, Any]:
         "orchestrator": orchestrator,
         "harvester": harvester,
         "compliance": compliance,
+        "safety": safety,
     }
 
 
 def cmd_bootstrap(env: dict[str, Any]) -> None:
     stake_manager: StakeManager = env["stake_manager"]
     stake_manager.deposit(env["config"].stake.minimum_stake)
+    safety_eval = env["safety"].guard("bootstrap", auto_resume=False)
     ens_result = env["ens_verifier"].verify()
     report = env["compliance"].evaluate(ens_result)
-    print(json.dumps(asdict(report), indent=2))
+    print(
+        json.dumps(
+            {
+                "compliance": asdict(report),
+                "safety": asdict(safety_eval),
+            },
+            indent=2,
+        )
+    )
 
 
 def cmd_status(env: dict[str, Any]) -> None:
@@ -69,8 +81,36 @@ def cmd_status(env: dict[str, Any]) -> None:
 
 
 def cmd_run(env: dict[str, Any]) -> None:
-    env["governance"].resume_all("auto")
+    safety_eval = env["safety"].guard("run-cycle")
+    if not safety_eval.safe:
+        state = env["state_store"].read()
+        print(
+            json.dumps(
+                {
+                    "status": "paused",
+                    "pause_reason": state.pause_reason,
+                    "safety": asdict(safety_eval),
+                },
+                indent=2,
+            )
+        )
+        return
+
     jobs = list(env["harvester"].harvest())
+    if not jobs:
+        compliance_report = env["compliance"].evaluate(env["ens_verifier"].verify())
+        print(
+            json.dumps(
+                {
+                    "status": "idle",
+                    "compliance": compliance_report.overall,
+                    "safety": asdict(safety_eval),
+                },
+                indent=2,
+            )
+        )
+        return
+
     report = env["orchestrator"].run(jobs)
     env["stake_manager"].accrue_rewards(
         sum(result.projected_reward for result in report.specialist_outputs.values()) * 0.05
@@ -81,17 +121,18 @@ def cmd_run(env: dict[str, Any]) -> None:
         "decisions": [asdict(decision) for decision in report.decisions],
         "specialists": {k: asdict(v) for k, v in report.specialist_outputs.items()},
         "compliance": compliance_report.overall,
+        "safety": asdict(safety_eval),
     }
     print(json.dumps(payload, indent=2))
 
 
 def cmd_pause(env: dict[str, Any]) -> None:
-    status = env["governance"].pause_all("operator request")
+    status = env["governance"].pause_all("operator-request")
     print(json.dumps(asdict(status), indent=2))
 
 
 def cmd_resume(env: dict[str, Any]) -> None:
-    status = env["governance"].resume_all("operator request")
+    status = env["governance"].resume_all("operator-resume")
     print(json.dumps(asdict(status), indent=2))
 
 
@@ -109,6 +150,11 @@ def cmd_compliance(env: dict[str, Any]) -> None:
         },
         indent=2,
     ))
+
+
+def cmd_safety(env: dict[str, Any]) -> None:
+    evaluation = env["safety"].evaluate()
+    print(json.dumps(asdict(evaluation), indent=2))
 
 
 def cmd_metrics(env: dict[str, Any]) -> None:  # pragma: no cover - server loop
@@ -134,6 +180,7 @@ def cmd_dashboard(env: dict[str, Any]) -> None:
             "overall": report.overall,
             "dimensions": {k: asdict(v) for k, v in report.dimensions.items()},
         },
+        "safety": asdict(env["safety"].evaluate()),
     }
     print(json.dumps(payload, indent=2))
 
@@ -141,6 +188,20 @@ def cmd_dashboard(env: dict[str, Any]) -> None:
 def cmd_rotate_governance(env: dict[str, Any], address: str) -> None:
     status = env["governance"].rotate_governance(address)
     print(json.dumps(asdict(status), indent=2))
+
+
+def cmd_drill(env: dict[str, Any]) -> None:
+    evaluation = env["safety"].conduct_drill()
+    compliance = env["compliance"].evaluate(env["ens_verifier"].verify())
+    print(
+        json.dumps(
+            {
+                "safety": asdict(evaluation),
+                "compliance": asdict(compliance),
+            },
+            indent=2,
+        )
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -160,6 +221,8 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("compliance")
     sub.add_parser("metrics")
     sub.add_parser("dashboard")
+    sub.add_parser("safety")
+    sub.add_parser("drill")
     rotate = sub.add_parser("rotate-governance")
     rotate.add_argument("--address", required=True)
     stake = sub.add_parser("stake-deposit")
@@ -178,10 +241,12 @@ def main(argv: list[str] | None = None) -> None:
         "pause": cmd_pause,
         "resume": cmd_resume,
         "compliance": cmd_compliance,
+        "safety": cmd_safety,
         "metrics": cmd_metrics,
         "dashboard": cmd_dashboard,
         "rotate-governance": lambda env: cmd_rotate_governance(env, args.address),
         "stake-deposit": lambda env: cmd_stake_deposit(env, args.amount),
+        "drill": cmd_drill,
     }
     command_map[args.command](env)
 

--- a/demo/AGI-Alpha-Node-v0/alpha_node/compliance.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/compliance.py
@@ -51,7 +51,14 @@ class ComplianceEngine:
         dimensions["governance"] = ComplianceDimension(
             name="Governance & Safety",
             score=0.0 if state.paused else 1.0,
-            rationale="System pause engaged" if state.paused else "System active",
+            rationale=(
+                "System pause engaged"
+                if state.paused
+                else "System active"
+            )
+            + (
+                f" ({state.pause_reason})" if state.pause_reason else ""
+            ),
         )
         dimensions["economic"] = ComplianceDimension(
             name="Economic Engine",
@@ -69,6 +76,7 @@ class ComplianceEngine:
             rationale=f"Strategic alpha {state.strategic_alpha_index:.2f}",
         )
         overall = sum(d.score for d in dimensions.values()) / len(dimensions)
+        self.store.update(compliance_score=round(overall, 3))
         return ComplianceReport(overall=round(overall, 3), dimensions=dimensions)
 
 

--- a/demo/AGI-Alpha-Node-v0/alpha_node/governance.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/governance.py
@@ -28,7 +28,7 @@ class GovernanceController:
         )
 
     def pause_all(self, reason: str = "manual pause") -> GovernanceStatus:
-        state = self.store.update(paused=True)
+        state = self.store.update(paused=True, pause_reason=reason)
         self.store.append_audit(f"[{datetime.now(UTC).isoformat()}Z] pause: {reason}")
         return GovernanceStatus(
             governance_address=state.governance_address,
@@ -38,7 +38,7 @@ class GovernanceController:
         )
 
     def resume_all(self, reason: str = "manual resume") -> GovernanceStatus:
-        state = self.store.update(paused=False)
+        state = self.store.update(paused=False, pause_reason="")
         self.store.append_audit(f"[{datetime.now(UTC).isoformat()}Z] resume: {reason}")
         return GovernanceStatus(
             governance_address=state.governance_address,

--- a/demo/AGI-Alpha-Node-v0/alpha_node/metrics.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/metrics.py
@@ -22,6 +22,10 @@ class MetricsServer(Thread):
         class Handler(BaseHTTPRequestHandler):
             def do_GET(self_inner):
                 state = self.store.read()
+                reason = state.last_safety_violation or "none"
+                reason_label = (
+                    reason.replace("\\", "\\\\").replace("\"", "\\\"")
+                )
                 payload = "\n".join(
                     [
                         "# HELP agi_alpha_node_paused Whether the node is paused",
@@ -33,6 +37,13 @@ class MetricsServer(Thread):
                         "# HELP agi_alpha_node_stake_locked Stake locked",
                         "# TYPE agi_alpha_node_stake_locked gauge",
                         f"agi_alpha_node_stake_locked {state.stake_locked}",
+                        "# HELP agi_alpha_node_compliance_score Composite compliance score",
+                        "# TYPE agi_alpha_node_compliance_score gauge",
+                        f"agi_alpha_node_compliance_score {state.compliance_score}",
+                        "# HELP agi_alpha_node_last_safety_violation Last safety halt recorded",
+                        "# TYPE agi_alpha_node_last_safety_violation gauge",
+                        f'agi_alpha_node_last_safety_violation{{reason="{reason_label}"}} '
+                        f"{1 if state.last_safety_violation else 0}",
                         "# HELP agi_alpha_node_antifragility_index Antifragility index",
                         "# TYPE agi_alpha_node_antifragility_index gauge",
                         f"agi_alpha_node_antifragility_index {state.antifragility_index}",

--- a/demo/AGI-Alpha-Node-v0/alpha_node/safety.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/safety.py
@@ -1,0 +1,147 @@
+"""Automated safety rails for the AGI Alpha Node demo."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import List
+
+from .ens import ENSVerifier
+from .governance import GovernanceController
+from .stake import StakeManager
+from .state import StateStore
+
+
+@dataclass(slots=True)
+class SafetyViolation:
+    """Represents a single invariant breach."""
+
+    code: str
+    message: str
+
+
+@dataclass(slots=True)
+class SafetyEvaluation:
+    """Snapshot of the node's current protection posture."""
+
+    safe: bool
+    ens_verified: bool
+    stake_sufficient: bool
+    paused: bool
+    ens_domain: str
+    ens_owner: str
+    ens_source: str
+    violations: List[SafetyViolation] = field(default_factory=list)
+
+
+class SafetyController:
+    """Automated safety rails coordinating ENS, stake, and pause controls."""
+
+    def __init__(
+        self,
+        store: StateStore,
+        stake_manager: StakeManager,
+        ens_verifier: ENSVerifier,
+        governance: GovernanceController,
+    ) -> None:
+        self.store = store
+        self.stake_manager = stake_manager
+        self.ens_verifier = ens_verifier
+        self.governance = governance
+
+    # ------------------------------------------------------------------
+    def evaluate(self) -> SafetyEvaluation:
+        """Assess the current state against all safety invariants."""
+
+        ens_result = self.ens_verifier.verify()
+        stake_ok = self.stake_manager.meets_minimum()
+        state = self.store.read()
+        violations: List[SafetyViolation] = []
+
+        if not ens_result.verified:
+            violations.append(
+                SafetyViolation(
+                    code="ens",
+                    message=(
+                        "ENS ownership mismatch – operations locked until the configured "
+                        "owner controls the domain"
+                    ),
+                )
+            )
+        if not stake_ok:
+            violations.append(
+                SafetyViolation(
+                    code="stake",
+                    message=(
+                        f"Stake below minimum requirement of {self.stake_manager.settings.minimum_stake} "
+                        f"{self.stake_manager.settings.asset_symbol}"
+                    ),
+                )
+            )
+        if state.paused:
+            reason = state.pause_reason or "operator pause"
+            violations.append(
+                SafetyViolation(
+                    code="paused",
+                    message=f"Node operations are paused ({reason})",
+                )
+            )
+
+        return SafetyEvaluation(
+            safe=not violations,
+            ens_verified=ens_result.verified,
+            stake_sufficient=stake_ok,
+            paused=state.paused,
+            ens_domain=ens_result.domain,
+            ens_owner=ens_result.owner,
+            ens_source=ens_result.source,
+            violations=violations,
+        )
+
+    # ------------------------------------------------------------------
+    def guard(self, operation: str, *, auto_resume: bool = True) -> SafetyEvaluation:
+        """Enforce safety before executing a critical operation."""
+
+        evaluation = self.evaluate()
+        state = self.store.read()
+        if evaluation.safe:
+            if state.paused and state.pause_reason.startswith("safety") and auto_resume:
+                self.governance.resume_all(f"safety-auto-resume:{operation}")
+            return evaluation
+
+        if (
+            len(evaluation.violations) == 1
+            and evaluation.violations[0].code == "paused"
+            and state.pause_reason.startswith("safety")
+            and auto_resume
+        ):
+            self.governance.resume_all(f"safety-auto-resume:{operation}")
+            return self.evaluate()
+
+        relevant = [
+            violation
+            for violation in evaluation.violations
+            if violation.code != "paused" or state.pause_reason.startswith("safety")
+        ]
+        if relevant:
+            reason = f"safety:{operation}:{'-'.join(v.code for v in relevant)}"
+            self.store.update(last_safety_violation=reason)
+            if not state.paused or state.pause_reason.startswith("safety"):
+                self.governance.pause_all(reason)
+        return evaluation
+
+    # ------------------------------------------------------------------
+    def conduct_drill(self) -> SafetyEvaluation:
+        """Run a pause/resume drill to validate the emergency pathway."""
+
+        self.governance.pause_all("safety:drill:init")
+        self.governance.resume_all("safety:drill:complete")
+        state = self.store.read()
+        antifragility = min(1.0, state.antifragility_index + 0.05)
+        self.store.update(antifragility_index=antifragility)
+        self.store.append_audit(
+            f"[{datetime.now(UTC).isoformat()}Z] safety-drill antifragility={antifragility:.2f}"
+        )
+        return self.evaluate()
+
+
+__all__ = ["SafetyController", "SafetyEvaluation", "SafetyViolation"]

--- a/demo/AGI-Alpha-Node-v0/alpha_node/state.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/state.py
@@ -11,7 +11,10 @@ from typing import Any, Dict
 @dataclass
 class NodeState:
     paused: bool = False
+    pause_reason: str = ""
     total_rewards: float = 0.0
+    compliance_score: float = 0.0
+    last_safety_violation: str = ""
     active_jobs: int = 0
     knowledge_entries: int = 0
     antifragility_index: float = 1.0

--- a/demo/AGI-Alpha-Node-v0/run_alpha_node.py
+++ b/demo/AGI-Alpha-Node-v0/run_alpha_node.py
@@ -122,8 +122,9 @@ def main() -> None:
             node.update_governance(address)
             print(f"Governance rotated to {address}")
         elif choice == "8":
-            node.run_safety_drill()
+            evaluation = node.run_safety_drill()
             print("Emergency pause drill executed and logged.")
+            print(json.dumps({"safety": asdict(evaluation)}, indent=2))
         elif choice == "9":
             report = node.compliance_report()
             print("Composite Compliance Score: %.2f" % report.overall)

--- a/demo/AGI-Alpha-Node-v0/tests/test_compliance.py
+++ b/demo/AGI-Alpha-Node-v0/tests/test_compliance.py
@@ -25,3 +25,4 @@ def test_compliance_scores_all_dimensions(tmp_path):
     report = engine.evaluate(ens_result)
     assert report.overall > 0.5
     assert len(report.dimensions) == 6
+    assert store.read().compliance_score == report.overall

--- a/demo/AGI-Alpha-Node-v0/tests/test_governance.py
+++ b/demo/AGI-Alpha-Node-v0/tests/test_governance.py
@@ -10,6 +10,10 @@ def test_pause_and_resume_update_state(tmp_path):
     store = StateStore(tmp_path / 'state.json')
     controller = GovernanceController(config.governance, store)
     controller.pause_all('test')
-    assert store.read().paused is True
+    paused_state = store.read()
+    assert paused_state.paused is True
+    assert paused_state.pause_reason == 'test'
     controller.resume_all('test')
-    assert store.read().paused is False
+    resumed_state = store.read()
+    assert resumed_state.paused is False
+    assert resumed_state.pause_reason == ''

--- a/demo/AGI-Alpha-Node-v0/tests/test_safety.py
+++ b/demo/AGI-Alpha-Node-v0/tests/test_safety.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+from alpha_node.config import AlphaNodeConfig
+from alpha_node.ens import ENSVerifier
+from alpha_node.governance import GovernanceController
+from alpha_node.safety import SafetyController
+from alpha_node.stake import StakeManager
+from alpha_node.state import StateStore
+
+
+def _build_env(tmp_path):
+    config = AlphaNodeConfig.load(Path('demo/AGI-Alpha-Node-v0/config.toml'))
+    state = StateStore(tmp_path / 'state.json')
+    stake_manager = StakeManager(config.stake, state, tmp_path / 'ledger.csv')
+    registry = tmp_path / 'ens_registry.csv'
+    registry.write_text(f"{config.ens.domain},{config.ens.owner_address}\n", encoding='utf-8')
+    ens_verifier = ENSVerifier(config.ens, registry)
+    governance = GovernanceController(config.governance, state)
+    safety = SafetyController(state, stake_manager, ens_verifier, governance)
+    return config, state, stake_manager, ens_verifier, governance, safety
+
+
+def test_guard_pauses_when_stake_missing(tmp_path):
+    _, state, _, _, _, safety = _build_env(tmp_path)
+    evaluation = safety.guard('activation', auto_resume=False)
+    assert evaluation.safe is False
+    paused_state = state.read()
+    assert paused_state.paused is True
+    assert paused_state.pause_reason.startswith('safety:activation:stake')
+    assert paused_state.last_safety_violation.startswith('safety:activation:stake')
+
+
+def test_guard_allows_operations_after_recovery(tmp_path):
+    config, state, stake_manager, _, _, safety = _build_env(tmp_path)
+    safety.guard('activation', auto_resume=False)
+    stake_manager.deposit(config.stake.minimum_stake)
+    evaluation = safety.guard('activation')
+    assert evaluation.safe is True
+    assert state.read().paused is False
+
+
+def test_manual_pause_is_respected(tmp_path):
+    config, state, stake_manager, _, governance, safety = _build_env(tmp_path)
+    stake_manager.deposit(config.stake.minimum_stake)
+    governance.pause_all('operator-request')
+    evaluation = safety.guard('run-cycle')
+    assert evaluation.safe is False
+    assert state.read().pause_reason == 'operator-request'
+    assert state.read().last_safety_violation == ''
+
+
+def test_conduct_drill_improves_antifragility(tmp_path):
+    _, state, stake_manager, _, _, safety = _build_env(tmp_path)
+    stake_manager.deposit(100)
+    before = state.read().antifragility_index
+    safety.conduct_drill()
+    after = state.read().antifragility_index
+    assert after >= before


### PR DESCRIPTION
## Summary
- add a dedicated `SafetyController` that enforces ENS, staking, and pause invariants and expose new safety/drill CLI commands
- wire safety state into the node runtime, Prometheus metrics, compliance tracking, and the operator runbook
- expand the automated test suite with safety-specific coverage and document the new operator workflow

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/AGI-Alpha-Node-v0/tests

------
https://chatgpt.com/codex/tasks/task_e_690354210b0c8333bd47b37e729d4960