### PR TITLE
Add owner reset workflow and human briefing output to day-one demo

### DIFF
--- a/demo/AGIJobs-Day-One-Utility-Benchmark/Makefile
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/Makefile
@@ -1,15 +1,15 @@
 PYTHON ?= python3
 STRATEGY ?= e2e
 
-.PHONY: deps bootstrap simulate e2e alphaevolve hgm trm omni owner-show owner-set owner-toggle list clean report ci verify
+.PHONY: deps bootstrap simulate e2e alphaevolve hgm trm omni owner-show owner-set owner-toggle owner-reset list clean report ci verify
 
 deps:
 	$(PYTHON) -m pip install --upgrade pip >/dev/null
 	$(PYTHON) -m pip install --quiet -r requirements.txt
 
 bootstrap:
-	@cp config/owner_controls.yaml config/owner_controls.yaml >/dev/null 2>&1 || true
-	@echo "Owner controls verified."
+	@cp config/owner_controls.defaults.yaml config/owner_controls.yaml >/dev/null 2>&1 || true
+	@echo "Owner controls restored from defaults."
 
 simulate: deps
 	$(PYTHON) run_demo.py simulate --strategy $(STRATEGY)
@@ -38,6 +38,9 @@ owner-set:
 
 owner-toggle:
 	$(PYTHON) run_demo.py owner --toggle-pause
+
+owner-reset:
+	$(PYTHON) run_demo.py owner --reset
 
 list:
 	$(PYTHON) run_demo.py list

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
@@ -45,6 +45,7 @@ full strength of **AGI Jobs v0 (v2)**.
    ```bash
    make owner-set KEY=platform_fee_bps VALUE=220
    make owner-toggle  # Pause/resume entire orchestration instantly
+   make owner-reset   # Restore the sovereign defaults in one command
    ```
 
 5. Serve the dashboard (optional):
@@ -104,6 +105,7 @@ mission metrics, and treasury analytics in a single cinematic surface.
 | `config/strategies.yaml` | Five iconic launch profiles (E2E, AlphaEvolve, HGM, TRM, OMNI). |
 | `config/rules.yaml` | Sentinel thresholds controlling launch approval. |
 | `config/owner_controls.yaml` | Owner-governed configuration (addresses, fees, overrides, pause switch). |
+| `config/owner_controls.defaults.yaml` | Canonical sovereign snapshot used for instant resets and CI bootstrapping. |
 | `contracts/v2/modules/DayOneUtilityController.sol` | Upgrade-ready solidity module mirroring the owner controls contract. |
 | `tests/test_demo_runner.py` | Pytest suite verifying guardrails, pausing, output artefacts. |
 
@@ -135,6 +137,10 @@ sequenceDiagram
 
 Every update triggers schema validation so a mis-typed value cannot compromise the
 pipeline.
+
+The command deck now ships with an instant rollback lever via `make owner-reset`
+and enforces mainnet-grade address validation, guaranteeing that only legitimate
+EVM owner/treasury pairs reach the control plane.
 
 ---
 
@@ -222,6 +228,14 @@ make verify  # Installs deps & runs pytest
 
 `pytest` covers pausing behaviour, guardrail correctness, HTML export, and the
 owner console.
+
+```bash
+python3 run_demo.py simulate --strategy e2e --format human
+```
+
+Pair the JSON export with a human-readable battle-briefing sized for founders.
+The command-line summary surfaces guardrail verdicts, treasury outcomes, and
+direct links to the generated dashboard without requiring any parsing tools.
 
 ---
 

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/config/owner_controls.defaults.yaml
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/config/owner_controls.defaults.yaml
@@ -1,0 +1,6 @@
+owner_address: "0x9F4c1dEFAa7d9f4f24B495C1b8E3aD4f5cB52173"
+treasury_address: "0x4C90d1C8F83F0b2c3d592BFb3E88e3a092f9a912"
+platform_fee_bps: 180
+latency_threshold_override_bps: null
+paused: false
+narrative: "Launch-ready orchestrator with audit-grade guardrails and sovereign owner command deck."

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 import sys
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -69,3 +70,41 @@ def test_unknown_strategy_raises():
     orchestrator = _orchestrator()
     with pytest.raises(StrategyNotFoundError):
         orchestrator.simulate("unknown")
+
+
+def test_owner_reset_restores_defaults():
+    orchestrator = _orchestrator()
+    orchestrator.update_owner_control("platform_fee_bps", "240")
+    orchestrator.update_owner_control("owner_address", "0x" + "1" * 40)
+    orchestrator.update_owner_control("treasury_address", "0x" + "2" * 40)
+    orchestrator.update_owner_control("narrative", "Temporary narrative for reset check.")
+
+    snapshot = orchestrator.reset_owner_controls()
+
+    defaults_path = orchestrator.base_path / "config" / "owner_controls.defaults.yaml"
+    defaults_payload = yaml.safe_load(defaults_path.read_text(encoding="utf-8"))
+
+    for key in orchestrator.OWNER_SCHEMA.keys():
+        assert snapshot[key] == defaults_payload[key]
+
+    live_payload = yaml.safe_load(
+        (orchestrator.base_path / "config" / "owner_controls.yaml").read_text(encoding="utf-8")
+    )
+    for key in orchestrator.OWNER_SCHEMA.keys():
+        assert live_payload[key] == defaults_payload[key]
+
+
+def test_execute_human_format_summary():
+    orchestrator = _orchestrator()
+    payload, fmt = orchestrator.execute(["simulate", "--strategy", "e2e", "--format", "human"])
+    assert fmt == "human"
+    summary = payload["summary"]
+    assert "Strategy:" in summary
+    assert "Utility uplift" in summary
+    assert "Dashboard:" in summary
+
+
+def test_invalid_owner_address_rejected():
+    orchestrator = _orchestrator()
+    with pytest.raises(ValueError):
+        orchestrator.update_owner_control("owner_address", "invalid-address")


### PR DESCRIPTION
## Summary
- add a canonical owner control defaults file and Makefile reset target so non-technical operators can restore the day-one demo instantly
- extend the orchestrator with owner reset support, address validation, and an optional human-readable narrative summary for simulations
- document the new controls and harden coverage with pytest checks for reset, validation, and human summaries

## Testing
- make verify
- python3 run_demo.py simulate --strategy e2e --format human


------
https://chatgpt.com/codex/tasks/task_e_6903b732f1a48333b47cdd95da4d8398