### PR TITLE
Improve day-one utility demo CLI compatibility

### DIFF
--- a/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
@@ -23,7 +23,9 @@ full strength of **AGI Jobs v0 (v2)**.
 
    This installs dependencies, simulates the Day-One launch, writes JSON
    telemetry, exports a cinematic HTML dashboard (`out/dashboard_e2e.html`), and
-   renders a high-fidelity chart snapshot.
+   renders a high-fidelity chart snapshot. Operators who prefer direct Python
+   invocations can run `python3 run_demo.py --strategy e2e` or even the shorthand
+   `python3 run_demo.py e2e`; both map to the same sovereign simulation flow.
 
 3. Launch additional strategies to explore the expansion path:
 

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
@@ -7,7 +7,7 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from demo_runner import DayOneUtilityOrchestrator, DemoPausedError, StrategyNotFoundError
+from demo_runner import DayOneUtilityOrchestrator, DemoPausedError, StrategyNotFoundError, run_cli
 
 
 def _orchestrator() -> DayOneUtilityOrchestrator:
@@ -108,3 +108,19 @@ def test_invalid_owner_address_rejected():
     orchestrator = _orchestrator()
     with pytest.raises(ValueError):
         orchestrator.update_owner_control("owner_address", "invalid-address")
+
+
+def test_run_cli_strategy_flag_alias(monkeypatch):
+    base_path = Path(__file__).resolve().parents[1]
+    monkeypatch.chdir(base_path)
+    payload, fmt = run_cli(["--strategy", "alphaevolve"])
+    assert fmt == "json"
+    assert payload["strategy"] == "alphaevolve"
+
+
+def test_run_cli_positional_strategy(monkeypatch):
+    base_path = Path(__file__).resolve().parents[1]
+    monkeypatch.chdir(base_path)
+    payload, fmt = run_cli(["omni"])
+    assert fmt == "json"
+    assert payload["strategy"] == "omni"


### PR DESCRIPTION
## Summary
- allow the day-one utility demo CLI to accept legacy shorthand invocations and positional strategies
- document the direct Python entrypoints available to non-technical operators
- expand the pytest suite to cover the new CLI aliases

## Testing
- make -C demo/AGIJobs-Day-One-Utility-Benchmark verify

------
https://chatgpt.com/codex/tasks/task_e_6903be432f208333bf3854676e3ca995