### PR TITLE
Add utility guardrail override to day-one demo

### DIFF
--- a/.github/workflows/demo-day-one-utility-benchmark.yml
+++ b/.github/workflows/demo-day-one-utility-benchmark.yml
@@ -92,7 +92,7 @@ jobs:
           if not report['guardrail_pass']['utility_uplift']:
               raise SystemExit('utility guardrail must pass for e2e demo')
           html = (base / 'dashboard_e2e.html').read_text()
-          for snippet in ['Day-One Utility Benchmark', 'class="mermaid"', 'Owner Controls Snapshot']:
+          for snippet in ['Day-One Utility Benchmark', 'class="mermaid"', 'Owner Controls Snapshot', 'Utility Guardrail']:
               if snippet not in html:
                   raise SystemExit(f'missing dashboard snippet: {snippet}')
           PY

--- a/contracts/v2/modules/DayOneUtilityController.sol
+++ b/contracts/v2/modules/DayOneUtilityController.sol
@@ -9,28 +9,40 @@ import {Governable} from "../Governable.sol";
 contract DayOneUtilityController is Governable {
     uint256 public constant MAX_PLATFORM_FEE_BPS = 2_500;
     int256 public constant MIN_LATENCY_GUARD_BPS = -1_000;
+    int256 public constant MIN_UTILITY_GUARD_BPS = -1_000;
+    int256 public constant MAX_UTILITY_GUARD_BPS = 100_000;
 
     bool public paused;
     uint256 public platformFeeBps;
     int256 public latencyGuardBps;
+    int256 public utilityGuardBps;
     string public narrative;
 
     event PlatformFeeUpdated(uint256 previousFeeBps, uint256 newFeeBps);
     event LatencyGuardUpdated(int256 previousGuardBps, int256 newGuardBps);
+    event UtilityGuardUpdated(int256 previousGuardBps, int256 newGuardBps);
     event NarrativeUpdated(string previousNarrative, string newNarrative);
     event Paused();
     event Unpaused();
 
     error FeeOutOfRange(uint256 feeBps);
     error LatencyGuardTooLow(int256 guardBps);
+    error UtilityGuardOutOfRange(int256 guardBps);
     error AlreadyPaused();
     error AlreadyUnpaused();
 
-    constructor(address governance, uint256 initialFeeBps, int256 initialLatencyGuardBps, string memory initialNarrative)
+    constructor(
+        address governance,
+        uint256 initialFeeBps,
+        int256 initialLatencyGuardBps,
+        int256 initialUtilityGuardBps,
+        string memory initialNarrative
+    )
         Governable(governance)
     {
         _setPlatformFee(initialFeeBps);
         _setLatencyGuard(initialLatencyGuardBps);
+        _setUtilityGuard(initialUtilityGuardBps);
         narrative = initialNarrative;
     }
 
@@ -44,6 +56,12 @@ contract DayOneUtilityController is Governable {
         int256 previous = latencyGuardBps;
         _setLatencyGuard(newGuardBps);
         emit LatencyGuardUpdated(previous, newGuardBps);
+    }
+
+    function setUtilityGuard(int256 newGuardBps) external onlyGovernance {
+        int256 previous = utilityGuardBps;
+        _setUtilityGuard(newGuardBps);
+        emit UtilityGuardUpdated(previous, newGuardBps);
     }
 
     function updateNarrative(string calldata newNarrative) external onlyGovernance {
@@ -67,9 +85,9 @@ contract DayOneUtilityController is Governable {
     function snapshot()
         external
         view
-        returns (bool isPaused, uint256 feeBps, int256 guardrailBps, string memory currentNarrative)
+        returns (bool isPaused, uint256 feeBps, int256 latencyGuard, int256 utilityGuard, string memory currentNarrative)
     {
-        return (paused, platformFeeBps, latencyGuardBps, narrative);
+        return (paused, platformFeeBps, latencyGuardBps, utilityGuardBps, narrative);
     }
 
     function _setPlatformFee(uint256 newFeeBps) internal {
@@ -80,5 +98,12 @@ contract DayOneUtilityController is Governable {
     function _setLatencyGuard(int256 newGuardBps) internal {
         if (newGuardBps < MIN_LATENCY_GUARD_BPS) revert LatencyGuardTooLow(newGuardBps);
         latencyGuardBps = newGuardBps;
+    }
+
+    function _setUtilityGuard(int256 newGuardBps) internal {
+        if (newGuardBps < MIN_UTILITY_GUARD_BPS || newGuardBps > MAX_UTILITY_GUARD_BPS) {
+            revert UtilityGuardOutOfRange(newGuardBps);
+        }
+        utilityGuardBps = newGuardBps;
     }
 }

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/Makefile
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/Makefile
@@ -33,7 +33,7 @@ owner-show:
 	$(PYTHON) run_demo.py owner --show
 
 owner-set:
-	@if [ -z "$(KEY)" ]; then echo "Usage: make owner-set KEY=platform_fee_bps VALUE=200"; exit 1; fi
+	@if [ -z "$(KEY)" ]; then echo "Usage: make owner-set KEY=utility_threshold_override_bps VALUE=900"; exit 1; fi
 	$(PYTHON) run_demo.py owner --set $(KEY) "$(VALUE)"
 
 owner-toggle:

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
@@ -46,6 +46,7 @@ full strength of **AGI Jobs v0 (v2)**.
 
    ```bash
    make owner-set KEY=platform_fee_bps VALUE=220
+   make owner-set KEY=utility_threshold_override_bps VALUE=900
    make owner-toggle  # Pause/resume entire orchestration instantly
    make owner-reset   # Restore the sovereign defaults in one command
    ```
@@ -133,12 +134,14 @@ sequenceDiagram
 | Control | Description |
 | ------- | ----------- |
 | `platform_fee_bps` | Instant revenue tuning (0–2500 bps). Applied on every run. |
+| `utility_threshold_override_bps` | Optional override of the minimum utility uplift guardrail (basis points). |
 | `latency_threshold_override_bps` | Optional override of latency guardrail from the owner console. |
 | `paused` | Hard stop for the entire orchestrator. When `true`, simulations refuse to run. |
 | `narrative` | Text displayed in the dashboard hero, enabling storytelling updates without deployments. |
 
 Every update triggers schema validation so a mis-typed value cannot compromise the
-pipeline.
+pipeline. Utility guardrails can now be tightened or relaxed live without touching
+YAML by adjusting `utility_threshold_override_bps`.
 
 The command deck now ships with an instant rollback lever via `make owner-reset`
 and enforces mainnet-grade address validation, guaranteeing that only legitimate
@@ -198,6 +201,7 @@ stateDiagram-v2
     Paused --> Active: owner.togglePause(false)
     Active --> Active: owner.setPlatformFee(bps)
     Active --> Active: owner.setLatencyGuard(bps)
+    Active --> Active: owner.setUtilityGuard(bps)
     Active --> Active: owner.updateNarrative()
 ```
 

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/config/owner_controls.defaults.yaml
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/config/owner_controls.defaults.yaml
@@ -2,5 +2,6 @@ owner_address: "0x9F4c1dEFAa7d9f4f24B495C1b8E3aD4f5cB52173"
 treasury_address: "0x4C90d1C8F83F0b2c3d592BFb3E88e3a092f9a912"
 platform_fee_bps: 180
 latency_threshold_override_bps: null
+utility_threshold_override_bps: null
 paused: false
 narrative: "Launch-ready orchestrator with audit-grade guardrails and sovereign owner command deck."

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/config/owner_controls.yaml
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/config/owner_controls.yaml
@@ -2,5 +2,6 @@ owner_address: "0x9F4c1dEFAa7d9f4f24B495C1b8E3aD4f5cB52173"
 treasury_address: "0x4C90d1C8F83F0b2c3d592BFb3E88e3a092f9a912"
 platform_fee_bps: 180
 latency_threshold_override_bps: null
+utility_threshold_override_bps: null
 paused: false
 narrative: "Launch-ready orchestrator with audit-grade guardrails and sovereign owner command deck."

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/web/index.html
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/web/index.html
@@ -166,8 +166,14 @@
         if (typeof metrics.utility_uplift === 'number') {
           blocks.push({ label: 'Utility Uplift', value: (metrics.utility_uplift * 100).toFixed(2) + '%' });
         }
+        if (data.rules && typeof data.rules.utility_uplift_threshold === 'number') {
+          blocks.push({ label: 'Utility Guardrail', value: (data.rules.utility_uplift_threshold * 100).toFixed(2) + '%' });
+        }
         if (typeof metrics.latency_delta === 'number') {
           blocks.push({ label: 'Latency Delta', value: (metrics.latency_delta * 100).toFixed(2) + '%' });
+        }
+        if (data.rules && typeof data.rules.max_latency_delta === 'number') {
+          blocks.push({ label: 'Latency Guardrail', value: (data.rules.max_latency_delta * 100).toFixed(2) + '%' });
         }
         if (metrics.candidate && typeof metrics.candidate.utility === 'number') {
           blocks.push({ label: 'Candidate Utility', value: metrics.candidate.utility.toFixed(2) });
@@ -177,6 +183,16 @@
         }
         if (data.strategy_profile && data.strategy_profile.reliability_score) {
           blocks.push({ label: 'Reliability Score', value: (data.strategy_profile.reliability_score * 100).toFixed(2) });
+        }
+        if (data.owner_controls && data.owner_controls.utility_threshold_override_bps !== undefined) {
+          const override = data.owner_controls.utility_threshold_override_bps;
+          const display = override === null ? '—' : `${override} bps`;
+          blocks.push({ label: 'Utility Override', value: display });
+        }
+        if (data.owner_controls && data.owner_controls.latency_threshold_override_bps !== undefined) {
+          const override = data.owner_controls.latency_threshold_override_bps;
+          const display = override === null ? '—' : `${override} bps`;
+          blocks.push({ label: 'Latency Override', value: display });
         }
         metricsEl.innerHTML = blocks.map(block => `
           <div class="metric">


### PR DESCRIPTION
## Summary
- allow the day-one demo owner console to override the utility uplift guardrail with schema validation and dashboard visibility
- surface the active utility guard thresholds throughout the README, HTML viewer, CI workflow, and pytest suite
- mirror the new guardrail in the DayOneUtilityController solidity module so governance can manage it on-chain

## Testing
- make -C demo/AGIJobs-Day-One-Utility-Benchmark e2e
- make -C demo/AGIJobs-Day-One-Utility-Benchmark verify
- npx hardhat compile --force


------
https://chatgpt.com/codex/tasks/task_e_6903c8a0317c83339b6baa4bfa6c2ecb