### PR TITLE
Add day-one scoreboard orchestration

### DIFF
--- a/.github/workflows/demo-day-one-utility-benchmark.yml
+++ b/.github/workflows/demo-day-one-utility-benchmark.yml
@@ -71,6 +71,10 @@ jobs:
           python3 run_demo.py owner --toggle-pause
           python3 run_demo.py owner --toggle-pause
 
+      - name: Generate scoreboard
+        working-directory: demo/AGIJobs-Day-One-Utility-Benchmark
+        run: python3 run_demo.py scoreboard
+
       - name: Validate artefacts
         run: |
           python3 - <<'PY'
@@ -82,6 +86,8 @@ jobs:
               'dashboard_e2e.html',
               'snapshot_e2e.png',
               'owner_controls_snapshot.json',
+              'scoreboard.json',
+              'scoreboard.html',
           ]
           for name in required:
               path = base / name
@@ -95,6 +101,16 @@ jobs:
           for snippet in ['Day-One Utility Benchmark', 'class="mermaid"', 'Owner Controls Snapshot', 'Utility Guardrail']:
               if snippet not in html:
                   raise SystemExit(f'missing dashboard snippet: {snippet}')
+
+          scoreboard = json.loads((base / 'scoreboard.json').read_text())
+          if scoreboard.get('type') != 'scoreboard':
+              raise SystemExit('scoreboard.json missing type=scoreboard')
+          if 'leaders' not in scoreboard:
+              raise SystemExit('scoreboard leaders missing')
+          board_html = (base / 'scoreboard.html').read_text()
+          for snippet in ['Day-One Utility Scoreboard', 'class="mermaid"', 'Strategy Leaderboard']:
+              if snippet not in board_html:
+                  raise SystemExit(f'missing scoreboard snippet: {snippet}')
           PY
 
       - name: Run pytest

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/Makefile
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= python3
 STRATEGY ?= e2e
 
-.PHONY: deps bootstrap simulate e2e alphaevolve hgm trm omni owner-show owner-set owner-toggle owner-reset list clean report ci verify
+.PHONY: deps bootstrap simulate e2e alphaevolve hgm trm omni scoreboard owner-show owner-set owner-toggle owner-reset list clean report ci verify
 
 deps:
 	$(PYTHON) -m pip install --upgrade pip >/dev/null
@@ -28,6 +28,9 @@ trm: simulate
 
 omni: STRATEGY := omni
 omni: simulate
+
+scoreboard: deps
+	$(PYTHON) run_demo.py scoreboard
 
 owner-show:
 	$(PYTHON) run_demo.py owner --show
@@ -58,4 +61,5 @@ ci: deps
 	$(PYTHON) run_demo.py simulate --strategy e2e
 	$(PYTHON) run_demo.py simulate --strategy alphaevolve
 	$(PYTHON) run_demo.py simulate --strategy hgm
+	$(PYTHON) run_demo.py scoreboard
 	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PYTHON) -m pytest -q

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
@@ -51,7 +51,17 @@ full strength of **AGI Jobs v0 (v2)**.
    make owner-reset   # Restore the sovereign defaults in one command
    ```
 
-5. Serve the dashboard (optional):
+5. Generate the omni scoreboard:
+
+   ```bash
+   make scoreboard
+   ```
+
+   This crowns utility/treasury/reliability leaders, emits `out/scoreboard.json`,
+   and renders a mermaid-rich command-room overview at
+   `out/scoreboard.html`.
+
+6. Serve the dashboard (optional):
 
    ```bash
    python3 -m http.server --directory out 9000
@@ -157,6 +167,7 @@ Running `make e2e` produces:
 - `out/dashboard_e2e.html` — mermaid-enhanced cinematic dashboard
 - `out/snapshot_e2e.png` — baseline vs candidate comparison chart
 - `out/owner_controls_snapshot.json` — owner snapshot for audit trails
+- `out/scoreboard.json` & `out/scoreboard.html` — cross-strategy leaderboard with live mermaid intelligence
 
 ![Dashboard preview](out/snapshot_e2e.png)
 
@@ -217,6 +228,7 @@ protects this demo. It:
 
 1. Installs Python dependencies via the Makefile.
 2. Runs the orchestrator across multiple strategies.
+3. Generates the multi-strategy scoreboard to guarantee leaderboard fidelity.
 3. Validates output artefacts (JSON + dashboard).
 4. Executes Pytest for regression coverage.
 5. Exercises owner commands (set + toggle) to guarantee sovereignty features.

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
@@ -107,6 +107,24 @@ def test_owner_utility_guardrail_override():
     assert report["guardrail_pass"]["utility_uplift"] is False
 
 
+def test_scoreboard_generates_dashboard():
+    orchestrator = _orchestrator()
+    scoreboard = orchestrator.scoreboard()
+
+    scoreboard_path = orchestrator.output_dir / "scoreboard.json"
+    assert scoreboard_path.exists()
+    payload = json.loads(scoreboard_path.read_text(encoding="utf-8"))
+    assert payload["type"] == "scoreboard"
+    assert "e2e" in payload["strategies"]
+    assert payload["leaders"]["utility_uplift"]["title"]
+
+    html_path = Path(scoreboard["outputs"]["dashboard"])
+    assert html_path.exists()
+    html = html_path.read_text(encoding="utf-8")
+    assert "Day-One Utility Scoreboard" in html
+    assert html.count('class="mermaid"') >= 3
+
+
 def test_execute_human_format_summary():
     orchestrator = _orchestrator()
     payload, fmt = orchestrator.execute(["simulate", "--strategy", "e2e", "--format", "human"])

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/web/index.html
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/web/index.html
@@ -125,6 +125,7 @@
           <option value="../out/report_hgm.json">Huxley-Gödel Machine</option>
           <option value="../out/report_trm.json">Total Revenue Maximizer</option>
           <option value="../out/report_omni.json">Omni-Concord Infinity Launch</option>
+          <option value="../out/scoreboard.json">Multi-Strategy Scoreboard</option>
         </select>
       </section>
       <section class="panel">
@@ -161,6 +162,58 @@
       }
 
       function renderMetrics(data) {
+        if (data.type === 'scoreboard') {
+          const blocks = [];
+          const leaders = data.leaders || {};
+          if (leaders.utility_uplift && leaders.utility_uplift.value) {
+            const leader = leaders.utility_uplift;
+            blocks.push({
+              label: 'Utility Leader',
+              value: `${leader.title} (${(leader.value.utility_uplift * 100).toFixed(2)}%)`
+            });
+          }
+          if (leaders.owner_treasury && leaders.owner_treasury.value) {
+            const leader = leaders.owner_treasury;
+            blocks.push({
+              label: 'Treasury Leader',
+              value: `${leader.title} (${leader.value.owner_treasury.toFixed(2)})`
+            });
+          }
+          if (leaders.reliability && leaders.reliability.value) {
+            const leader = leaders.reliability;
+            blocks.push({
+              label: 'Reliability Leader',
+              value: `${leader.title} (${(leader.value.reliability_score * 100).toFixed(2)}%)`
+            });
+          }
+          if (Array.isArray(data.guardrail_failures)) {
+            const failures = data.guardrail_failures.length;
+            const noun = failures === 1 ? 'strategy' : 'strategies';
+            blocks.push({ label: 'Guardrail Alerts', value: failures === 0 ? 'All Clear' : `${failures} ${noun}` });
+          }
+          if (data.aggregates) {
+            blocks.push({
+              label: 'Total Owner Treasury',
+              value: data.aggregates.total_owner_treasury.toFixed(2)
+            });
+            blocks.push({
+              label: 'Avg Utility Uplift',
+              value: (data.aggregates.average_utility_uplift * 100).toFixed(2) + '%'
+            });
+            blocks.push({
+              label: 'Avg Latency Delta',
+              value: (data.aggregates.average_latency_delta * 100).toFixed(2) + '%'
+            });
+          }
+          metricsEl.innerHTML = blocks.map(block => `
+            <div class="metric">
+              <h3>${block.label}</h3>
+              <p>${block.value}</p>
+            </div>
+          `).join('');
+          return;
+        }
+
         const metrics = data.metrics || {};
         const blocks = [];
         if (typeof metrics.utility_uplift === 'number') {


### PR DESCRIPTION
## Summary
- add a multi-strategy scoreboard orchestration path to the day-one demo, complete with dashboard rendering and mermaid intelligence
- expose the scoreboard through the CLI, Makefile, README, and web viewer so non-technical operators can crown leaders instantly
- extend automated coverage in pytest and GitHub Actions to validate the new scoreboard artefacts on every run

## Testing
- make scoreboard
- make verify

------
https://chatgpt.com/codex/tasks/task_e_6903d21e6d088333a489cbf4cdaa343c