### PR TITLE
Enhance day-one utility analytics with latency P95 insights

### DIFF
--- a/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
@@ -49,6 +49,7 @@ def test_simulate_e2e_outputs():
     payload = json.loads(report_path.read_text(encoding="utf-8"))
     assert payload["metrics"]["candidate"]["platform_fee"] > 0
     assert payload["metrics"]["candidate"]["treasury_bonus"] >= 0
+    assert payload["metrics"]["latency_p95"] > 0
 
 
 def test_pause_blocks_simulation():
@@ -123,6 +124,12 @@ def test_scoreboard_generates_dashboard():
     html = html_path.read_text(encoding="utf-8")
     assert "Day-One Utility Scoreboard" in html
     assert html.count('class="mermaid"') >= 3
+    assert "P95 Latency" in html
+
+    assert "average_latency_p95" in payload["aggregates"]
+    assert payload["metrics"]["best_latency_p95"] == pytest.approx(
+        payload["leaders"]["latency_p95"]["value"]["latency_p95"]
+    )
 
 
 def test_execute_human_format_summary():
@@ -133,6 +140,7 @@ def test_execute_human_format_summary():
     assert "Strategy:" in summary
     assert "Utility uplift" in summary
     assert "Dashboard:" in summary
+    assert "P95 latency" in summary
 
 
 def test_invalid_owner_address_rejected():

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/web/index.html
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/web/index.html
@@ -186,6 +186,13 @@
               value: `${leader.title} (${(leader.value.reliability_score * 100).toFixed(2)}%)`
             });
           }
+          if (leaders.latency_p95 && leaders.latency_p95.value) {
+            const leader = leaders.latency_p95;
+            blocks.push({
+              label: 'P95 Latency Leader',
+              value: `${leader.title} (${leader.value.latency_p95.toFixed(3)}s)`
+            });
+          }
           if (Array.isArray(data.guardrail_failures)) {
             const failures = data.guardrail_failures.length;
             const noun = failures === 1 ? 'strategy' : 'strategies';
@@ -203,6 +210,16 @@
             blocks.push({
               label: 'Avg Latency Delta',
               value: (data.aggregates.average_latency_delta * 100).toFixed(2) + '%'
+            });
+            blocks.push({
+              label: 'Avg Latency P95',
+              value: data.aggregates.average_latency_p95.toFixed(3) + 's'
+            });
+          }
+          if (data.metrics && typeof data.metrics.best_latency_p95 === 'number') {
+            blocks.push({
+              label: 'Best P95 Latency',
+              value: data.metrics.best_latency_p95.toFixed(3) + 's'
             });
           }
           metricsEl.innerHTML = blocks.map(block => `
@@ -224,6 +241,9 @@
         }
         if (typeof metrics.latency_delta === 'number') {
           blocks.push({ label: 'Latency Delta', value: (metrics.latency_delta * 100).toFixed(2) + '%' });
+        }
+        if (typeof metrics.latency_p95 === 'number') {
+          blocks.push({ label: 'Latency P95', value: metrics.latency_p95.toFixed(3) + 's' });
         }
         if (data.rules && typeof data.rules.max_latency_delta === 'number') {
           blocks.push({ label: 'Latency Guardrail', value: (data.rules.max_latency_delta * 100).toFixed(2) + '%' });


### PR DESCRIPTION
## Summary
- surface latency p95 telemetry throughout the day-one orchestrator dashboards and scoreboard JSON
- extend the web command deck to highlight new latency leaders and aggregated p95 insights
- expand the regression suite to enforce the richer analytics and human summary output

## Testing
- make e2e
- make scoreboard
- make verify
- python3 run_demo.py simulate --strategy e2e --format human

------
https://chatgpt.com/codex/tasks/task_e_6903eef7f9208333b0b074a0768ae4e4