### PR TITLE
Ensure AlphaEvolve demo tests ignore external pytest plugins

### DIFF
--- a/demo/AlphaEvolve-v0/tests/conftest.py
+++ b/demo/AlphaEvolve-v0/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest configuration for AlphaEvolve demo tests.
+
+We explicitly disable auto-loading of third-party pytest plugins to
+prevent web3.tools extras from attempting to import optional Ethereum
+packages that are not part of the demo runtime. This keeps the unit
+tests hermetic and ensures non-technical operators can run the demo's
+verification suite without additional dependencies.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")


### PR DESCRIPTION
## Summary
- add a dedicated pytest conftest in the AlphaEvolve demo test suite to disable auto-loading of external plugins
- document the rationale so non-technical operators can run the verification suite without extra dependencies

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/AlphaEvolve-v0/tests

------
https://chatgpt.com/codex/tasks/task_e_6903f477842483339d858ad5813e38fe