### PR TITLE
Extend day-one controller owner controls

### DIFF
--- a/contracts/v2/modules/DayOneUtilityController.sol
+++ b/contracts/v2/modules/DayOneUtilityController.sol
@@ -17,6 +17,8 @@ contract DayOneUtilityController is Governable {
     int256 public latencyGuardBps;
     int256 public utilityGuardBps;
     string public narrative;
+    address public ownerAccount;
+    address public treasuryAccount;
 
     event PlatformFeeUpdated(uint256 previousFeeBps, uint256 newFeeBps);
     event LatencyGuardUpdated(int256 previousGuardBps, int256 newGuardBps);
@@ -24,6 +26,8 @@ contract DayOneUtilityController is Governable {
     event NarrativeUpdated(string previousNarrative, string newNarrative);
     event Paused();
     event Unpaused();
+    event OwnerAccountUpdated(address previousOwnerAccount, address newOwnerAccount);
+    event TreasuryAccountUpdated(address previousTreasuryAccount, address newTreasuryAccount);
 
     error FeeOutOfRange(uint256 feeBps);
     error LatencyGuardTooLow(int256 guardBps);
@@ -33,6 +37,8 @@ contract DayOneUtilityController is Governable {
 
     constructor(
         address governance,
+        address initialOwnerAccount,
+        address initialTreasuryAccount,
         uint256 initialFeeBps,
         int256 initialLatencyGuardBps,
         int256 initialUtilityGuardBps,
@@ -40,6 +46,8 @@ contract DayOneUtilityController is Governable {
     )
         Governable(governance)
     {
+        _setOwnerAccount(initialOwnerAccount);
+        _setTreasuryAccount(initialTreasuryAccount);
         _setPlatformFee(initialFeeBps);
         _setLatencyGuard(initialLatencyGuardBps);
         _setUtilityGuard(initialUtilityGuardBps);
@@ -70,6 +78,18 @@ contract DayOneUtilityController is Governable {
         emit NarrativeUpdated(previous, newNarrative);
     }
 
+    function setOwnerAccount(address newOwnerAccount) external onlyGovernance {
+        address previous = ownerAccount;
+        _setOwnerAccount(newOwnerAccount);
+        emit OwnerAccountUpdated(previous, newOwnerAccount);
+    }
+
+    function setTreasuryAccount(address newTreasuryAccount) external onlyGovernance {
+        address previous = treasuryAccount;
+        _setTreasuryAccount(newTreasuryAccount);
+        emit TreasuryAccountUpdated(previous, newTreasuryAccount);
+    }
+
     function togglePause(bool shouldPause) external onlyGovernance {
         if (shouldPause) {
             if (paused) revert AlreadyPaused();
@@ -85,9 +105,25 @@ contract DayOneUtilityController is Governable {
     function snapshot()
         external
         view
-        returns (bool isPaused, uint256 feeBps, int256 latencyGuard, int256 utilityGuard, string memory currentNarrative)
+        returns (
+            bool isPaused,
+            uint256 feeBps,
+            int256 latencyGuard,
+            int256 utilityGuard,
+            string memory currentNarrative,
+            address ownerAccount_,
+            address treasuryAccount_
+        )
     {
-        return (paused, platformFeeBps, latencyGuardBps, utilityGuardBps, narrative);
+        return (
+            paused,
+            platformFeeBps,
+            latencyGuardBps,
+            utilityGuardBps,
+            narrative,
+            ownerAccount,
+            treasuryAccount
+        );
     }
 
     function _setPlatformFee(uint256 newFeeBps) internal {
@@ -105,5 +141,15 @@ contract DayOneUtilityController is Governable {
             revert UtilityGuardOutOfRange(newGuardBps);
         }
         utilityGuardBps = newGuardBps;
+    }
+
+    function _setOwnerAccount(address newOwnerAccount) internal {
+        if (newOwnerAccount == address(0)) revert ZeroAddress();
+        ownerAccount = newOwnerAccount;
+    }
+
+    function _setTreasuryAccount(address newTreasuryAccount) internal {
+        if (newTreasuryAccount == address(0)) revert ZeroAddress();
+        treasuryAccount = newTreasuryAccount;
     }
 }

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
@@ -202,8 +202,9 @@ Omni-Concord Launch   :milestone, 0, 1
 ## Smart contract mirror
 
 To anchor the demo in mainnet-grade reality, `contracts/v2/modules/DayOneUtilityController.sol`
-implements the same controls as the CLI. Owners can update fees, guardrails, and
-narratives, plus pause/resume the system through a timelock-governed surface.
+implements the same controls as the CLI. Owners can update fees, guardrails,
+narratives, mapped owner / treasury accounts, plus pause/resume the system
+through a timelock-governed surface.
 
 ```mermaid
 stateDiagram-v2
@@ -214,10 +215,23 @@ stateDiagram-v2
     Active --> Active: owner.setLatencyGuard(bps)
     Active --> Active: owner.setUtilityGuard(bps)
     Active --> Active: owner.updateNarrative()
+    Active --> Active: owner.setOwnerAccount(address)
+    Active --> Active: owner.setTreasuryAccount(address)
 ```
 
 Compile or test with your existing Foundry/Hardhat stack — no extra wiring is
 required.
+
+**Owner surface capabilities**
+
+- `setPlatformFee(uint256)` — calibrate platform revenue share in basis points.
+- `setLatencyGuard(int256)` / `setUtilityGuard(int256)` — tune guardrail gates in
+  basis points, mirrored by the CLI overrides.
+- `setOwnerAccount(address)` / `setTreasuryAccount(address)` — mirror the demo
+  owner + treasury handles on-chain for analytics + payout routing.
+- `updateNarrative(string)` — refreshes the storytelling headline for
+  downstream dashboards.
+- `togglePause(bool)` — instant kill-switch + resume without redeploying.
 
 ---
 


### PR DESCRIPTION
## Summary
- extend the day-one utility controller module with explicit owner and treasury account storage, setter events, and expanded snapshot output
- document the new owner surface capabilities in the day-one utility benchmark README, including mermaid state updates

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q
- python3 - <<'PY' ... (solcx compile of DayOneUtilityController)


------
https://chatgpt.com/codex/tasks/task_e_6903f44d10ec83338b3ad36dfcf34349