### PR TITLE
Add hermetic AlphaEvolve test runner

### DIFF
--- a/demo/AlphaEvolve-v0/README.md
+++ b/demo/AlphaEvolve-v0/README.md
@@ -58,3 +58,13 @@ flowchart TD
 - **Economic Singularity Engine**: Demonstrates a market optimizer capable of compounding improvements beyond conventional operational limits.
 
 See [`alphaevolve_runner.py`](alphaevolve_runner.py) and the `alphaevolve/` package for implementation details.
+
+## Verification Suite
+
+Run the hermetic AlphaEvolve tests with the dedicated runner so that pytest disables external plugin auto-discovery before initialisation:
+
+```bash
+python demo/AlphaEvolve-v0/tests/run_demo_tests.py
+```
+
+Additional arguments are forwarded directly to pytest, e.g. `python demo/AlphaEvolve-v0/tests/run_demo_tests.py -k trade_flow`.

--- a/demo/AlphaEvolve-v0/tests/conftest.py
+++ b/demo/AlphaEvolve-v0/tests/conftest.py
@@ -1,14 +1,10 @@
 """Pytest configuration for AlphaEvolve demo tests.
 
-We explicitly disable auto-loading of third-party pytest plugins to
-prevent web3.tools extras from attempting to import optional Ethereum
-packages that are not part of the demo runtime. This keeps the unit
-tests hermetic and ensures non-technical operators can run the demo's
-verification suite without additional dependencies.
+The AlphaEvolve demo test runner (`run_demo_tests.py`) ensures
+`PYTEST_DISABLE_PLUGIN_AUTOLOAD` is set *before* pytest initialises so that
+third-party plugins installed globally do not interfere with the suite.
+This module stays intentionally minimal; shared fixtures for the demo should
+be defined here.
 """
 
 from __future__ import annotations
-
-import os
-
-os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")

--- a/demo/AlphaEvolve-v0/tests/run_demo_tests.py
+++ b/demo/AlphaEvolve-v0/tests/run_demo_tests.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Dedicated entry point that runs the AlphaEvolve demo tests hermetically."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Execute pytest with plugin auto-discovery disabled.
+
+    The AlphaEvolve demo depends solely on the repository's pinned Python
+    requirements. Some globally installed pytest plugins attempt to import
+    optional third-party stacks (for example, Ethereum toolchains) that are
+    outside the demo's scope. To provide a turnkey experience for operators,
+    we disable pytest's entry-point auto discovery here *before* importing the
+    pytest package. This mirrors the manual command
+    ``PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/AlphaEvolve-v0/tests``
+    while sparing operators from environment fiddling.
+    """
+
+    os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+
+    try:
+        import pytest
+    except ModuleNotFoundError as exc:  # pragma: no cover - surfaced to operators
+        raise SystemExit(
+            "pytest is required to run the AlphaEvolve demo test suite. "
+            "Install development dependencies via `pip install -r requirements-python.txt`."
+        ) from exc
+
+    tests_dir = pathlib.Path(__file__).resolve().parent
+    args = argv if argv is not None else sys.argv[1:]
+    return pytest.main([str(tests_dir), *args])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dedicated AlphaEvolve test runner that sets PYTEST_DISABLE_PLUGIN_AUTOLOAD before importing pytest
- document the entry point so operators invoke the suite without leaking external plugins
- clean up the conftest stub now that the environment guard lives in the runner

## Testing
- python demo/AlphaEvolve-v0/tests/run_demo_tests.py --collect-only

------
https://chatgpt.com/codex/tasks/task_e_6903f5a617b483338171c878892c0a8e