### PR TITLE
Add CI v2 status artefact for branch protection audits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -915,6 +915,7 @@ jobs:
         run: |
           node <<'NODE'
           const fs = require('fs');
+          const path = require('path');
           const needs = JSON.parse(process.env.NEEDS_CONTEXT);
           const prettyNames = {
             lint: 'Lint & static checks',
@@ -937,6 +938,7 @@ jobs:
           };
           const lines = ['# AGI Jobs v0 — CI v2 status', '', '| Job | Result |', '| --- | --- |'];
           let failed = false;
+          const jobSummaries = [];
           for (const [jobId, info] of Object.entries(needs)) {
             const status = (info.result || 'unknown').toUpperCase();
             const label = prettyNames[jobId] || jobId;
@@ -944,13 +946,44 @@ jobs:
               failed = true;
             }
             lines.push(`| ${label} | ${status} |`);
+            jobSummaries.push({
+              id: jobId,
+              label,
+              result: info.result || 'unknown',
+              conclusion: info.conclusion || null,
+              url: info.url || null
+            });
           }
-          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
+          const markdown = lines.join('\n') + '\n';
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown);
+
+          const outputDir = path.join('reports', 'ci');
+          fs.mkdirSync(outputDir, { recursive: true });
+          fs.writeFileSync(path.join(outputDir, 'status.md'), markdown, 'utf8');
+          const statusPayload = {
+            generatedAt: new Date().toISOString(),
+            workflow: process.env.GITHUB_WORKFLOW,
+            runId: process.env.GITHUB_RUN_ID,
+            runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+            jobs: jobSummaries
+          };
+          fs.writeFileSync(
+            path.join(outputDir, 'status.json'),
+            JSON.stringify(statusPayload, null, 2) + '\n',
+            'utf8'
+          );
+
           if (failed) {
             console.error('One or more CI jobs failed.');
             process.exit(1);
           }
           NODE
+      - name: Upload CI status artefact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ci-summary
+          path: reports/ci
 
   invariants:
     name: Invariant tests

--- a/docs/ci-v2-branch-protection-checklist.md
+++ b/docs/ci-v2-branch-protection-checklist.md
@@ -65,6 +65,8 @@ gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled
 2. Verify the `CI summary` job lists every upstream job (Lint, Tests, Foundry, Coverage) with matching outcomes.
 3. Confirm the job is marked as **Required** in the run header. If it is missing, update branch protection immediately and re-run the workflow to refresh the badge.
 4. When troubleshooting, re-run the workflow with **Re-run failed jobs** so historical logs remain intact for incident reviews.
+5. Download the `ci-summary` artifact and archive `reports/ci/status.md` plus `status.json` with the change ticket; these files
+   mirror the on-screen table and prove which jobs were evaluated.【F:.github/workflows/ci.yml†L905-L953】
 
 ### 4. Double-check companion workflows
 

--- a/docs/v2-ci-operations.md
+++ b/docs/v2-ci-operations.md
@@ -85,7 +85,9 @@ Keep the rest of the release surface visible by marking the following workflows 
 
 1. Confirm that the **Checks** tab shows all five required `ci (v2)` contexts above plus the companion workflows you have marked as required.
 2. Inspect the **Artifacts** section for `coverage-lcov` when coverage needs auditing.
-3. Review the `CI summary` job output for a condensed Markdown table of job results.
+3. Review the `CI summary` job output for a condensed Markdown table of job results. The job now also archives the same table as
+   `reports/ci/status.md` together with a machine-readable `status.json`, both available in the `ci-summary` artifact for
+   compliance records.【F:.github/workflows/ci.yml†L905-L953】
 4. When re-running failed jobs, choose **Re-run failed jobs** to keep historical logs.
 5. If a dependent job unexpectedly skips, inspect the workflow definition to confirm the `if: ${{ always() }}` guard is still present.
 


### PR DESCRIPTION
## Summary
- extend the `ci (v2)` summary job to emit a machine-readable report and upload it as an artifact for auditors
- document the new `ci-summary` bundle in the CI v2 operations and branch protection guides so non-technical owners can archive it

## Testing
- node <<'NODE' ... (failure scenario to confirm the gate still halts on red jobs)
- node <<'NODE' ... (success scenario to confirm the artifact files are written)


------
https://chatgpt.com/codex/tasks/task_e_6904b451f9e88333a64d696a6bb70f5d