### PR TITLE
docs: refresh operator green-path runbook

### DIFF
--- a/OperatorRunbook.md
+++ b/OperatorRunbook.md
@@ -1,6 +1,6 @@
 # AGI Jobs v0 (v2) Operator Runbook — Green Path
 
-The **AGI Jobs v0 (v2)** platform you are piloting is the superintelligent machine that anchors our labour lattice. This playbook equips non-technical operators to launch the flagship Day-One Utility demo, capture a ✅ verdict, and review the cinematic evidence in just a few minutes.
+The **AGI Jobs v0 (v2)** platform you are piloting is the superintelligent machine that anchors our labour lattice. This runbook keeps non-technical operators on the happy path: launch the Day-One Utility demo, confirm the ✅ verdict, open the cinematic artefacts, and make a fast call.
 
 ---
 
@@ -9,101 +9,120 @@ The **AGI Jobs v0 (v2)** platform you are piloting is the superintelligent machi
 **Codespaces (recommended)**
 1. Visit <https://github.com/MontrealAI/AGIJobsv0>.
 2. Click **Code ▸ Codespaces ▸ Create codespace on main**.
-3. Wait for the workspace to boot (Python 3.10+ and Node are pre-installed).
+3. Wait for the workspace to initialise (Python 3.10+, Node.js, and Make are pre-provisioned).
 
 **Local clone (optional)**
 ```bash
 git clone https://github.com/MontrealAI/AGIJobsv0
 cd AGIJobsv0
 ```
-Ensure Python 3.10+ is on your PATH. Node/npm are optional for the green path.
+Install Python 3.10+ if it is not already on your PATH. Node/npm are optional for the green path.
 
 ---
 
-## 1. One-command green path
+## 1. Run the one-command green path
 
-From the repository root run:
+From the repository root execute:
 
 ```bash
 make operator:green
 ```
 
-This target orchestrates the demo end-to-end:
-- Upgrades pip and installs `demo/AGIJobs-Day-One-Utility-Benchmark/requirements.txt` (falls back to PyYAML + Matplotlib).
-- Executes `python3 run_demo.py` for the Day-One Utility scenario (retries with `python3 run_demo.py simulate --strategy e2e` if needed).
-- Streams artefacts into `demo/AGIJobs-Day-One-Utility-Benchmark/out/` (JSON telemetry, PNG snapshots, HTML dashboards).
-- Invokes `tools/operator_banner.py` to print a banner such as `✅ Day-One Utility +X.XX%` using the freshest JSON report.
-- Echoes absolute paths for the newest snapshot and telemetry so you can open them immediately.
+Behind the scenes this target performs the entire production-strength flow:
+
+- Upgrades `pip` and installs `demo/AGIJobs-Day-One-Utility-Benchmark/requirements.txt` (falls back to `pyyaml` + `matplotlib` if the file is ever absent).
+- Enters the Day-One Utility demo directory and runs `python3 run_demo.py`; if the CLI exits non-zero it immediately retries with `python3 run_demo.py simulate --strategy e2e`.
+- Invokes the `DayOneUtilityOrchestrator` to simulate the flagship strategy, enforce guardrails, and write artefacts into `demo/AGIJobs-Day-One-Utility-Benchmark/out/`:
+  - `out/report_e2e.json` — canonical telemetry & guardrail verdicts.
+  - `out/dashboard_e2e.html` — mermaid-powered dashboard.
+  - `out/snapshot_e2e.png` — Baseline vs Candidate visual (if Matplotlib is available).
+  - `out/owner_controls_snapshot.json` — sovereign owner controls at execution time.
+- Calls `tools/operator_banner.py out` to parse the freshest JSON report and print `✅ Day-One Utility +X.XX%` (falls back to `✅ Day-One run complete` if uplift cannot be derived).
+- Echoes absolute paths to the newest PNG/HTML snapshot and JSON telemetry so you can open them immediately.
 
 Sample output:
 ```
-✅ Day-One Utility +09.87%
+✅ Day-One Utility +08.92%
 Snapshot: /workspaces/AGIJobsv0/demo/AGIJobs-Day-One-Utility-Benchmark/out/snapshot_e2e.png
-Telemetry: /workspaces/AGIJobsv0/demo/AGIJobs-Day-One-Utility-Benchmark/out/owner_controls_snapshot.json
+Telemetry: /workspaces/AGIJobsv0/demo/AGIJobs-Day-One-Utility-Benchmark/out/report_e2e.json
 ```
-(If the uplift cannot be parsed, you will still see `✅ Day-One run complete` along with the artefact paths.)
+(If no PNG is rendered, the command prints the latest HTML dashboard path instead.)
 
 ---
 
-## 2. Validate the run
+## 2. Validate the run (acceptance checklist)
 
-1. **Banner** — Confirm the banner begins with `✅ Day-One Utility`. Any uplift ≥ +5.00% satisfies the default guardrail in `config/rules.yaml`.
-2. **Snapshot** — Open the printed PNG path to review the Baseline vs Candidate comparison. If only an HTML dashboard is available, open it in your browser.
-3. **Telemetry** — Download the JSON path for guardrail verdicts, owner controls, and utility metrics. Archive it with the snapshot.
-4. **Artefact location** — All outputs accumulate inside `demo/AGIJobs-Day-One-Utility-Benchmark/out/`; the make target always surfaces the newest files.
+1. **Banner** — Confirm the terminal banner begins with `✅ Day-One Utility`. An uplift of **+5.00% or greater** satisfies the baseline guardrail encoded in `demo/AGIJobs-Day-One-Utility-Benchmark/config/rules.yaml`.
+2. **Snapshot** — Open the printed `snapshot_*.png` path to review Baseline vs Candidate metrics side-by-side. If the PNG is missing, open the `dashboard_*.html` path; it contains the same story in a cinematic layout.
+3. **Telemetry** — Download `report_e2e.json` for the metrics, guardrail verdicts, owner treasury impact, and mermaid summaries. Archive it together with `owner_controls_snapshot.json` for audit continuity.
+4. **Artefact location** — All outputs live under `demo/AGIJobs-Day-One-Utility-Benchmark/out/`. The Make target always surfaces the newest files so you never hunt manually.
 
 ---
 
 ## 3. Daily operator cadence (≈5 minutes)
 
-1. `make operator:green`
-2. Read the uplift banner and guardrail verdict.
-3. Inspect the snapshot (PNG/HTML) for narrative alignment.
-4. File the snapshot + JSON in your decision log when uplift and guardrails are green.
-5. (Optional) Adjust owner controls before rerunning:
+1. Run `make operator:green`.
+2. Read the uplift banner and ensure guardrails report "pass" inside the JSON telemetry.
+3. Open the snapshot (PNG or HTML) to verify the narrative and sanity-check Baseline vs Candidate KPIs.
+4. When uplift and guardrails are green, capture both the snapshot and `report_e2e.json`/`owner_controls_snapshot.json` in your decision log.
+5. (Optional) Adjust sovereign owner controls between runs:
    ```bash
    cd demo/AGIJobs-Day-One-Utility-Benchmark
+   make owner-show                      # Inspect the current snapshot
    make owner-set KEY=platform_fee_bps VALUE=220
    make owner-set KEY=utility_threshold_override_bps VALUE=900
-   make owner-toggle   # Pause/resume instantly
-   make owner-reset    # Restore sovereign defaults
+   make owner-toggle                    # Pause/resume instantly
+   make owner-reset                     # Restore defaults from owner_controls.defaults.yaml
    ```
-   Active values live in `config/owner_controls.yaml`; the reset baseline is `config/owner_controls.defaults.yaml`.
-6. (Optional) Explore alternative launch profiles from the demo directory:
-   ```bash
-   make alphaevolve
-   make hgm
-   make trm
-   make omni
-   make scoreboard   # Generates out/scoreboard.json + out/scoreboard.html
-   ```
-   These targets reuse the same dataset, guardrail engine, and dashboard renderer to showcase AlphaEvolve/HGM/TRM/OMNI strategies.
+   Live updates are validated before saving, guaranteeing safe inputs for non-technical operators.
 
 ---
 
-## 4. Troubleshooting checklist
+## 4. Explore additional launch profiles & scoreboards
+
+Stay inside `demo/AGIJobs-Day-One-Utility-Benchmark` to compare strategies that reuse the same dataset, guardrails, and renderer:
+
+```bash
+make alphaevolve
+make hgm
+make trm
+make omni
+```
+
+Generate the consolidated scoreboard when you need a multi-strategy briefing:
+
+```bash
+make scoreboard
+# or
+python3 run_demo.py scoreboard
+```
+
+This produces `out/scoreboard.json` plus a mermaid-rich command-room dashboard at `out/scoreboard.html`, highlighting leaders in utility uplift, latency, treasury impact, and reliability.
+
+---
+
+## 5. Troubleshooting checklist
 
 | Symptom | Action |
 | --- | --- |
-| `python3` missing | Install Python 3.10+ (`sudo apt install python3 python3-pip`) or relaunch in Codespaces. |
-| Pip install errors | Re-run `make operator:green`; dependency installation is idempotent and recreates `out/` as needed. |
-| Banner missing uplift | Open the printed JSON path and confirm it includes `metrics.utility_uplift`; share the artefacts with engineering. |
-| No PNG path printed | The fallback HTML dashboard path will appear. Open it in a browser and export a screenshot if stakeholders need imagery. |
-| Demo paused | Run `cd demo/AGIJobs-Day-One-Utility-Benchmark && make owner-toggle` to resume, or `make owner-reset` to restore defaults. |
+| `python3: command not found` | Install Python 3.10+ locally or relaunch in Codespaces where it is pre-installed. |
+| Pip install failures | Re-run `make operator:green`; dependency installation is idempotent and recreates `out/` automatically. |
+| Banner prints `✅ Day-One run complete` | Open the printed JSON path and verify it contains `metrics.utility_uplift`; share the artefact with engineering if uplift is missing. |
+| No PNG snapshot reported | The HTML dashboard path is printed instead — open it in a browser and export a screenshot if stakeholders need imagery. |
+| Demo reports "paused" | Run `cd demo/AGIJobs-Day-One-Utility-Benchmark && make owner-toggle` to resume, or `make owner-reset` to restore the sovereign defaults. |
 
 ---
 
-## 5. Key directories & artefacts
+## 6. Key files & directories
 
 | Path | Purpose |
 | --- | --- |
-| `Makefile` (repo root) | Hosts the `operator:green` target used by this runbook. |
-| `tools/operator_banner.py` | Parses the latest JSON report and prints the uplift banner. |
-| `demo/AGIJobs-Day-One-Utility-Benchmark/run_demo.py` | CLI entrypoint executed by `make operator:green`. |
-| `demo/AGIJobs-Day-One-Utility-Benchmark/demo_runner.py` | Simulation, guardrail enforcement, HTML rendering, charting. |
-| `demo/AGIJobs-Day-One-Utility-Benchmark/config/` | Microset, strategy, guardrail, and owner control YAMLs. |
-| `demo/AGIJobs-Day-One-Utility-Benchmark/out/` | JSON telemetry, PNG snapshots, HTML dashboards per run. |
-| `demo/AGIJobs-Day-One-Utility-Benchmark/tests/` | Pytest suite validating guardrails, artefact creation, owner controls. |
-| `demo/AGIJobs-Day-One-Utility-Benchmark/README.md` | Full deep-dive into additional demos and governance flows. |
+| `Makefile` (repo root) | Hosts the `operator:green` orchestration target used by this runbook. |
+| `tools/operator_banner.py` | Parses the latest `out/*.json` report and prints the ✅ uplift banner. |
+| `demo/AGIJobs-Day-One-Utility-Benchmark/run_demo.py` | Friendly CLI entrypoint for the Day-One Utility orchestrator. |
+| `demo/AGIJobs-Day-One-Utility-Benchmark/demo_runner.py` | Full simulation engine: strategy maths, guardrail enforcement, dashboard & chart rendering, scoreboard generation. |
+| `demo/AGIJobs-Day-One-Utility-Benchmark/config/` | Microset dataset, strategy definitions, guardrail thresholds, owner control snapshots. |
+| `demo/AGIJobs-Day-One-Utility-Benchmark/out/` | Latest JSON telemetry, cinematic dashboards, chart snapshots, and scoreboard exports. |
+| `demo/AGIJobs-Day-One-Utility-Benchmark/tests/` | Pytest suite proving guardrail enforcement, pausing, artefact creation, and owner control safety. |
 
-Stay on this rhythm and every operator will verify Day-One Utility uplift, capture artefacts, and steer **AGI Jobs v0 (v2)** with production-grade confidence.
+Stay on this rhythm and every operator will verify Day-One Utility uplift, capture the artefacts, and steer **AGI Jobs v0 (v2)** with production-grade confidence.


### PR DESCRIPTION
## Summary
- update OperatorRunbook.md to reflect the current Day-One Utility demo workflow
- document the operator:green automation, produced artefacts, and acceptance checklist
- expand guidance on daily cadence, scoreboard usage, owner controls, and troubleshooting

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_6904f0f6f314833397355c2582eb7b90