### PR TITLE
Automate CI v2 branch protection contexts

### DIFF
--- a/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
+++ b/demo/Phase-6-Scaling-Multi-Domain-Expansion/README.md
@@ -150,7 +150,7 @@ A new job in `.github/workflows/ci.yml` named **Phase 6 readiness** runs on ever
 3. Asserts the mermaid UI, ABI files, and config schema stay in sync.
 4. Publishes a short status summary to the GitHub Checks UI.
 
-`EXPECTED_CONTEXTS` in `scripts/ci/verify-branch-protection.ts` is updated so branch protection refuses merges without this signal.
+Branch protection contexts are derived directly from `.github/workflows/ci.yml` via `scripts/ci/verify-branch-protection.ts`, so the guard refuses merges whenever the Phase 6 checks drift from the workflow definition.
 
 ---
 

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -1,6 +1,6 @@
 # Branch Protection Policy (AGI Jobs v2)
 
-To keep `main` deployable at all times, enable the following rules in the GitHub repository settings:
+To keep `main` deployable at all times, enable the following rules in the GitHub repository settings. The `npm run ci:verify-branch-protection` helper now reads `.github/workflows/ci.yml` directly, so any change to the CI matrix automatically updates the required context list.
 
 1. **Require status checks to pass before merging** — type the contexts exactly as they appear in the Checks tab. Group them as shown to keep the list manageable when auditing:
 

--- a/scripts/ci/branch-protection-contexts.ts
+++ b/scripts/ci/branch-protection-contexts.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { load } from 'js-yaml';
+
+type BranchProtectionConfig =
+  | boolean
+  | {
+      required?: boolean;
+      alias?: string;
+    };
+
+type WorkflowJob = {
+  name?: string;
+  branch_protection?: BranchProtectionConfig;
+};
+
+type WorkflowFile = {
+  name?: string;
+  jobs?: Record<string, WorkflowJob | undefined>;
+};
+
+export const WORKFLOW_PATH = resolve(
+  __dirname,
+  '..',
+  '..',
+  '.github',
+  'workflows',
+  'ci.yml'
+);
+
+export function computeBranchProtectionContexts(): string[] {
+  const fileContents = readFileSync(WORKFLOW_PATH, 'utf8');
+  const parsed = load(fileContents) as WorkflowFile | undefined;
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`Unable to parse workflow at ${WORKFLOW_PATH}`);
+  }
+
+  const workflowName =
+    typeof parsed.name === 'string' && parsed.name.trim().length > 0
+      ? parsed.name.trim()
+      : 'ci (v2)';
+  const jobs = parsed.jobs;
+
+  if (!jobs || typeof jobs !== 'object' || Object.keys(jobs).length === 0) {
+    throw new Error('Workflow does not define any jobs to guard.');
+  }
+
+  const contexts: string[] = [];
+
+  for (const [jobId, jobValue] of Object.entries(jobs)) {
+    if (!jobValue || typeof jobValue !== 'object') {
+      continue;
+    }
+
+    const jobName =
+      typeof jobValue.name === 'string' && jobValue.name.trim().length > 0
+        ? jobValue.name.trim()
+        : jobId;
+
+    const config = jobValue.branch_protection;
+
+    let required = true;
+    let alias = jobName;
+
+    if (typeof config === 'boolean') {
+      required = config;
+    } else if (config && typeof config === 'object') {
+      if (typeof config.required === 'boolean') {
+        required = config.required;
+      }
+      if (typeof config.alias === 'string' && config.alias.trim().length > 0) {
+        alias = config.alias.trim();
+      }
+    }
+
+    if (!required) {
+      continue;
+    }
+
+    contexts.push(`${workflowName} / ${alias}`);
+  }
+
+  if (contexts.length === 0) {
+    throw new Error(
+      'No branch protection contexts were derived from the workflow.'
+    );
+  }
+
+  return contexts;
+}
+
+if (require.main === module) {
+  const contexts = computeBranchProtectionContexts();
+  for (const ctx of contexts) {
+    console.log(ctx);
+  }
+}

--- a/scripts/ci/verify-branch-protection.ts
+++ b/scripts/ci/verify-branch-protection.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env ts-node
 import { execSync } from 'node:child_process';
 import { exit } from 'node:process';
+import { computeBranchProtectionContexts } from './branch-protection-contexts';
 
 type ResultRow = {
   label: string;
@@ -15,30 +16,7 @@ type Args = {
   token?: string;
 };
 
-const EXPECTED_CONTEXTS = [
-  'ci (v2) / Lint & static checks',
-  'ci (v2) / Tests',
-  'ci (v2) / Python unit tests',
-  'ci (v2) / Python integration tests',
-  'ci (v2) / Load-simulation reports',
-  'ci (v2) / Python coverage enforcement',
-  'ci (v2) / HGM guardrails',
-  'ci (v2) / Foundry',
-  'ci (v2) / Coverage thresholds',
-  'ci (v2) / Phase 6 readiness',
-  'ci (v2) / Phase 8 readiness',
-  'ci (v2) / Kardashev II readiness',
-  'ci (v2) / ASI Take-Off Demonstration',
-  'ci (v2) / Zenith Sapience Demonstration',
-  'ci (v2) / AGI Labor Market Grand Demo',
-  'ci (v2) / Sovereign Mesh Demo — build',
-  'ci (v2) / Sovereign Constellation Demo — build',
-  'ci (v2) / Celestial Archon Demonstration',
-  'ci (v2) / Hypernova Governance Demonstration',
-  'ci (v2) / Branch protection guard',
-  'ci (v2) / CI summary',
-  'ci (v2) / Invariant tests',
-] as const;
+const EXPECTED_CONTEXTS = computeBranchProtectionContexts();
 
 type BranchProtectionResponse = {
   required_status_checks?: {

--- a/test/scripts/ciPhase8Workflow.test.ts
+++ b/test/scripts/ciPhase8Workflow.test.ts
@@ -2,16 +2,25 @@ import { expect } from 'chai';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { load } from 'js-yaml';
+import { computeBranchProtectionContexts } from '../../scripts/ci/branch-protection-contexts';
 
-const WORKFLOW_PATH = join(__dirname, '..', '..', '.github', 'workflows', 'ci.yml');
-const BRANCH_PROTECTION_SCRIPT = join(__dirname, '..', '..', 'scripts', 'ci', 'verify-branch-protection.ts');
+const WORKFLOW_PATH = join(
+  __dirname,
+  '..',
+  '..',
+  '.github',
+  'workflows',
+  'ci.yml'
+);
 
 describe('CI Phase 8 readiness workflow', function () {
   it('runs on pull requests and protects main with Phase 8 readiness', function () {
     const workflow = load(readFileSync(WORKFLOW_PATH, 'utf-8')) as any;
     expect(workflow?.on?.pull_request).to.not.equal(undefined);
     const pushBranches: unknown = workflow?.on?.push?.branches ?? [];
-    expect(Array.isArray(pushBranches) ? pushBranches : [pushBranches]).to.include('main');
+    expect(
+      Array.isArray(pushBranches) ? pushBranches : [pushBranches]
+    ).to.include('main');
 
     const phase8Job = workflow?.jobs?.phase8;
     expect(phase8Job, 'phase8 job missing').to.not.equal(undefined);
@@ -20,7 +29,7 @@ describe('CI Phase 8 readiness workflow', function () {
   });
 
   it('enforces Phase 8 readiness in branch protection expectations', function () {
-    const script = readFileSync(BRANCH_PROTECTION_SCRIPT, 'utf-8');
-    expect(script).to.contain('"ci (v2) / Phase 8 readiness"');
+    const contexts = computeBranchProtectionContexts();
+    expect(contexts).to.include('ci (v2) / Phase 8 readiness');
   });
 });


### PR DESCRIPTION
## Summary
- derive the CI v2 branch-protection context list directly from `.github/workflows/ci.yml`
- document the dynamic enforcement in the branch protection runbooks and demos
- update the Phase 8 readiness test to assert against the generated context list

## Testing
- npx eslint scripts/ci/verify-branch-protection.ts scripts/ci/branch-protection-contexts.ts test/scripts/ciPhase8Workflow.test.ts
- npx ts-node --compiler-options '{"module":"commonjs"}' scripts/ci/branch-protection-contexts.ts | head
- npx ts-node --compiler-options '{"module":"commonjs"}' scripts/ci/verify-branch-protection.ts --help

------
https://chatgpt.com/codex/tasks/task_e_690514bf1a6c8333a4fffcee0b80a818