### PR TITLE
Add automated CI context guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
         run: npm ci --no-audit --prefer-offline --progress=false
       - name: Verify toolchain locks
         run: npm run ci:verify-toolchain
+      - name: Ensure branch protection contexts match workflow
+        run: npm run ci:verify-contexts
       - name: Prettier formatting check
         run: npm run format:check
       - name: Targeted lint suite

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ The V2 CI lattice keeps every subsystem green and verifiable:
 - **Contracts & Chain Logic** – `npm run test`, `forge test`, and targeted Hardhat suites (`npm run test:fork`, `npm run test:alpha-agi-mark`) validate protocol upgrades and sovereign controls.
 - **Python & Agent Services** – `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` spans `tests/`, `test/`, and demo-specific suites; additional CLI verifiers live under `scripts/v2/`.
 - **Security & Supply Chain** – `npm run security:audit`, `npm run sbom:generate`, `npm run release:manifest:validate`, and license verifiers within [`ci/`](ci/) sustain production trust.
-- **Branch Protection Checks** – `npm run ci:verify-branch-protection` (in [`scripts/ci`](scripts/ci)) ensures all CI (v2) workflows remain mandatory before merges.
+- **Branch Protection Checks** – `npm run ci:verify-contexts` guarantees the workflow job display names stay synchronised with branch protection, and `npm run ci:verify-branch-protection` (both in [`scripts/ci`](scripts/ci)) ensures all CI (v2) workflows remain mandatory before merges.
 
 ### CI v2 — enforced gates
 `ci (v2)` now requires every surfaced check on pull requests and the `main` branch. The branch-protection guard asserts that the following contexts stay locked before merges are allowed:

--- a/docs/ci-v2-branch-protection-checklist.md
+++ b/docs/ci-v2-branch-protection-checklist.md
@@ -57,7 +57,7 @@
 | `static-analysis / Slither static analysis` | [`slither`](../.github/workflows/static-analysis.yml) | Fails the merge if Slither reports unapproved high-severity findings and uploads SARIF to the security tab.【F:.github/workflows/static-analysis.yml†L20-L106】 |
 | `static-analysis / CodeQL analysis` | [`codeql`](../.github/workflows/static-analysis.yml) | Ensures CodeQL JavaScript/TypeScript scans succeed with the hardened config and SARIF upload before merges land.【F:.github/workflows/static-analysis.yml†L108-L157】 |
 
-The job display names in GitHub Actions must stay in sync with these contexts. Any rename requires updating branch protection and this checklist.
+The job display names in GitHub Actions must stay in sync with these contexts. Any rename requires updating branch protection and this checklist. The lint stage now executes `npm run ci:verify-contexts` to fail fast when `.github/workflows/ci.yml` and `scripts/ci/verify-branch-protection.ts` drift, giving administrators an immediate signal before a PR reaches review.【F:.github/workflows/ci.yml†L53-L60】【F:scripts/ci/check-ci-required-contexts.ts†L1-L107】
 
 ---
 
@@ -73,12 +73,14 @@ The job display names in GitHub Actions must stay in sync with these contexts. A
 
 ### 2. Confirm enforcement with the GitHub CLI
 
-Run the automated audit (set `GITHUB_TOKEN` or `GH_TOKEN` with `repo` scope first):
+Run the automated audits (set `GITHUB_TOKEN` or `GH_TOKEN` with `repo` scope first):
 
 ```bash
+npm run ci:verify-contexts
 npm run ci:verify-branch-protection
 ```
 
+- `npm run ci:verify-contexts` parses `.github/workflows/ci.yml` and confirms every job name maps to a required status context, preventing silent drift when contributors rename jobs.【F:scripts/ci/check-ci-required-contexts.ts†L1-L107】
 - `npm run audit:final -- --full` runs this verifier automatically when assembling the release dossier, keeping non-technical owners aligned with branch policy. The command also records the outcome in `reports/audit/final-readiness.json` for auditors who track freeze evidence across releases.【F:scripts/audit/final-readiness.ts†L1-L305】
 
 - Save the ✅/❌ table output in your change ticket. It proves the required contexts, ordering, strict mode, and administrator enforcement all align with policy.

--- a/docs/v2-ci-operations.md
+++ b/docs/v2-ci-operations.md
@@ -41,6 +41,8 @@ All three entry points converge on the same job graph, keeping the `CI summary` 
 
 Enable branch protection on `main` with every status context below. The list mirrors `scripts/ci/verify-branch-protection.ts` so automated audits and the GitHub UI stay synchronised.
 
+> 🔄 **Self-checking contexts:** The lint job now runs `npm run ci:verify-contexts`, which parses `.github/workflows/ci.yml` and fails the pipeline if any required job name drifts from the enforced context list. This keeps non-technical approvers from encountering missing checks in the UI.【F:.github/workflows/ci.yml†L53-L60】【F:scripts/ci/check-ci-required-contexts.ts†L1-L107】
+
 ### Core execution gate
 
 | Check context | Source job | Notes |
@@ -90,8 +92,11 @@ Enable branch protection on `main` with every status context below. The list mir
 After applying or updating branch protection rules, verify them without leaving the terminal:
 
 ```bash
+npm run ci:verify-contexts
 npm run ci:verify-branch-protection
 ```
+
+Run `npm run ci:verify-contexts` after editing job display names to confirm the workflow and branch rule stay aligned before pushing a branch. It emits a concise ✅/❌ summary and surfaces duplicates or missing entries immediately.【F:scripts/ci/check-ci-required-contexts.ts†L1-L107】
 
 Set `GITHUB_TOKEN` (or `GH_TOKEN`) with `repo` scope first. The script auto-detects the repository from `GITHUB_REPOSITORY` or the local git remote and prints a status table covering contexts, ordering, the `strict` flag, and the **Include administrators** toggle. Provide `--owner`, `--repo`, or `--branch` when auditing forks.
 

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "check:access-control": "node scripts/ci/check-access-control-coverage.js",
     "check:coverage": "node scripts/check-coverage.js 90",
     "ci:verify-branch-protection": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/ci/verify-branch-protection.ts",
+    "ci:verify-contexts": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/ci/check-ci-required-contexts.ts",
     "ci:verify-signers": "node scripts/ci/check-signers.js",
     "ci:verify-toolchain": "node scripts/ci/check-toolchain-locks.js",
     "compile": "ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/generate-constants.ts && hardhat compile",

--- a/scripts/ci/check-ci-required-contexts.ts
+++ b/scripts/ci/check-ci-required-contexts.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env ts-node
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import yaml from 'js-yaml';
+
+const WORKFLOW_PATH = resolve(__dirname, '../../.github/workflows/ci.yml');
+const BRANCH_GUARD_PATH = resolve(__dirname, 'verify-branch-protection.ts');
+
+function parseExpectedContexts(): string[] {
+  const source = readFileSync(BRANCH_GUARD_PATH, 'utf8');
+  const match = source.match(/const\s+EXPECTED_CONTEXTS\s*=\s*\[(.*?)\]\s*as\s+const/su);
+  if (!match) {
+    throw new Error('Unable to locate EXPECTED_CONTEXTS definition in verify-branch-protection.ts');
+  }
+
+  const rawEntries = match[1]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('//'))
+    .map((line) => line.replace(/[,\s]*$/u, ''))
+    .map((line) => line.replace(/^['"]/u, '').replace(/['"]$/u, ''))
+    .filter((line) => line.length > 0);
+
+  const invalid = rawEntries.filter((entry) => !entry.startsWith('ci (v2) / '));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Expected every context to begin with "ci (v2) / ". Offending entries: ${invalid.join(', ')}`
+    );
+  }
+
+  return rawEntries;
+}
+
+function parseWorkflowJobNames(): Map<string, string> {
+  const workflow = yaml.load(readFileSync(WORKFLOW_PATH, 'utf8')) as {
+    jobs?: Record<string, { name?: unknown }>;
+  };
+
+  if (!workflow || typeof workflow !== 'object' || !('jobs' in workflow)) {
+    throw new Error('Unable to parse jobs from ci.yml');
+  }
+
+  const jobMap = new Map<string, string>();
+  for (const [jobId, jobConfig] of Object.entries(workflow.jobs ?? {})) {
+    if (!jobConfig || typeof jobConfig !== 'object') {
+      continue;
+    }
+    const jobNameRaw = 'name' in jobConfig ? jobConfig.name : undefined;
+    const jobName = typeof jobNameRaw === 'string' && jobNameRaw.trim().length > 0 ? jobNameRaw.trim() : jobId;
+    jobMap.set(jobName, jobId);
+  }
+
+  if (jobMap.size === 0) {
+    throw new Error('No jobs discovered in ci.yml; workflow parsing likely failed');
+  }
+
+  return jobMap;
+}
+
+function main(): void {
+  const contexts = parseExpectedContexts();
+  const workflowJobs = parseWorkflowJobNames();
+
+  const contextJobNames = contexts.map((entry) => entry.replace(/^ci \(v2\) \/ /u, ''));
+
+  const missingJobNames = contextJobNames.filter((name) => !workflowJobs.has(name));
+  if (missingJobNames.length > 0) {
+    const suggestions = missingJobNames
+      .map((name) => {
+        const similar = Array.from(workflowJobs.keys()).find(
+          (jobName) => jobName.toLowerCase() === name.toLowerCase()
+        );
+        return similar ? `${name} (did you mean ${similar}?)` : name;
+      })
+      .join(', ');
+    throw new Error(
+      `Expected workflow jobs with display names matching branch protection contexts. Missing: ${suggestions}`
+    );
+  }
+
+  const missingContexts = Array.from(workflowJobs.keys()).filter(
+    (name) => !contextJobNames.includes(name)
+  );
+  if (missingContexts.length > 0) {
+    throw new Error(
+      `Workflow defines job names that are not enforced via branch protection contexts: ${missingContexts.join(', ')}`
+    );
+  }
+
+  const duplicates = new Set<string>();
+  const seen = new Set<string>();
+  for (const context of contexts) {
+    if (seen.has(context)) {
+      duplicates.add(context);
+    }
+    seen.add(context);
+  }
+
+  if (duplicates.size > 0) {
+    throw new Error(`Duplicate contexts detected: ${Array.from(duplicates).join(', ')}`);
+  }
+
+  console.log('✅ Branch protection contexts align with ci.yml job display names.');
+  console.log(`• Checked ${contexts.length} contexts against ${workflowJobs.size} workflow jobs.`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a CI drift detector that cross-checks workflow job names against the required branch protection contexts
- wire the guard into the lint stage and expose an npm script for manual audits
- document the new enforcement hook across the README and branch-protection guides

## Testing
- npm run ci:verify-contexts


------
https://chatgpt.com/codex/tasks/task_e_690519e988a0833396b5deb19c650866