### PR TITLE
Refresh module READMEs for CI v2 operations

### DIFF
--- a/apps/onebox-static/README.md
+++ b/apps/onebox-static/README.md
@@ -1,55 +1,59 @@
-# AGI Jobs v0 (v2) — Apps → Onebox Static
+# AGI Jobs v0 (v2) — Onebox Static Console
 
-> AGI Jobs v0 (v2) is our sovereign intelligence engine; this module extends that superintelligent machine with specialised capabilities for `apps/onebox-static`.
+[![Webapp](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/webapp.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/webapp.yml)
+[![CI (v2)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
-## Overview
-- **Path:** `apps/onebox-static/README.md`
-- **Module Focus:** Anchors Apps → Onebox Static inside the AGI Jobs v0 (v2) lattice so teams can orchestrate economic, governance, and operational missions with deterministic guardrails.
-- **Integration Role:** Interfaces with the unified owner control plane, telemetry mesh, and contract registry to deliver end-to-end resilience.
+This package delivers the zero-dependency static console that can be hosted on any CDN. It mirrors the Next.js cockpit but ships as
+plain HTML/CSS/JS so the contract owner can drop a preconfigured dashboard into sovereign environments without building assets.
 
-## Capabilities
-- Provides opinionated configuration and assets tailored to `apps/onebox-static` while remaining interoperable with the global AGI Jobs v0 (v2) runtime.
-- Ships with safety-first defaults so non-technical operators can activate the experience without compromising security or compliance.
-- Publishes ready-to-automate hooks for CI, observability, and ledger reconciliation.
+## Architecture
 
-## Systems Map
+- `app.mjs` – Core runtime that validates ICS payloads, calls the orchestrator REST endpoints, streams SSE responses, and renders
+  owner console widgets for on-chain parameter changes.【F:apps/onebox-static/app.mjs†L1-L160】
+- `config.mjs` – Build-time configuration (orchestrator URLs, IPFS endpoints, storage keys) that can be overridden by the hosting
+  environment before deployment.【F:apps/onebox-static/config.mjs†L1-L56】
+- `lib.mjs` – Utilities for intent validation, IPFS pinning, and transcript formatting.
+- `scripts/` – Build helpers for hashing assets and publishing static bundles.
+
 ```mermaid
-flowchart LR
-    Operators((Mission Owners)) --> apps_onebox_static[[Apps → Onebox Static]]
-    apps_onebox_static --> Core[[AGI Jobs v0 (v2) Core Intelligence]]
-    Core --> Observability[[Unified CI / CD & Observability]]
-    Core --> Governance[[Owner Control Plane]]
+flowchart TD
+    StaticUI[Static HTML/CSS/JS] --> Orchestrator
+    StaticUI --> Gateway
+    StaticUI --> OwnerConsole[Owner action widgets]
+    OwnerConsole --> Contracts
 ```
 
-## Working With This Module
-1. From the repository root run `npm install` once to hydrate all workspaces.
-2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `apps/onebox-static`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
-4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
+## Local preview
 
-## Directory Guide
-### Key Directories
-- `scripts`
-- `test`
-- `v2`
-### Key Files
-- `app.js`
-- `app.mjs`
-- `config.js`
-- `config.mjs`
-- `index.html`
-- `lib.js`
-- `lib.mjs`
-- `pin-payload.mjs`
-- `sse-parser.mjs`
-- `styles.css`
+```bash
+cd apps/onebox-static
+npm install
+npm run onebox:static:build    # builds dist/ with hashed assets
+npm run onebox:static:publish  # optional deploy helper (configurable)
+```
 
-## Quality & Governance
-- Every change must land through a pull request with all required checks green (unit, integration, linting, security scan).
-- Reference [`RUNBOOK.md`](../../RUNBOOK.md) and [`OperatorRunbook.md`](../../OperatorRunbook.md) for escalation patterns and owner approvals.
-- Keep secrets outside the tree; use the secure parameter stores wired to the AGI Jobs v0 (v2) guardian mesh.
+Open `dist/index.html` in a browser and set the orchestrator base URL using the on-screen controls or by defining the following
+query parameters:
 
-## Next Steps
-- Review this module's issue board for open automation, data, or research threads.
-- Link new deliverables back to the central manifest via `npm run release:manifest`.
-- Publish artefacts (dashboards, mermaid charts, datasets) into `reports/` for downstream intelligence alignment.
+```
+?orchestrator=https://alpha-orchestrator.example.com&oneboxPrefix=/onebox
+```
+
+Saved values are cached under `localStorage` keys declared in `config.mjs`, so operators can persist approved endpoints between
+sessions.【F:apps/onebox-static/app.mjs†L19-L80】
+
+## Owner console
+
+The static bundle includes an owner action panel that wraps the same controls exposed by `npm run owner:command-center`. Operators
+can update stake thresholds, treasury addresses, and fee/burn percentages directly from the browser; the console prepares
+calldata compatible with the orchestrator SDK for review before submission.【F:apps/onebox-static/app.mjs†L81-L160】
+
+## Extending the bundle
+
+1. Edit `config.mjs` to add new configuration knobs or CSP origins.
+2. Extend `app.mjs` with the corresponding UI and orchestrator interaction.
+3. Update `apps/onebox/README.md` if the static and dynamic consoles diverge in capabilities.
+4. Rebuild (`npm run onebox:static:build`) and capture screenshots for documentation.
+
+The static console keeps the superintelligent machine operable even in air-gapped or compliance-restricted environments—no build
+pipeline or Node.js runtime required.

--- a/apps/onebox-static/v2/README.md
+++ b/apps/onebox-static/v2/README.md
@@ -1,44 +1,40 @@
-# AGI Jobs v0 (v2) — Apps → Onebox Static → V2
+# AGI Jobs v0 (v2) — Onebox Static Console v2
 
-> AGI Jobs v0 (v2) is our sovereign intelligence engine; this module extends that superintelligent machine with specialised capabilities for `apps/onebox-static/v2`.
+[![Webapp](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/webapp.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/webapp.yml)
+[![CI (v2)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
-## Overview
-- **Path:** `apps/onebox-static/v2/README.md`
-- **Module Focus:** Anchors Apps → Onebox Static → V2 inside the AGI Jobs v0 (v2) lattice so teams can orchestrate economic, governance, and operational missions with deterministic guardrails.
-- **Integration Role:** Interfaces with the unified owner control plane, telemetry mesh, and contract registry to deliver end-to-end resilience.
+The `v2` variant is a single-file static dashboard optimised for kiosks and minimal environments. It stores configuration entirely
+in `localStorage`, renders orchestration transcripts inline, and provides an “expert mode” toggle for direct JSON editing.
 
-## Capabilities
-- Provides opinionated configuration and assets tailored to `apps/onebox-static/v2` while remaining interoperable with the global AGI Jobs v0 (v2) runtime.
-- Ships with safety-first defaults so non-technical operators can activate the experience without compromising security or compliance.
-- Publishes ready-to-automate hooks for CI, observability, and ledger reconciliation.
+## Key capabilities
 
-## Systems Map
-```mermaid
-flowchart LR
-    Operators((Mission Owners)) --> apps_onebox_static_v2[[Apps → Onebox Static → V2]]
-    apps_onebox_static_v2 --> Core[[AGI Jobs v0 (v2) Core Intelligence]]
-    Core --> Observability[[Unified CI / CD & Observability]]
-    Core --> Governance[[Owner Control Plane]]
+- **Persistent settings** – Orchestrator URL, API token, and status refresh interval persist across sessions using storage keys
+  such as `ORCH_URL` and `ONEBOX_STATUS_INTERVAL`.【F:apps/onebox-static/v2/app.js†L1-L40】
+- **Expert mode** – Operators can toggle expert mode to unlock raw JSON intent editing, captured in the `ONEBOX_EXPERT_MODE` flag
+  so the interface remembers the preference.【F:apps/onebox-static/v2/app.js†L6-L34】
+- **Robust error context** – The console walks nested error objects to surface the most relevant message, status code, and error
+  code, giving non-technical owners actionable feedback without browser devtools.【F:apps/onebox-static/v2/app.js†L41-L120】
+- **Status polling** – Periodically fetches `/status` from the orchestrator and annotates the UI with the most recent events; the
+  interval is adjustable from the settings dialog.【F:apps/onebox-static/v2/app.js†L13-L34】【F:apps/onebox-static/v2/app.js†L121-L200】
+
+## Running locally
+
+Open `index.html` directly in a browser or serve the folder from any static host:
+
+```bash
+cd apps/onebox-static/v2
+python -m http.server 4173
+# Visit http://localhost:4173
 ```
 
-## Working With This Module
-1. From the repository root run `npm install` once to hydrate all workspaces.
-2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `apps/onebox-static/v2`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
-4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../../OperatorRunbook.md).
+Use the Settings button to point the console at your orchestrator and supply the API token (if required). Expert mode exposes a raw
+textbox for ICS payloads when you need to craft custom requests.
 
-## Directory Guide
-### Key Files
-- `app.js`
-- `index.html`
-- `styles.css`
+## Extending v2
 
-## Quality & Governance
-- Every change must land through a pull request with all required checks green (unit, integration, linting, security scan).
-- Reference [`RUNBOOK.md`](../../../RUNBOOK.md) and [`OperatorRunbook.md`](../../../OperatorRunbook.md) for escalation patterns and owner approvals.
-- Keep secrets outside the tree; use the secure parameter stores wired to the AGI Jobs v0 (v2) guardian mesh.
+1. Modify `app.js` to add new controls or validation logic.
+2. Update `styles.css` for any layout changes; the stylesheet is intentionally minimal.
+3. Keep the documentation in `apps/onebox-static/README.md` aligned if both static flavours should expose the same functionality.
 
-## Next Steps
-- Review this module's issue board for open automation, data, or research threads.
-- Link new deliverables back to the central manifest via `npm run release:manifest`.
-- Publish artefacts (dashboards, mermaid charts, datasets) into `reports/` for downstream intelligence alignment.
+This v2 bundle keeps the fallback experience simple yet powerful enough for owner-led interventions when the full Next.js console
+is unavailable.

--- a/apps/onebox/README.md
+++ b/apps/onebox/README.md
@@ -1,55 +1,62 @@
-# AGI Jobs v0 (v2) — Apps → Onebox
+# AGI Jobs v0 (v2) — Onebox Next.js Console
 
-> AGI Jobs v0 (v2) is our sovereign intelligence engine; this module extends that superintelligent machine with specialised capabilities for `apps/onebox`.
+[![Webapp](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/webapp.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/webapp.yml)
+[![CI (v2)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
-## Overview
-- **Path:** `apps/onebox/README.md`
-- **Module Focus:** Anchors Apps → Onebox inside the AGI Jobs v0 (v2) lattice so teams can orchestrate economic, governance, and operational missions with deterministic guardrails.
-- **Integration Role:** Interfaces with the unified owner control plane, telemetry mesh, and contract registry to deliver end-to-end resilience.
+The Onebox console is a Next.js 14 operator UI that guides mission owners through orchestrating jobs, staking, and governance
+scenarios. It renders streamed transcripts from the TypeScript orchestrator SDK, exposes onboarding for non-technical operators,
+and pulls live contract metadata from environment/runtime configuration.
 
-## Capabilities
-- Provides opinionated configuration and assets tailored to `apps/onebox` while remaining interoperable with the global AGI Jobs v0 (v2) runtime.
-- Ships with safety-first defaults so non-technical operators can activate the experience without compromising security or compliance.
-- Publishes ready-to-automate hooks for CI, observability, and ledger reconciliation.
+## Features
 
-## Systems Map
+- **Mission cockpit** – `OneBoxMissionPanel` curates prompts, quick actions, and ENS onboarding for operators, while
+  `ChatWindow` streams the ICS transcript returned by the orchestrator router.【F:apps/onebox/src/app/page.tsx†L1-L60】
+- **Runtime configuration** – `readOneboxConfig()` merges server-provided JSON with `NEXT_PUBLIC_*` environment variables to
+  surface contract addresses, explorer links, and orchestrator endpoints inside the UI.【F:apps/onebox/src/lib/environment.ts†L1-L120】
+- **Governance intelligence** – `lib/governanceScenario.ts` and `lib/governanceSnapshot.ts` hydrate the dashboard with current
+  council compositions and snapshot proposals so owners can confirm authority before executing transactions.【F:apps/onebox/src/lib/governanceSnapshot.ts†L1-L160】
+- **Health surface** – `lib/orchestratorHealth.ts` polls the orchestrator status API and flags drift for the operator to resolve
+  before committing changes.【F:apps/onebox/src/lib/orchestratorHealth.ts†L1-L120】
+
 ```mermaid
 flowchart LR
-    Operators((Mission Owners)) --> apps_onebox[[Apps → Onebox]]
-    apps_onebox --> Core[[AGI Jobs v0 (v2) Core Intelligence]]
-    Core --> Observability[[Unified CI / CD & Observability]]
-    Core --> Governance[[Owner Control Plane]]
+    Owner[Owner / Operator] --> UI[Next.js interface]
+    UI --> OrchestratorSDK[@agi/orchestrator]
+    OrchestratorSDK --> AgentGateway
+    UI --> Metrics[Gateway metrics & health]
+    Metrics --> UI
 ```
 
-## Working With This Module
-1. From the repository root run `npm install` once to hydrate all workspaces.
-2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `apps/onebox`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
-4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
+## Local development
 
-## Directory Guide
-### Key Directories
-- `scripts`
-- `src`
-- `test`
-### Key Files
-- `app.js`
-- `config.mjs`
-- `index.html`
-- `next-env.d.ts`
-- `next.config.mjs`
-- `package-lock.json`
-- `package.json`
-- `styles.css`
-- `tsconfig.json`
-- `url-overrides.js`
+```bash
+cd apps/onebox
+npm install
+npm run dev
+```
 
-## Quality & Governance
-- Every change must land through a pull request with all required checks green (unit, integration, linting, security scan).
-- Reference [`RUNBOOK.md`](../../RUNBOOK.md) and [`OperatorRunbook.md`](../../OperatorRunbook.md) for escalation patterns and owner approvals.
-- Keep secrets outside the tree; use the secure parameter stores wired to the AGI Jobs v0 (v2) guardian mesh.
+Set the following env variables to display contract wiring inside the cockpit:
 
-## Next Steps
-- Review this module's issue board for open automation, data, or research threads.
-- Link new deliverables back to the central manifest via `npm run release:manifest`.
-- Publish artefacts (dashboards, mermaid charts, datasets) into `reports/` for downstream intelligence alignment.
+```bash
+export NEXT_PUBLIC_ONEBOX_ORCHESTRATOR_URL="https://orchestrator.local"
+export NEXT_PUBLIC_JOB_REGISTRY_ADDRESS=0x...
+export NEXT_PUBLIC_SYSTEM_PAUSE_ADDRESS=0x...
+```
+
+Run `npm run lint` and `npm run typecheck` before committing; these commands are executed automatically inside `webapp.yml` and
+`ci (v2) / Lint & static checks`.
+
+## Testing
+
+Use Vitest or Playwright suites under `test/` to exercise conversational flows. The webapp workflow builds and smoke-tests the
+console on every pull request, ensuring the experience stays production-ready.
+
+## Extending the console
+
+1. Add new prompts or panels under `src/components/`.
+2. Extend the orchestrator SDK so transcripts include the new capability.
+3. Update `readOneboxConfig()` to surface any additional contract addresses required by the feature.
+4. Capture UI snapshots for documentation and update `apps/onebox-static` if the static export changes.
+
+The Onebox console remains the fast onboarding surface for the superintelligent machine—keep it aligned with the orchestrator SDK
+so operators retain end-to-end visibility and control.

--- a/apps/validator-ui/README.md
+++ b/apps/validator-ui/README.md
@@ -1,53 +1,49 @@
-# AGI Jobs v0 (v2) — Apps → Validator UI
+# AGI Jobs v0 (v2) — Validator UI
 
-> AGI Jobs v0 (v2) is our sovereign intelligence engine; this module extends that superintelligent machine with specialised capabilities for `apps/validator-ui`.
+[![Webapp](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/webapp.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/webapp.yml)
+[![CI (v2)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
-## Overview
-- **Path:** `apps/validator-ui/README.md`
-- **Module Focus:** Anchors Apps → Validator UI inside the AGI Jobs v0 (v2) lattice so teams can orchestrate economic, governance, and operational missions with deterministic guardrails.
-- **Integration Role:** Interfaces with the unified owner control plane, telemetry mesh, and contract registry to deliver end-to-end resilience.
+The validator UI is a minimal Next.js interface for validators to review pending jobs, commit/reveal their decision, and verify ENS
+subdomains. It is optimised for fast onboarding and shares its configuration with the agent gateway and orchestrator manifests.
 
-## Capabilities
-- Provides opinionated configuration and assets tailored to `apps/validator-ui` while remaining interoperable with the global AGI Jobs v0 (v2) runtime.
-- Ships with safety-first defaults so non-technical operators can activate the experience without compromising security or compliance.
-- Publishes ready-to-automate hooks for CI, observability, and ledger reconciliation.
+## Highlights
 
-## Systems Map
-```mermaid
-flowchart LR
-    Operators((Mission Owners)) --> apps_validator_ui[[Apps → Validator UI]]
-    apps_validator_ui --> Core[[AGI Jobs v0 (v2) Core Intelligence]]
-    Core --> Observability[[Unified CI / CD & Observability]]
-    Core --> Governance[[Owner Control Plane]]
+- **Pending jobs feed** – Fetches jobs from the agent gateway, verifies token decimals against `config/agialpha.json`, and formats
+  rewards/stakes using ethers.js to avoid precision loss.【F:apps/validator-ui/pages/index.tsx†L1-L60】
+- **Commit/reveal automation** – Uses `generateCommit` and `scheduleReveal` to derive deterministic commitments and automatically
+  reveal after the configured delay, calling the validation module through the user’s wallet.【F:apps/validator-ui/pages/index.tsx†L60-L120】
+- **ENS guardrails** – `verifyEnsSubdomain` warns validators when their ENS proof is missing or invalid before they submit a vote.【F:apps/validator-ui/lib/ens.ts†L1-L120】
+- **Error surfacing** – Shared `useError` hook renders toasts for wallet or RPC issues so non-technical validators know how to
+  recover.【F:apps/validator-ui/lib/error.tsx†L1-L120】
+
+## Running locally
+
+```bash
+cd apps/validator-ui
+npm install
+npm run dev
 ```
 
-## Working With This Module
-1. From the repository root run `npm install` once to hydrate all workspaces.
-2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `apps/validator-ui`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
-4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
+Set these environment variables to point at your stack:
 
-## Directory Guide
-### Key Directories
-- `__tests__`
-- `components`
-- `lib`
-- `pages`
-### Key Files
-- `Dockerfile`
-- `next-env.d.ts`
-- `next.config.js`
-- `package-lock.json`
-- `package.json`
-- `tsconfig.json`
-- `vitest.config.ts`
+```bash
+export NEXT_PUBLIC_RPC_URL=http://127.0.0.1:8545
+export NEXT_PUBLIC_GATEWAY_URL=http://localhost:3000
+export NEXT_PUBLIC_VALIDATION_MODULE_ADDRESS=0x...
+export NEXT_PUBLIC_REVEAL_DELAY_MS=7500
+```
 
-## Quality & Governance
-- Every change must land through a pull request with all required checks green (unit, integration, linting, security scan).
-- Reference [`RUNBOOK.md`](../../RUNBOOK.md) and [`OperatorRunbook.md`](../../OperatorRunbook.md) for escalation patterns and owner approvals.
-- Keep secrets outside the tree; use the secure parameter stores wired to the AGI Jobs v0 (v2) guardian mesh.
+## Testing & CI
 
-## Next Steps
-- Review this module's issue board for open automation, data, or research threads.
-- Link new deliverables back to the central manifest via `npm run release:manifest`.
-- Publish artefacts (dashboards, mermaid charts, datasets) into `reports/` for downstream intelligence alignment.
+- `npm test` runs Vitest via `vitest.config.ts`.
+- The shared `webapp` workflow builds and type-checks the UI on every PR, while `ci (v2)` enforces linting and coverage to keep the
+  console production ready.【F:.github/workflows/webapp.yml†L1-L196】【F:.github/workflows/ci.yml†L44-L70】
+
+## Extending the UI
+
+1. Add new validator tools or dashboards under `pages/`.
+2. Update `lib/commit.js` if additional commit schemes are introduced.
+3. Keep environment variable names synchronised with `config/` so owner tooling and this UI stay aligned.
+
+Validators rely on this UI when orchestrating missions under pressure—keep it lean, deterministic, and tied to the same manifests
+that CI v2 validates.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,49 +1,105 @@
-# AGI Jobs v0 (v2) — Contracts
+# AGI Jobs v0 (v2) — Smart Contract Stack
 
-> AGI Jobs v0 (v2) is our sovereign intelligence engine; this module extends that superintelligent machine with specialised capabilities for `contracts`.
+[![CI (v2)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
+[![Fuzz](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/fuzz.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/fuzz.yml)
+[![Invariant tests](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
-## Overview
-- **Path:** `contracts/README.md`
-- **Module Focus:** Anchors Contracts inside the AGI Jobs v0 (v2) lattice so teams can orchestrate economic, governance, and operational missions with deterministic guardrails.
-- **Integration Role:** Interfaces with the unified owner control plane, telemetry mesh, and contract registry to deliver end-to-end resilience.
+The `contracts/` tree delivers the production Solidity system that powers the AGI Jobs v0 (v2) superintelligence. It packages the
+kernel that governs job lifecycle and staking, the module adapters that extend governance, and the owner tooling that keeps the
+contract owner in direct command of every parameter. CI v2 compiles, tests, fuzzes, and enforces coverage on every change so the
+system stays deployable in high-stakes environments.
 
-## Capabilities
-- Provides opinionated configuration and assets tailored to `contracts` while remaining interoperable with the global AGI Jobs v0 (v2) runtime.
-- Ships with safety-first defaults so non-technical operators can activate the experience without compromising security or compliance.
-- Publishes ready-to-automate hooks for CI, observability, and ledger reconciliation.
+## Contract families
 
-## Systems Map
 ```mermaid
 flowchart LR
-    Operators((Mission Owners)) --> contracts[[Contracts]]
-    contracts --> Core[[AGI Jobs v0 (v2) Core Intelligence]]
-    Core --> Observability[[Unified CI / CD & Observability]]
-    Core --> Governance[[Owner Control Plane]]
+    classDef kernel fill:#ecfeff,stroke:#0284c7,color:#0c4a6e,stroke-width:1px;
+    classDef module fill:#fef2f2,stroke:#b91c1c,color:#7f1d1d,stroke-width:1px;
+    classDef admin fill:#f5f3ff,stroke:#7c3aed,color:#4c1d95,stroke-width:1px;
+
+    subgraph Kernel
+        JR[JobRegistry]:::kernel
+        SM[StakeManager]:::kernel
+        VM[ValidationModule]:::kernel
+        RE[RewardEngine]:::kernel
+    end
+
+    subgraph Modules
+        Dispute[DisputeModule]
+        Platform[PlatformRegistry]
+        Thermostat[Thermostat]
+        Hamiltonian[HamiltonianMonitor]
+        Attest[AttestationRegistry]
+    end
+
+    subgraph Owner
+        Configurator[OwnerConfigurator]:::admin
+        SystemPause[SystemPause]:::admin
+    end
+
+    Configurator --> Kernel
+    Configurator --> Modules
+    SystemPause --> JR
+    SystemPause --> SM
+    SystemPause --> VM
+    SystemPause --> Dispute
+    JR --> Platform
+    JR --> Dispute
+    JR --> Thermostat
+    Thermostat --> Hamiltonian
+    VM --> Dispute
 ```
 
-## Working With This Module
-1. From the repository root run `npm install` once to hydrate all workspaces.
-2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `contracts`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
-4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../OperatorRunbook.md).
+| Directory | Contents |
+| --------- | -------- |
+| `v2/kernel/` | Core runtime (job registry, validation module, stake manager, reward engine) with ownable governance shims and pause hooks.【F:contracts/v2/JobRegistry.sol†L4-L157】 |
+| `v2/modules/` | Auxiliary governance modules (dispute resolution, thermostat, culture registry, quadratic voting) that plug into the kernel interfaces. |
+| `v2/admin/` | Owner-focused façade contracts such as `OwnerConfigurator` for batched parameter updates.【F:contracts/v2/admin/OwnerConfigurator.sol†L7-L112】 |
+| `v2/governance/` | Commit-reveal governance, quadratic voting, and council scaffolding for validator assemblies. |
+| `v2/utils/` & `v2/libraries/` | Shared math, encoding, and Ownable2Step primitives that keep the surface area small and auditable. |
+| `coverage/` | Solidity coverage instrumentation used by `npm run coverage`. |
+| `test/` | Solidity mocks and fixtures consumed by the Hardhat + Foundry suites. |
 
-## Directory Guide
-### Key Directories
-- `gas`
-- `legacy`
-- `mocks`
-- `test`
-- `v2`
-### Key Files
-- `CommitRevealMock.sol`
-- `Migrations.sol`
+## Owner control surface
 
-## Quality & Governance
-- Every change must land through a pull request with all required checks green (unit, integration, linting, security scan).
-- Reference [`RUNBOOK.md`](../RUNBOOK.md) and [`OperatorRunbook.md`](../OperatorRunbook.md) for escalation patterns and owner approvals.
-- Keep secrets outside the tree; use the secure parameter stores wired to the AGI Jobs v0 (v2) guardian mesh.
+- **Batch parameter updates** – `OwnerConfigurator` emits a `ParameterUpdated` event for every change, giving the owner console a
+  complete audit log while executing batched upgrades.【F:contracts/v2/admin/OwnerConfigurator.sol†L16-L112】
+- **System pause** – `SystemPause` validates the addresses of every connected module and lets governance pause/unpause them in a
+  single transaction, enforcing that ownership has been delegated correctly before changes land.【F:contracts/v2/SystemPause.sol†L15-L157】
+- **Tax & treasury safety** – `JobRegistry` never escrows tax liabilities, routing them to the configured policy so the owner can
+  rotate destinations without redeploying the kernel.【F:contracts/v2/JobRegistry.sol†L21-L54】
 
-## Next Steps
-- Review this module's issue board for open automation, data, or research threads.
-- Link new deliverables back to the central manifest via `npm run release:manifest`.
-- Publish artefacts (dashboards, mermaid charts, datasets) into `reports/` for downstream intelligence alignment.
+These contracts are wired to the `npm run owner:*` commands documented in [`config/README.md`](../config/README.md), ensuring the
+contract owner maintains total control over pause levers, treasury routing, and validator quotas.
+
+## Developer workflow
+
+```bash
+npm run compile          # Hardhat compile with profile-aware constants
+npm test                 # Hardhat test suite (see test/v2/**)
+forge test -vvvv --ffi   # Foundry fuzz + invariant harness
+npm run coverage         # Generates lcov + access-control coverage reports
+```
+
+The Hardhat tests exercise the registry, governance, and module flows defined under `test/v2/**` and the shared fixtures under
+`contracts/test/`. Foundry invariants extend this by fuzzing stateful interactions and validating owner guardrails before CI marks
+a run green.【F:.github/workflows/ci.yml†L62-L189】【F:.github/workflows/ci.yml†L478-L552】
+
+## Quality gates
+
+- **Coverage** – `ci (v2) / Coverage thresholds` enforces ≥90 % Solidity coverage and maps results back to the access-control
+  modules listed in `ci.yml`, catching regressions in pause/governance paths.【F:.github/workflows/ci.yml†L500-L552】
+- **Fuzzing** – The dedicated [`fuzz.yml`](../.github/workflows/fuzz.yml) workflow and the `ci (v2) / Invariant tests` job run
+  Foundry fuzz cases on every PR for continuous assurance.【F:.github/workflows/fuzz.yml†L1-L144】【F:.github/workflows/ci.yml†L1208-L1339】
+- **Owner control assurance** – The CI job regenerates calldata through the owner doctor scripts so any missing configurator
+  wiring fails fast.【F:.github/workflows/ci.yml†L386-L434】
+
+## Artefact outputs
+
+- **ABIs** – `npm run abi:export` writes JSON ABIs under `artifacts/` for downstream services.
+- **Gas reports** – `npm run gas:report` produces deterministic gas snapshots under `gas-snapshots/`.
+- **Authority matrix** – `npm run ci:owner-authority` exports Markdown and JSON matrices describing every owner lever; the CI job
+  uploads them as artefacts for release management.【F:.github/workflows/ci.yml†L418-L434】
+
+The contract stack is designed to remain flawless under owner-led configuration changes and to emit the artefacts regulators and
+operators need to deploy AGI Jobs v0 (v2) at production scale.

--- a/contracts/test/README.md
+++ b/contracts/test/README.md
@@ -1,53 +1,43 @@
-# AGI Jobs v0 (v2) — Contracts → Test
+# AGI Jobs v0 (v2) — Solidity Test Harness
 
-> AGI Jobs v0 (v2) is our sovereign intelligence engine; this module extends that superintelligent machine with specialised capabilities for `contracts/test`.
+[![CI (v2)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
+[![Fuzz](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/fuzz.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/fuzz.yml)
 
-## Overview
-- **Path:** `contracts/test/README.md`
-- **Module Focus:** Anchors Contracts → Test inside the AGI Jobs v0 (v2) lattice so teams can orchestrate economic, governance, and operational missions with deterministic guardrails.
-- **Integration Role:** Interfaces with the unified owner control plane, telemetry mesh, and contract registry to deliver end-to-end resilience.
+The `contracts/test/` toolkit contains deterministic mocks, harnesses, and Echidna fixtures that power the Hardhat, Foundry, and
+Echidna suites. These contracts isolate each subsystem—staking, dispute resolution, validation failovers—so regressions surface
+before they reach production deployments.
 
-## Capabilities
-- Provides opinionated configuration and assets tailored to `contracts/test` while remaining interoperable with the global AGI Jobs v0 (v2) runtime.
-- Ships with safety-first defaults so non-technical operators can activate the experience without compromising security or compliance.
-- Publishes ready-to-automate hooks for CI, observability, and ledger reconciliation.
+## Layout
 
-## Systems Map
-```mermaid
-flowchart LR
-    Operators((Mission Owners)) --> contracts_test[[Contracts → Test]]
-    contracts_test --> Core[[AGI Jobs v0 (v2) Core Intelligence]]
-    Core --> Observability[[Unified CI / CD & Observability]]
-    Core --> Governance[[Owner Control Plane]]
+| File | Purpose |
+| ---- | ------- |
+| `CommitRevealEchidna.sol` | Property-based harness that validates the commit/reveal lifecycle and feeds the nightly Echidna run. |
+| `ConfigurableModuleMock.sol` | Flexible proxy that lets tests simulate modules accepting arbitrary configuration calls. |
+| `DeterministicValidationModule.sol` | Lightweight validation module used to assert validator quorum paths under fuzz. |
+| `EmployerContract.sol` | Simulated employer contract exercising the registry APIs. |
+| `GovernanceRewardMock.sol` | Stub for governance reward distribution to validate HGM reward accounting. |
+| `StakeManagerHarness.sol` | Exposes internal stake manager calculations for invariant tests. |
+
+All helpers are pure Solidity with no external dependencies so they compile alongside production contracts.
+
+## Running the suites
+
+```bash
+npm test                          # Hardhat unit + integration tests (uses contracts/test mocks)
+forge test -vvvv --ffi            # Foundry fuzz suite (ci (v2) / Foundry job)
+forge test -vvvv --ffi --match-path 'test/v2/invariant/**' --fuzz-runs 512  # Invariant harness
+npm run test:fork                 # Optional fork-mode regression suite
 ```
 
-## Working With This Module
-1. From the repository root run `npm install` once to hydrate all workspaces.
-2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `contracts/test`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
-4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
+CI v2 executes the Hardhat suite in the `Tests` job, the Foundry fuzz suite in `ci (v2) / Foundry`, and the dedicated invariant
+run in `ci (v2) / Invariant tests`, keeping every helper in this directory covered on each commit.【F:.github/workflows/ci.yml†L62-L152】【F:.github/workflows/ci.yml†L452-L641】【F:.github/workflows/ci.yml†L1208-L1339】
 
-## Directory Guide
-### Key Files
-- `AGIALPHAToken.sol`
-- `BadStakeManager.sol`
-- `CommitRevealEchidna.sol`
-- `ConfigurableModuleMock.sol`
-- `DeterministicValidationModule.sol`
-- `EchidnaHarness.sol`
-- `EmployerContract.sol`
-- `GovernanceRewardMock.sol`
-- `GovernanceTarget.sol`
-- `HGMJobRegistryMock.sol`
-- `HGMPlatformRegistryMock.sol`
-- `HGMReputationEngineMock.sol`
+## Extending the harness
 
-## Quality & Governance
-- Every change must land through a pull request with all required checks green (unit, integration, linting, security scan).
-- Reference [`RUNBOOK.md`](../../RUNBOOK.md) and [`OperatorRunbook.md`](../../OperatorRunbook.md) for escalation patterns and owner approvals.
-- Keep secrets outside the tree; use the secure parameter stores wired to the AGI Jobs v0 (v2) guardian mesh.
+1. Add your mock or harness contract under `contracts/test/` with a descriptive filename.
+2. Wire it into the Hardhat or Foundry test that exercises the new behaviour (`test/v2/**`).
+3. Export any helper types through `contracts/test/utils` if they will be reused across multiple specs.
+4. Update `npm run coverage` snapshots when the new harness changes branch counts.
 
-## Next Steps
-- Review this module's issue board for open automation, data, or research threads.
-- Link new deliverables back to the central manifest via `npm run release:manifest`.
-- Publish artefacts (dashboards, mermaid charts, datasets) into `reports/` for downstream intelligence alignment.
+The harness is intentionally modular so non-technical owners can rely on the CI signal without needing to understand the Solidity
+internals—every new scenario must integrate here to inherit the automated guarantees.

--- a/services/sentinel/README.md
+++ b/services/sentinel/README.md
@@ -1,46 +1,46 @@
-# AGI Jobs v0 (v2) — Services → Sentinel
+# AGI Jobs v0 (v2) — Sentinel Monitor
 
-> AGI Jobs v0 (v2) is our sovereign intelligence engine; this module extends that superintelligent machine with specialised capabilities for `services/sentinel`.
+[![CI (v2)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
+[![Python unit tests](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
-## Overview
-- **Path:** `services/sentinel/README.md`
-- **Module Focus:** Anchors Services → Sentinel inside the AGI Jobs v0 (v2) lattice so teams can orchestrate economic, governance, and operational missions with deterministic guardrails.
-- **Integration Role:** Interfaces with the unified owner control plane, telemetry mesh, and contract registry to deliver end-to-end resilience.
+The sentinel service enforces guardrails around the Higher Governance Machine. It listens to expansion/evaluation events, tracks
+ROI, prunes risky agents, and emits alerts when owner intervention is required. The agent gateway and orchestrator feed events into
+this monitor during CI and production runs.
 
-## Capabilities
-- Provides opinionated configuration and assets tailored to `services/sentinel` while remaining interoperable with the global AGI Jobs v0 (v2) runtime.
-- Ships with safety-first defaults so non-technical operators can activate the experience without compromising security or compliance.
-- Publishes ready-to-automate hooks for CI, observability, and ledger reconciliation.
+## Components
 
-## Systems Map
+- **`service.py`** – Defines `SentinelMonitor`, an asyncio-driven event processor that consumes expansion/evaluation events, keeps
+  ROI totals, manages pause reasons, and exposes a `snapshot()` for dashboards.【F:services/sentinel/service.py†L1-L160】
+- **`config.py`** – `SentinelConfig` dataclass describing thresholds (ROI caps, pause windows, max failures).【F:services/sentinel/config.py†L1-L160】
+- **`tests/`** – Pytest suite verifying pruning, ROI thresholds, and alert emission.
+
+## Event flow
+
 ```mermaid
 flowchart LR
-    Operators((Mission Owners)) --> services_sentinel[[Services → Sentinel]]
-    services_sentinel --> Core[[AGI Jobs v0 (v2) Core Intelligence]]
-    Core --> Observability[[Unified CI / CD & Observability]]
-    Core --> Governance[[Owner Control Plane]]
+    Orchestrator --> Sentinel[SentinelMonitor]
+    AgentGateway --> Sentinel
+    Sentinel --> Alerts[services.alerting]
+    Sentinel --> Thermostat
+    Sentinel --> Snapshot[Dashboard snapshots]
 ```
 
-## Working With This Module
-1. From the repository root run `npm install` once to hydrate all workspaces.
-2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `services/sentinel`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
-4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
+## Usage
 
-## Directory Guide
-### Key Directories
-- `tests`
-### Key Files
-- `__init__.py`
-- `config.py`
-- `service.py`
+```python
+from services.sentinel.service import SentinelMonitor
+from hgm_core.engine import HGMEngine
+from services.sentinel.config import SentinelConfig
 
-## Quality & Governance
-- Every change must land through a pull request with all required checks green (unit, integration, linting, security scan).
-- Reference [`RUNBOOK.md`](../../RUNBOOK.md) and [`OperatorRunbook.md`](../../OperatorRunbook.md) for escalation patterns and owner approvals.
-- Keep secrets outside the tree; use the secure parameter stores wired to the AGI Jobs v0 (v2) guardian mesh.
+monitor = SentinelMonitor(engine=HGMEngine(), config=SentinelConfig())
+await monitor.observe_expansion("mission/alpha", {"score": 0.8})
+await monitor.observe_evaluation("mission/alpha", {"reward": 1.2})
+snapshot = monitor.snapshot()
+```
 
-## Next Steps
-- Review this module's issue board for open automation, data, or research threads.
-- Link new deliverables back to the central manifest via `npm run release:manifest`.
-- Publish artefacts (dashboards, mermaid charts, datasets) into `reports/` for downstream intelligence alignment.
+The sentinel integrates with the thermostat and orchestrator to request pauses when ROI dips below the configured thresholds. CI v2
+runs these tests in `ci (v2) / Python unit tests` and the `HGM guardrails` job, guaranteeing the contract owner retains immediate
+control when anomalies arise.【F:.github/workflows/ci.yml†L118-L345】【F:.github/workflows/ci.yml†L352-L420】
+
+Keep the sentinel thresholds aligned with owner policy so the superintelligent machine flags anomalies before they impact mission
+outcomes.

--- a/services/thermostat/README.md
+++ b/services/thermostat/README.md
@@ -1,46 +1,52 @@
-# AGI Jobs v0 (v2) — Services → Thermostat
+# AGI Jobs v0 (v2) — Thermostat Service
 
-> AGI Jobs v0 (v2) is our sovereign intelligence engine; this module extends that superintelligent machine with specialised capabilities for `services/thermostat`.
+[![CI (v2)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
+[![Python unit tests](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MontrealAI/AGIJobsv0/actions/workflows/ci.yml)
 
-## Overview
-- **Path:** `services/thermostat/README.md`
-- **Module Focus:** Anchors Services → Thermostat inside the AGI Jobs v0 (v2) lattice so teams can orchestrate economic, governance, and operational missions with deterministic guardrails.
-- **Integration Role:** Interfaces with the unified owner control plane, telemetry mesh, and contract registry to deliver end-to-end resilience.
+The thermostat keeps the Higher Governance Machine within owner-defined ROI bands. It consumes streaming metrics, adjusts HGM
+widening/Thompson parameters, and surfaces adjustments back to the orchestrator. Owners can tune the guardrails via `config/agialpha/`
+without changing code.
 
-## Capabilities
-- Provides opinionated configuration and assets tailored to `services/thermostat` while remaining interoperable with the global AGI Jobs v0 (v2) runtime.
-- Ships with safety-first defaults so non-technical operators can activate the experience without compromising security or compliance.
-- Publishes ready-to-automate hooks for CI, observability, and ledger reconciliation.
+## Core modules
 
-## Systems Map
+- **`controller.py`** – Implements `ThermostatController`, a feedback loop that ingests ROI samples, enforces cooldown windows, and
+  adjusts widening/Thompson parameters when ROI drifts outside the permitted margins.【F:services/thermostat/controller.py†L1-L160】
+- **`metrics.py`** – Defines the `MetricSample` dataclass and helpers for computing ROI snapshots delivered from orchestrator
+  workflows.【F:services/thermostat/metrics.py†L1-L160】
+- **`tests/`** – Pytest suite covering controller edge cases (cooldowns, boundary enforcement, concurrent updates).
+
 ```mermaid
 flowchart LR
-    Operators((Mission Owners)) --> services_thermostat[[Services → Thermostat]]
-    services_thermostat --> Core[[AGI Jobs v0 (v2) Core Intelligence]]
-    Core --> Observability[[Unified CI / CD & Observability]]
-    Core --> Governance[[Owner Control Plane]]
+    Metrics[Metrics stream] --> Controller[ThermostatController]
+    Controller --> Adjustments[EngineConfig adjustments]
+    Adjustments --> OrchestratorWorkflow
+    OrchestratorWorkflow --> Metrics
 ```
 
-## Working With This Module
-1. From the repository root run `npm install` once to hydrate all workspaces.
-2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `services/thermostat`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
-4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
+## Configuration
 
-## Directory Guide
-### Key Directories
-- `tests`
-### Key Files
-- `__init__.py`
-- `controller.py`
-- `metrics.py`
+Thermostat defaults live in `config/agialpha/thermostat.json`. CI regenerates the owner parameter matrix and fails if values fall
+outside safety thresholds, guaranteeing the contract owner can adjust targets at any time.【F:.github/workflows/ci.yml†L386-L434】
 
-## Quality & Governance
-- Every change must land through a pull request with all required checks green (unit, integration, linting, security scan).
-- Reference [`RUNBOOK.md`](../../RUNBOOK.md) and [`OperatorRunbook.md`](../../OperatorRunbook.md) for escalation patterns and owner approvals.
-- Keep secrets outside the tree; use the secure parameter stores wired to the AGI Jobs v0 (v2) guardian mesh.
+Key knobs:
 
-## Next Steps
-- Review this module's issue board for open automation, data, or research threads.
-- Link new deliverables back to the central manifest via `npm run release:manifest`.
-- Publish artefacts (dashboards, mermaid charts, datasets) into `reports/` for downstream intelligence alignment.
+- `target_roi` – Desired return-on-investment.
+- `lower_margin` / `upper_margin` – Permitted drift before adjustments trigger.
+- `widening_step` / `thompson_step` – Incremental adjustments applied to the HGM engine.
+
+## Local usage
+
+```python
+from services.thermostat.controller import ThermostatController, ThermostatConfig
+from orchestrator.workflows.hgm import HGMOrchestrationWorkflow
+
+controller = ThermostatController(workflow=workflow, config=ThermostatConfig())
+await controller.initialize()
+await controller.ingest(sample)  # sample is services.thermostat.metrics.MetricSample
+```
+
+CI v2 executes these tests as part of `ci (v2) / Python unit tests`, and the load-simulation job verifies ROI behaviour across
+Monte Carlo sweeps.【F:.github/workflows/ci.yml†L118-L345】【F:.github/workflows/ci.yml†L206-L272】
+
+Keep the thermostat aligned with owner requirements so mission owners can operate the superintelligent machine with predictable
+financial outcomes.


### PR DESCRIPTION
## Summary
- refresh the configuration and smart contract READMEs with current CI v2 commands, owner controls, and architecture diagrams
- update agent gateway, orchestrator, and SDK documentation to document runtime surfaces, environment knobs, and integration flows
- align Onebox, validator UI, and service README guides with the latest orchestrator pipeline so non-technical owners can operate safely

## Testing
- npm run lint:ci

------
https://chatgpt.com/codex/tasks/task_e_690611e18ca08333bfa40dd65b336434