### PR TITLE
docs: codify ci branch protection rehearsal

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -66,6 +66,18 @@ npm run ci:owner-authority -- --network ci --out reports/owner-control  # Regene
 CI v2 executes the same commands inside the `Lint & static checks` and `Owner control assurance` jobs, keeping the branch
 protection rule in lock-step with the manifests.【F:.github/workflows/ci.yml†L44-L70】【F:.github/workflows/ci.yml†L386-L434】
 
+### Branch-protection sync
+
+```bash
+npm run ci:sync-contexts -- --check
+npm run ci:verify-contexts
+npm run ci:verify-companion-contexts
+npm run ci:verify-branch-protection -- --branch main
+```
+
+- Run the four commands after changing manifests or shipping new workflows so GitHub’s branch rule mirrors the JSON manifest under `ci/`. The scripts diff job names, enforce companion workflows, and assert that the protected branch still requires every status you expect.【F:package.json†L132-L139】【F:ci/required-contexts.json†L1-L23】【F:ci/required-companion-contexts.json†L1-L11】
+- `ci:verify-branch-protection` reads the live rule via the GitHub API, which means it will fail fast if an administrator or automation drifts the policy without updating the repository—preserving owner control and CI visibility without dashboard spelunking.【F:package.json†L132-L139】
+
 ## Owner operations
 
 - **Pause / resume** – `npm run owner:system-pause -- --network <network>` toggles the global pause switch declared in

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -62,6 +62,28 @@ auto-selects `FileRunStateStore` when no environment variables are provided.【F
   defaults.【F:.github/workflows/ci.yml†L352-L420】
 - `ci (v2) / Load-simulation reports` consumes orchestrator metrics to generate Monte Carlo dissipation sweeps for owners.【F:.github/workflows/ci.yml†L206-L272】
 
+### CI handshake
+
+```mermaid
+sequenceDiagram
+    participant Dev as Maintainer
+    participant Runner as ci/hgm-suite.sh
+    participant PyUnit as pytest suites
+    participant Demo as HGM guided demo
+    participant CI as ci (v2)
+    Dev->>Runner: ci/hgm-suite.sh
+    Runner->>PyUnit: pytest tests/backend tests/orchestrator tests/routes/test_hgm_routes.py
+    Runner->>PyUnit: pytest demo/Huxley-Godel-Machine-v0/tests
+    Runner->>PyUnit: pytest packages/hgm-core/tests
+    Runner->>Demo: node demo/Huxley-Godel-Machine-v0/scripts/demo_hgm.js --seed 3
+    Demo-->>Runner: Deterministic transcript + metrics
+    Runner-->>CI: Exit 0 with summary log
+    CI-->>Maintainer: ci (v2) / HGM guardrails status & artefacts
+```
+
+- `ci/hgm-suite.sh` is the canonical entry point for orchestrator regression testing; it lints manifests, runs every Python orchestrator suite, and executes the deterministic Huxley–Gödel guided demo with seeded randomness so CI can diff behaviour across runs.【F:ci/hgm-suite.sh†L1-L34】
+- The guided demo output is echoed to `/tmp/hgm-demo.log` during CI, making it easy for owners to inspect ROI dynamics and validator interactions directly from the run artefacts.【F:ci/hgm-suite.sh†L20-L34】
+
 ## Extending the orchestrator
 
 1. Model the new mission in `models.py` and encode steps as subclasses where necessary.


### PR DESCRIPTION
## Summary
- expand the root README with a branch-protection rehearsal sequence and explicit local CI gate commands
- document branch-policy sync steps in `config/README.md` and enrich contracts, agent-gateway, and orchestrator READMEs with owner-control diagrams
- highlight owner rehearsal flows that keep the AGI Jobs v0 (v2) CI lattice visible and enforceable on main

## Testing
- npm run ci:sync-contexts -- --check
- npm run ci:verify-contexts
- npm run ci:verify-companion-contexts
- npm run ci:verify-branch-protection -- --branch main --owner MontrealAI --repo AGIJobsv0 --token dummy *(expected to fail without a GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_6906818c6d1c8333bf322891f4bc5f80