### PR TITLE
Harden CI summary artefact enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1256,6 +1256,7 @@ jobs:
         with:
           name: ci-summary
           path: reports/ci
+          if-no-files-found: error
 
   invariants:
     name: Invariant tests

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ flowchart TD
 - **Single source of truth:** The `ci (v2)` workflow exposes 23 required contexts that map 1:1 with [`ci/required-contexts.json`](ci/required-contexts.json). The lint stage fails fast when display names drift so branch protection never hides a status for owners or reviewers.【F:.github/workflows/ci.yml†L33-L71】【F:ci/required-contexts.json†L1-L23】
 - **Operations guide:** [CI v2 operations](docs/v2-ci-operations.md) and the [branch protection checklist](docs/ci-v2-branch-protection-checklist.md) walk administrators through enforcing the checks on `main`, including CLI commands that sync the rule and export an auditable status table for compliance teams.【F:docs/v2-ci-operations.md†L1-L182】【F:docs/ci-v2-branch-protection-checklist.md†L1-L206】
 - **Companion workflows:** Static analysis, fuzzing, web application smoke tests, orchestrator rehearsals, and deterministic e2e drills are all surfaced as required checks so the Checks tab stays comprehensible to non-technical stakeholders. Each badge above links directly to its workflow for live status and history.【F:.github/workflows/static-analysis.yml†L1-L157】【F:.github/workflows/fuzz.yml†L1-L144】【F:.github/workflows/webapp.yml†L1-L196】【F:.github/workflows/orchestrator-ci.yml†L1-L214】【F:.github/workflows/e2e.yml†L1-L164】
-- **Summary artefacts:** Every CI run uploads `reports/ci/status.md` and `status.json`, letting release captains attach a machine-readable audit trail to their change tickets without leaving GitHub.【F:.github/workflows/ci.yml†L1130-L1199】
+- **Summary artefacts:** Every CI run uploads `reports/ci/status.md` and `status.json`, letting release captains attach a machine-readable audit trail to their change tickets without leaving GitHub. The upload step now fails the workflow if the artefacts are ever missing, guaranteeing the evidence is immutable and reviewable.【F:.github/workflows/ci.yml†L1130-L1259】
 
 ### Pipeline topology
 ```mermaid
@@ -192,7 +192,7 @@ flowchart LR
     branchGuard --> summary
 ```
 
-- The summary job fans in from every required context, so a single failure keeps the workflow red and writes an auditable status table to `reports/ci/status.{md,json}` for administrators.【F:.github/workflows/ci.yml†L1130-L1199】
+- The summary job fans in from every required context, so a single failure keeps the workflow red and writes an auditable status table to `reports/ci/status.{md,json}` for administrators. If the summary bundle is missing, the workflow now fails immediately, preserving the evidence trail for compliance teams.【F:.github/workflows/ci.yml†L1130-L1259】
 - The branch protection guard audits the GitHub rule set against the JSON manifests, ensuring required contexts and companion workflows stay aligned with the enforced policy.【F:.github/workflows/ci.yml†L936-L1120】【F:ci/required-contexts.json†L1-L24】【F:ci/required-companion-contexts.json†L1-L11】
 - Python coverage consolidation depends explicitly on the unit and integration suites so coverage gates only report green when both analytics layers succeed.【F:.github/workflows/ci.yml†L280-L345】
 

--- a/docs/ci-v2-branch-protection-checklist.md
+++ b/docs/ci-v2-branch-protection-checklist.md
@@ -56,7 +56,7 @@ branch protection UI matches the automation surface.【F:ci/required-companion-c
 | Context                             | Source job                                         | Why it matters                                                                                                                                       |
 | ----------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ci (v2) / Branch protection guard` | [`branch_protection`](../.github/workflows/ci.yml) | Calls the GitHub API to verify branch protection matches these contexts and keeps administrators gated.【F:.github/workflows/ci.yml†L932-L1076】     |
-| `ci (v2) / CI summary`              | [`summary`](../.github/workflows/ci.yml)           | Aggregates upstream job results into a single ✅/❌ indicator and surfaces permitted skips for forked PRs.【F:.github/workflows/ci.yml†L1078-L1159】 |
+| `ci (v2) / CI summary`              | [`summary`](../.github/workflows/ci.yml)           | Aggregates upstream job results into a single ✅/❌ indicator, surfaces permitted skips for forked PRs, and fails if the status artefact bundle is missing.【F:.github/workflows/ci.yml†L1130-L1259】 |
 
 ### Companion workflows
 
@@ -121,7 +121,8 @@ gh api repos/:owner/:repo/branches/main/protection --jq '.enforce_admins.enabled
 3. Confirm the job is marked as **Required** in the run header. If it is missing, update branch protection immediately and re-run the workflow to refresh the badge.
 4. When troubleshooting, re-run the workflow with **Re-run failed jobs** so historical logs remain intact for incident reviews.
 5. Download the `ci-summary` artifact and archive `reports/ci/status.md` plus `status.json` with the change ticket; these files
-   mirror the on-screen table and prove which jobs were evaluated.【F:.github/workflows/ci.yml†L1033-L1159】
+   mirror the on-screen table and prove which jobs were evaluated. The upload step uses `if-no-files-found: error`, so a missing
+   artefact automatically fails the workflow and surfaces during review.【F:.github/workflows/ci.yml†L1130-L1259】
 
 ### 4. Double-check companion workflows
 

--- a/docs/v2-ci-operations.md
+++ b/docs/v2-ci-operations.md
@@ -84,7 +84,7 @@ Enable branch protection on `main` with every status context below. The list mir
 | Check context                       | Source job              | Notes                                                                             |
 | ----------------------------------- | ----------------------- | --------------------------------------------------------------------------------- |
 | `ci (v2) / Branch protection guard` | `branch_protection` job | Audits GitHub branch protection via the API and fails if required contexts drift. |
-| `ci (v2) / CI summary`              | `summary` job           | Aggregates upstream job outcomes and fails when any dependency is non-success.    |
+| `ci (v2) / CI summary`              | `summary` job           | Aggregates upstream job outcomes, fails when any dependency is non-success, and now enforces the presence of the status artefact bundle.    |
 
 > ✅ **Tip:** In GitHub branch protection, mark `Require branches to be up to date` and **Include administrators** so every push re-runs the workflow and administrators respect the gate.
 
@@ -134,7 +134,7 @@ Keep the rest of the release surface visible by marking the following workflows 
 2. Inspect the **Artifacts** section for `coverage-lcov` when coverage needs auditing.
 3. Review the `CI summary` job output for a condensed Markdown table of job results. The job now also archives the same table as
    `reports/ci/status.md` together with a machine-readable `status.json`, both available in the `ci-summary` artifact for
-   compliance records.【F:.github/workflows/ci.yml†L905-L960】 The table labels branch-protection skips on forks as `SKIPPED (permitted)` so reviewers know the guardrail remains enforced on `main`.
+   compliance records. The upload step is hardened with `if-no-files-found: error`, so missing artefacts flip the entire workflow red instead of silently succeeding.【F:.github/workflows/ci.yml†L1130-L1259】 The table labels branch-protection skips on forks as `SKIPPED (permitted)` so reviewers know the guardrail remains enforced on `main`.
 4. When re-running failed jobs, choose **Re-run failed jobs** to keep historical logs.
 5. If a dependent job unexpectedly skips, inspect the workflow definition to confirm the `if: ${{ always() }}` guard is still present.
 


### PR DESCRIPTION
## Summary
- fail the CI summary artefact upload when the reports directory is missing so the workflow never goes green without evidence
- refresh the top-level README and CI runbooks to document the stronger enforcement and keep citations in sync

## Testing
- npm run ci:verify-contexts
- npm run ci:verify-companion-contexts
- npm run ci:sync-contexts -- --check


------
https://chatgpt.com/codex/tasks/task_e_6906818c6d1c8333bf322891f4bc5f80