### PR TITLE
Document CI branch protection verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,12 @@ Companion workflows are also required (`static-analysis`, `fuzz`, `webapp`, `con
    ```bash
    npm run ci:enforce-branch-protection -- --dry-run --branch main
    ```
-3. Apply the rule (requires repo admin token):
+3. Verify the GitHub rule via the public API without mutating anything (requires a fine-grained PAT or GitHub App token with `administration:read` scope):
+   ```bash
+   GITHUB_TOKEN=<token> npm run ci:verify-branch-protection -- --owner MontrealAI --repo AGIJobsv0 --branch main
+   ```
+   The script confirms the live protection rule matches `ci/required-contexts.json` and `ci/required-companion-contexts.json`, failing if the GitHub configuration is stale or missing contexts.【F:package.json†L138-L146】【F:scripts/ci/verify-branch-protection.ts†L1-L239】
+4. Apply the rule (requires repo admin token):
    ```bash
    npm run ci:enforce-branch-protection -- --branch main
    ```

--- a/ci/README.md
+++ b/ci/README.md
@@ -113,7 +113,12 @@ Use `npm run ci:verify-companion-contexts` to make sure the manifest stays synch
    ```bash
    npm run ci:enforce-branch-protection -- --dry-run --branch main
    ```
-2. Apply enforcement after reviewing the dry-run output:
+2. Verify the live GitHub rule against the manifests (requires a fine-grained PAT with `administration:read` scope or a GitHub App token):
+   ```bash
+   GITHUB_TOKEN=<token> npm run ci:verify-branch-protection -- --owner MontrealAI --repo AGIJobsv0 --branch main
+   ```
+   The script fetches branch protection via the REST API, compares the enforced contexts to `required-contexts.json` and `required-companion-contexts.json`, and fails if any item is missing or out of order.【F:package.json†L138-L146】【F:scripts/ci/verify-branch-protection.ts†L1-L239】
+3. Apply enforcement after reviewing the dry-run output:
    ```bash
    npm run ci:enforce-branch-protection -- --branch main
    ```


### PR DESCRIPTION
## Summary
- document the CI branch protection verification command in the top-level README
- extend the CI deck to show how to audit branch protection against the manifests via the GitHub API

## Testing
- npm run lint:ci

------
https://chatgpt.com/codex/tasks/task_e_6907c97cae3483339ca99bca6c436041