### PR TITLE
Harden branch protection guard to succeed on forked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -965,7 +965,6 @@ jobs:
 
   branch_protection:
     name: Branch protection guard
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -973,15 +972,29 @@ jobs:
       pull-requests: read
       administration: read
     steps:
+      - name: Detect fork context
+        id: fork_context
+        run: |
+          if [ "${IS_FORK}" = "true" ]; then
+            echo "Detected forked pull_request context; branch protection audit will be skipped because the token lacks administration:read scope."
+            echo "fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "fork=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
       - name: Harden runner
+        if: steps.fork_context.outputs.fork == 'false'
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
           egress-policy: audit
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        if: steps.fork_context.outputs.fork == 'false'
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Node
+        if: steps.fork_context.outputs.fork == 'false'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: '.nvmrc'
@@ -990,12 +1003,21 @@ jobs:
             package-lock.json
             **/package-lock.json
       - name: Install dependencies
+        if: steps.fork_context.outputs.fork == 'false'
         run: ./scripts/ci/npm-ci.sh --no-audit --prefer-offline --progress=false
       - name: Verify branch protection configuration
+        if: steps.fork_context.outputs.fork == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: main
         run: npm run ci:verify-branch-protection -- --branch "$BRANCH_NAME"
+      - name: Record fork bypass for summary
+        if: steps.fork_context.outputs.fork == 'true'
+        run: |
+          mkdir -p reports/ci
+          cat <<'EOF' >> reports/ci/status.md
+          > Branch protection audit skipped automatically because this run originates from a forked pull request without the required administrative scope. The required context remains green on protected branches.
+          EOF
 
   summary:
     name: CI summary

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The branch protection rule enforces the following `ci (v2)` contexts, guaranteei
 | Sovereign Constellation Demo — build | Builds constellation orchestrator + console assets.【F:.github/workflows/ci.yml†L818-L855】 |
 | Celestial Archon Demonstration | Deterministic + local rehearsals for Celestial Archon governance.【F:.github/workflows/ci.yml†L856-L910】 |
 | Hypernova Governance Demonstration | Hypernova rehearsal with local deterministic replay.【F:.github/workflows/ci.yml†L911-L965】 |
-| Branch protection guard | Audits GitHub branch protection live against the manifests and fails on drift.【F:.github/workflows/ci.yml†L966-L999】【F:ci/required-contexts.json†L1-L24】 |
+| Branch protection guard | Audits GitHub branch protection live against the manifests and fails on drift. Forked PRs log a bypass note yet keep the required context green so protected branches still enforce the policy.【F:.github/workflows/ci.yml†L966-L1089】【F:ci/required-contexts.json†L1-L24】 |
 | CI summary | Aggregates every job outcome, writes Markdown + JSON status artefacts, and fails if any job was red or artefacts are missing.【F:.github/workflows/ci.yml†L1000-L1130】 |
 | Invariant tests | Dedicated Forge invariant suite with cached build graph and fuzz tuning.【F:.github/workflows/ci.yml†L1131-L1181】 |
 
@@ -192,7 +192,7 @@ The manifest in `ci/required-companion-contexts.json` marks every companion work
    ```bash
    npm run ci:enforce-branch-protection -- --branch main
    ```
-   The branch protection guard job revalidates these expectations on every push to `main`, keeping policy and automation in sync.【F:package.json†L135-L146】【F:.github/workflows/ci.yml†L966-L999】
+   The branch protection guard job revalidates these expectations on every push to `main`, keeping policy and automation in sync while gracefully bypassing forked PRs that lack administrative scope.【F:package.json†L135-L146】【F:.github/workflows/ci.yml†L966-L1089】
 
 ### Artefacts
 - `reports/ci/status.{md,json}` – machine-readable run summaries consumed by release captains and compliance audits.【F:.github/workflows/ci.yml†L1000-L1130】

--- a/ci/README.md
+++ b/ci/README.md
@@ -91,7 +91,7 @@ flowchart LR
 | `sovereign_constellation_demo` | `ci (v2) / Sovereign Constellation Demo — build` | Constellation orchestrator + console build.【F:.github/workflows/ci.yml†L818-L855】 |
 | `celestial_archon_demo` | `ci (v2) / Celestial Archon Demonstration` | Celestial Archon deterministic + local rehearsals.【F:.github/workflows/ci.yml†L856-L910】 |
 | `hypernova_demo` | `ci (v2) / Hypernova Governance Demonstration` | Hypernova deterministic + local rehearsals.【F:.github/workflows/ci.yml†L911-L965】 |
-| `branch_protection` | `ci (v2) / Branch protection guard` | Live GitHub branch protection audit against manifests.【F:.github/workflows/ci.yml†L966-L999】【F:ci/required-contexts.json†L1-L24】 |
+| `branch_protection` | `ci (v2) / Branch protection guard` | Live GitHub branch protection audit against manifests. Fork pull requests emit a bypass note yet leave the required context green so enforcement still lands on protected branches.【F:.github/workflows/ci.yml†L966-L1089】【F:ci/required-contexts.json†L1-L24】 |
 | `summary` | `ci (v2) / CI summary` | Aggregates job outcomes, writes `reports/ci/status.{md,json}`, fails on missing artefacts or red jobs.【F:.github/workflows/ci.yml†L1000-L1130】 |
 | `invariants` | `ci (v2) / Invariant tests` | Forge invariant harness with fuzz-runs 512.【F:.github/workflows/ci.yml†L1131-L1181】 |
 
@@ -143,7 +143,7 @@ Every arrow represents a required status entry on the pull-request checks wall. 
    ```bash
    npm run ci:enforce-branch-protection -- --branch main
    ```
-   The branch protection guard job uses the same manifests and fails the workflow if enforcement is misconfigured, keeping `main` locked to the manifest expectations.【F:package.json†L135-L146】【F:.github/workflows/ci.yml†L966-L999】
+   The branch protection guard job uses the same manifests and fails the workflow if enforcement is misconfigured, keeping `main` locked to the manifest expectations while still succeeding on forked PRs that cannot call the admin API.【F:package.json†L135-L146】【F:.github/workflows/ci.yml†L966-L1089】
 
 ## Artefacts & forensic trail
 - `reports/ci/status.{md,json}` – Consolidated run summary and JSON feed for downstream dashboards.【F:.github/workflows/ci.yml†L1000-L1130】


### PR DESCRIPTION
## Summary
- update the branch protection guard job to detect forked pull requests, skip the API call safely, and leave an audit note instead of dropping the required status
- refresh the root README and CI deck to explain the fork bypass behaviour while keeping branch protection enforcement guidance up to date

## Testing
- npm run ci:verify-contexts
- npm run ci:verify-companion-contexts

------
https://chatgpt.com/codex/tasks/task_e_6907dcb5ec3483339b81b4891e594d26