### PR TITLE
Clarify CI parity prerequisites for developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,15 @@ AGI Jobs v0 (v2) is delivered as a production-hardened intelligence core that fu
    npm run ci:verify-companion-contexts
    ```
    The sync command confirms `ci/required-contexts.json` matches the workflow before the verification scripts enforce ordering, so keeping this quartet green locally mirrors branch protection expectations.【F:package.json†L135-L150】【F:scripts/ci/update-ci-required-contexts.ts†L1-L83】【F:.github/workflows/ci.yml†L34-L74】
-4. Validate the critical suites:
+4. Validate the critical suites (prime the Hardhat cache once so local runs mirror CI performance):
    ```bash
-   npm test
+   npm run compile           # generates artifacts exactly like the tests job
+   npm test                  # reuses the compiled artefacts, matching ci (v2) / Tests
    npm run lint:ci
    npm run coverage
    forge test -vvvv --ffi --fuzz-runs 256
    ```
-   These commands reproduce the Hardhat, linting, coverage, and Foundry stages the pipeline requires.【F:package.json†L233-L245】【F:.github/workflows/ci.yml†L75-L546】
+   Compiling first avoids the local fallback where `hardhat test --no-compile` triggers a fresh Solidity build, bringing the experience in line with the workflow’s dedicated compile step before `npm test`. These commands reproduce the Hardhat, linting, coverage, and Foundry stages the pipeline requires.【F:package.json†L233-L245】【F:.github/workflows/ci.yml†L75-L546】
 5. When the signal is green, push signed commits and open a pull request—CI v2 enforces the exact same contexts on `main` and PRs.
 
 ## Repository atlas

--- a/docs/BRANCH_PROTECTION.md
+++ b/docs/BRANCH_PROTECTION.md
@@ -42,13 +42,15 @@ To keep `main` deployable at all times, enable the following rules in the GitHub
      - `containers / build (owner-console)`
      - *(Optional, path-filtered)* `apps-images / console` and `apps-images / portal` for Docker image safety when `apps/**` changes.
 
-   After saving the rule, verify the required contexts programmatically:
+   After saving the rule, verify the required contexts programmatically. The fastest option is to run the repository scripts that parse `.github/workflows/ci.yml` and compare it with the live rule:
 
    ```bash
-   gh api repos/:owner/:repo/branches/main/protection --jq '{checks: .required_status_checks.contexts}'
+   npm run ci:verify-contexts
+   npm run ci:verify-companion-contexts
+   npm run ci:verify-branch-protection -- --branch main
    ```
 
-   The response must list the contexts above in the same order. If the API returns a subset, rerun `npm run ci:verify-branch-protection` to surface the exact delta and restore parity with the workflow job names.
+   Each command prints a ✅/❌ table and exits non-zero if drift is detected, making them ideal for change tickets and runbooks.【F:scripts/ci/check-ci-required-contexts.ts†L1-L117】【F:scripts/ci/check-ci-companion-contexts.ts†L1-L74】【F:scripts/ci/verify-branch-protection.ts†L1-L220】 If you prefer raw API output, `gh api repos/:owner/:repo/branches/main/protection --jq '{checks: .required_status_checks.contexts}'` must list the contexts above in the same order. Any mismatch means the rule needs to be updated immediately.
 
    > **Fork pull requests:** `ci (v2) / Branch protection guard` requires elevated repository permissions. When a forked PR runs the workflow, that job skips automatically and the CI summary labels it as “SKIPPED (permitted)”. Branch protection still enforces the job on `main` and trusted branches.
 


### PR DESCRIPTION
## Summary
- highlight the compile warmup step in the root README so local Hardhat runs mirror the `ci (v2)` workflow before executing tests
- document the repository scripts that verify branch-protection contexts to keep administrators aligned with the workflow manifest

## Testing
- npm run ci:preflight
- ./scripts/ci/npm-ci.sh --no-audit --prefer-offline --progress=false
- npm run lint:ci
- npm run ci:verify-contexts
- npm run ci:verify-companion-contexts

------
https://chatgpt.com/codex/tasks/task_e_690912e479b883338a12e9c45d14ae57