### PR TITLE
Add summary coverage guard for CI status wall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
         run: npm run ci:verify-contexts
       - name: Verify companion workflow contexts
         run: npm run ci:verify-companion-contexts
+      - name: Verify CI summary coverage vs workflow
+        run: npm run ci:verify-summary-needs
       - name: Prettier formatting check
         run: npm run format:check
       - name: Targeted lint suite
@@ -1055,6 +1057,14 @@ jobs:
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
           egress-policy: audit
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate summary needs coverage
+        env:
+          NEEDS_CONTEXT: ${{ toJson(needs) }}
+        run: node scripts/ci/check-summary-needs.js
       - name: Publish pipeline summary
         env:
           NEEDS_CONTEXT: ${{ toJson(needs) }}

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ scripts/**/*.js
 !scripts/ci/check-lock-integrity.js
 !scripts/ci/ensure-tag-signature.js
 !scripts/ci/check-signers.js
+!scripts/ci/check-summary-needs.js
 !scripts/verify-wiring.js
 !scripts/run-wire-verify.js
 !scripts/subgraph-e2e.js

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ The same manifest powers the branch-protection guard inside CI v2 and the local 
    npm run ci:sync-contexts -- --check
    npm run ci:verify-contexts
    npm run ci:verify-companion-contexts
+   npm run ci:verify-summary-needs
    ```
-   The sync command confirms `ci/required-contexts.json` matches the workflow before the verification scripts enforce ordering, so keeping this quartet green locally mirrors branch protection expectations.【F:package.json†L135-L150】【F:scripts/ci/update-ci-required-contexts.ts†L1-L83】【F:.github/workflows/ci.yml†L34-L74】
+   The sync command confirms `ci/required-contexts.json` matches the workflow before the verification scripts enforce ordering, and the summary check proves the wall coverage is intact—keeping this quintet green locally mirrors branch protection expectations.【F:package.json†L135-L150】【F:scripts/ci/update-ci-required-contexts.ts†L1-L83】【F:scripts/ci/check-summary-needs.js†L1-L79】【F:.github/workflows/ci.yml†L34-L74】【F:.github/workflows/ci.yml†L1009-L1077】
 4. Validate the critical suites (prime the Hardhat cache once so local runs mirror CI performance):
    ```bash
    npm run compile           # generates artifacts exactly like the tests job

--- a/ci/README.md
+++ b/ci/README.md
@@ -39,6 +39,8 @@ Every required context publishes its own badge so the assurance wall is visible 
 
 The `ci/` deck defines the manifest, verification scripts, and artefacts that keep AGI Jobs v0 (v2) permanently green. Required contexts here mirror the branch protection rule; automation in `.github/workflows/ci.yml` fails immediately when drift is detected, so release captains always see the full assurance wall.【F:.github/workflows/ci.yml†L22-L292】【F:.github/workflows/ci.yml†L970-L1155】
 
+Run `npm run ci:verify-summary-needs` whenever you touch `.github/workflows/ci.yml` to double-check that the `CI summary` job’s `needs` array spans every non-summary job. The script parses the workflow, confirms the lattice is complete, and fails fast if any required job is omitted or duplicated so the wall cannot silently degrade.【F:package.json†L135-L143】【F:scripts/ci/check-summary-needs.js†L1-L79】【F:.github/workflows/ci.yml†L1009-L1077】
+
 ## Workflow topology
 ```mermaid
 flowchart LR

--- a/docs/status-wall.md
+++ b/docs/status-wall.md
@@ -38,14 +38,15 @@ required-context manifest [`ci/required-contexts.json`](../ci/required-contexts.
 Follow this checklist whenever you add, rename, or remove a required status context:
 
 1. Update [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) with the new job definition or edits.
-2. Run `npm run ci:sync-contexts -- --check` to ensure the manifest is in sync. If the job list changes, regenerate it with
+2. Run `npm run ci:verify-summary-needs` to ensure the `CI summary` job references every non-summary job. The script fails fast when the wall would lose coverage, so catch drift before manifests are regenerated.【F:scripts/ci/check-summary-needs.js†L1-L79】【F:package.json†L135-L143】【F:.github/workflows/ci.yml†L1009-L1077】
+3. Run `npm run ci:sync-contexts -- --check` to ensure the manifest is in sync. If the job list changes, regenerate it with
    `npm run ci:sync-contexts` and commit the updated [`ci/required-contexts.json`](../ci/required-contexts.json).
-3. Re-run `npm run ci:verify-contexts` and `npm run ci:verify-companion-contexts` to confirm the enforcement scripts agree with
+4. Re-run `npm run ci:verify-contexts` and `npm run ci:verify-companion-contexts` to confirm the enforcement scripts agree with
 the manifests.
-4. Refresh the wall output for documentation by executing
+5. Refresh the wall output for documentation by executing
    `npm run ci:status-wall -- --token $GITHUB_TOKEN --format markdown > reports/ci/status-wall.md` and copy the table into the
    README or release briefings as needed.
-5. Update [`README.md`](../README.md), [`ci/README.md`](../ci/README.md), and this document so that the mapping, job IDs, and
+6. Update [`README.md`](../README.md), [`ci/README.md`](../ci/README.md), and this document so that the mapping, job IDs, and
    badges match the manifest.
 
 When introducing a brand-new workflow (for example a companion pipeline), also update

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "ci:owner-authority": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/ci/render-owner-assurance.ts",
     "ci:verify-contexts": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/ci/check-ci-required-contexts.ts",
     "ci:verify-companion-contexts": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/ci/check-ci-companion-contexts.ts",
+    "ci:verify-summary-needs": "node scripts/ci/check-summary-needs.js",
     "ci:status-wall": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/ci/check-ci-status-wall.ts",
     "ci:verify-signers": "node scripts/ci/check-signers.js",
     "ci:verify-toolchain": "node scripts/ci/check-toolchain-locks.js",

--- a/scripts/ci/check-summary-needs.js
+++ b/scripts/ci/check-summary-needs.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+const { readFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+
+const WORKFLOW_PATH = resolve(__dirname, '../../.github/workflows/ci.yml');
+
+function extractJobsAndSummaryNeeds(content) {
+  const lines = content.split(/\r?\n/);
+  const jobIds = [];
+  const summaryNeeds = [];
+  let currentJob = null;
+  let insideSummaryNeeds = false;
+  let inJobsSection = false;
+
+  for (const line of lines) {
+    if (!inJobsSection) {
+      if (/^jobs:\s*$/.test(line)) {
+        inJobsSection = true;
+      }
+      continue;
+    }
+
+    if (/^[A-Za-z0-9_]+:\s*$/.test(line)) {
+      // Reached another top-level section after jobs.
+      break;
+    }
+
+    const jobMatch = line.match(/^  ([A-Za-z0-9_]+):\s*$/);
+    if (jobMatch) {
+      currentJob = jobMatch[1];
+      jobIds.push(currentJob);
+      insideSummaryNeeds = false;
+      continue;
+    }
+
+    if (currentJob === 'summary') {
+      if (/^ {4}needs:\s*$/.test(line)) {
+        insideSummaryNeeds = true;
+        summaryNeeds.length = 0;
+        continue;
+      }
+
+      if (insideSummaryNeeds) {
+        const needsMatch = line.match(/^ {6}- ([A-Za-z0-9_]+)\s*$/);
+        if (needsMatch) {
+          summaryNeeds.push(needsMatch[1]);
+          continue;
+        }
+
+        if (/^ {4}\S/.test(line) || /^ {0,3}\S/.test(line)) {
+          insideSummaryNeeds = false;
+        }
+      }
+    }
+  }
+
+  return { jobIds, summaryNeeds };
+}
+
+function main() {
+  const workflowRaw = readFileSync(WORKFLOW_PATH, 'utf8');
+  const { jobIds, summaryNeeds } = extractJobsAndSummaryNeeds(workflowRaw);
+
+  if (jobIds.length === 0) {
+    throw new Error('No jobs discovered in ci.yml.');
+  }
+
+  if (!jobIds.includes('summary')) {
+    throw new Error('ci.yml is missing the summary job.');
+  }
+
+  const expected = jobIds.filter((jobId) => jobId !== 'summary');
+  const missing = expected.filter((jobId) => !summaryNeeds.includes(jobId));
+  const extra = summaryNeeds.filter((jobId) => !expected.includes(jobId));
+
+  if (missing.length > 0 || extra.length > 0) {
+    const issues = [];
+    if (missing.length > 0) {
+      issues.push(`missing needs entries: ${missing.join(', ')}`);
+    }
+    if (extra.length > 0) {
+      issues.push(`unexpected needs entries: ${extra.join(', ')}`);
+    }
+    throw new Error(
+      `ci (v2) summary needs list does not match job set (${issues.join('; ')}).`
+    );
+  }
+
+  if (summaryNeeds.length !== expected.length) {
+    throw new Error(
+      `ci (v2) summary needs ${summaryNeeds.length} jobs but ${expected.length} were discovered.`
+    );
+  }
+
+  console.log(
+    `✅ ci (v2) summary needs list covers ${summaryNeeds.length} jobs (all non-summary jobs).`
+  );
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(String(error instanceof Error ? error.message : error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a workflow validation step that confirms the CI summary job depends on every other job
- ship a reusable `ci:verify-summary-needs` script and surface the guard in the contributor docs and status-wall playbook
- ensure the new checker is tracked in gitignore and executed during linting and the CI summary job itself

## Testing
- `npm run ci:verify-summary-needs`


------
https://chatgpt.com/codex/tasks/task_e_690a1cc2081c8333a52099b5941a064b