### PR TITLE
Add orchestration coverage tests and align Python deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - `RandaoCoordinator.random` now mixes the XORed seed with `block.prevrandao` for block-dependent entropy.
 - Default identity cache durations for agents and validators are now zero so every job application and validation commit requires a fresh ENS proof; governance can extend the cache via on-chain setters if necessary.
 - Added scripted ABI exports with diff checking, ensured coverage enforcement scripts skip gracefully when artifacts are absent, and vendored forge-std so Foundry fuzzing runs without extra setup.
+- Expanded the Python coverage harness with worker and simulation regression tests and ensured the editable `hgm_core` package is installed via `requirements-python.txt` so the CI parity instructions stay reproducible.
 
 ## v1
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The same manifest powers the branch-protection guard inside CI v2 and the local 
    forge test -vvvv --ffi --fuzz-runs 256
    ```
    Compiling first avoids the local fallback where `hardhat test --no-compile` triggers a fresh Solidity build, bringing the experience in line with the workflow’s dedicated compile step before `npm test`. These commands reproduce the Hardhat, linting, coverage, and Foundry stages the pipeline requires.【F:package.json†L233-L245】【F:.github/workflows/ci.yml†L75-L546】
+   The Python coverage harness additionally exercises the HGM worker dispatcher and sharded simulation CLI so CI’s 85% gate reflects the orchestrator workloads developers rehearse locally.【F:test/orchestrator/test_worker.py†L1-L41】【F:test/simulation/test_harness.py†L1-L19】【F:test/simulation/test_sharded_simulation.py†L1-L68】
 5. When the signal is green, push signed commits and open a pull request—CI v2 enforces the exact same contexts on `main` and PRs.
 
 ## Repository atlas

--- a/requirements-python.txt
+++ b/requirements-python.txt
@@ -1,4 +1,5 @@
 -r services/meta_api/requirements.txt
+-e packages/hgm-core
 
 # Testing toolchain
 coverage==7.6.4

--- a/test/orchestrator/test_worker.py
+++ b/test/orchestrator/test_worker.py
@@ -1,0 +1,41 @@
+import asyncio
+
+import pytest
+
+from orchestrator.worker import build_worker, run_worker_forever
+
+
+def test_build_worker_and_dispatch_records_events():
+    async def runner() -> None:
+        worker = build_worker(concurrency=2)
+        await worker.workflow.ensure_node("root")
+
+        await worker.dispatch("hgm.expand", "root", "child", payload={"quality": 0.8})
+        await worker.dispatch("hgm.evaluate", "root", 0.75, weight=0.5, payload={"score": 0.75})
+
+        assert worker.workflow.expansion_events, "Expansion dispatch should record an event"
+        assert worker.workflow.evaluation_events, "Evaluation dispatch should record an event"
+
+        with pytest.raises(KeyError):
+            await worker.dispatch("unknown.activity")
+
+    asyncio.run(runner())
+
+
+def test_run_worker_forever_invokes_sleep(monkeypatch):
+    async def runner() -> None:
+        worker = build_worker()
+        calls: list[float] = []
+
+        async def fake_sleep(interval: float) -> None:
+            calls.append(interval)
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        with pytest.raises(asyncio.CancelledError):
+            await run_worker_forever(worker)
+
+        assert calls == [3600], "Worker loop should sleep for an hour between polls"
+
+    asyncio.run(runner())

--- a/test/simulation/test_harness.py
+++ b/test/simulation/test_harness.py
@@ -1,0 +1,19 @@
+import asyncio
+
+from simulation.hgm.harness import run_simulation
+
+
+def test_run_simulation_generates_snapshot():
+    async def runner() -> None:
+        snapshot = await run_simulation(expansions=3, concurrency=2, seed=123)
+
+        assert "root" in snapshot
+        child_entries = {key: data for key, data in snapshot.items() if key.startswith("root/")}
+        assert child_entries, "Simulation should expand child nodes"
+        for payload in child_entries.values():
+            assert "visits" in payload
+            assert payload["visits"] >= 1
+            metadata = payload.get("metadata", {})
+            assert "quality" in metadata
+
+    asyncio.run(runner())

--- a/test/simulation/test_sharded_simulation.py
+++ b/test/simulation/test_sharded_simulation.py
@@ -1,0 +1,84 @@
+from argparse import ArgumentTypeError, Namespace
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from simulation.run_sharded_simulation import _parse_workload_mix, build_config_from_args
+from simulation.sharded_simulation import default_config, run_sharded_simulation
+from simulation.simulation_reports import export_reports
+
+
+def test_parse_workload_mix_valid_and_invalid():
+    mix = _parse_workload_mix("alpha=0.6,beta=0.4")
+    assert mix == {"alpha": 0.6, "beta": 0.4}
+
+    with pytest.raises(ArgumentTypeError):
+        _parse_workload_mix("")
+    with pytest.raises(ArgumentTypeError):
+        _parse_workload_mix("invalid")
+
+
+def test_build_config_from_args_defaults_and_custom():
+    default_args = Namespace(
+        use_defaults=True,
+        total_jobs=50,
+        shard_count=4,
+        jobs_per_tick=10,
+        failure_injection_chance=0.05,
+        failure_recovery_ticks=3,
+        orchestrator_kill_tick=20,
+        orchestrator_downtime=2,
+        seed=42,
+        workload=[],
+        workload_mix="baseline=1.0",
+    )
+    config = build_config_from_args(default_args)
+    assert config.total_jobs == 50
+    assert config.failure_injection_chance == pytest.approx(0.05)
+    assert config.orchestrator_kill_tick == 20
+
+    custom_args = Namespace(
+        use_defaults=False,
+        total_jobs=30,
+        shard_count=2,
+        jobs_per_tick=5,
+        failure_injection_chance=0.1,
+        failure_recovery_ticks=2,
+        orchestrator_kill_tick=10,
+        orchestrator_downtime=1,
+        seed=7,
+        workload=["fast:0.9,2,0.5"],
+        workload_mix="fast=1.0",
+    )
+    custom_config = build_config_from_args(custom_args)
+    assert custom_config.workloads["fast"].success_probability == pytest.approx(0.9)
+    assert custom_config.workload_mix == {"fast": 1.0}
+
+
+def test_run_sharded_simulation_and_reports(tmp_path: Path):
+    config = default_config(total_jobs=40, shard_count=3)
+    config = replace(
+        config,
+        jobs_per_tick=100,
+        failure_injection_chance=0.0,
+        failure_recovery_ticks=1,
+        orchestrator_kill_tick=5,
+        orchestrator_downtime_ticks=1,
+        random_seed=123,
+    )
+
+    result = run_sharded_simulation(config)
+    assert result.total_jobs == 40
+    assert result.failure_rate < 0.05
+    result.assert_failure_rate(0.1)
+
+    export_reports(result, tmp_path)
+    jobs_csv = tmp_path / "jobs.csv"
+    summary_json = tmp_path / "summary_detailed.json"
+    throughput_plot = tmp_path / "throughput.png"
+
+    assert jobs_csv.exists()
+    assert summary_json.exists()
+    assert throughput_plot.exists()
+    assert "total_jobs" in summary_json.read_text()


### PR DESCRIPTION
## Summary
- add regression coverage for the HGM worker dispatcher and sharded simulation tooling to ensure the Python gate exercises orchestration workloads
- wire the local hgm_core package into requirements-python.txt so coverage and pytest runs resolve shared engine primitives without manual installs
- document the expanded coverage harness in the README and changelog for CI parity

## Testing
- npm run ci:preflight
- npm run lint
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 COVERAGE_FILE=.coverage.unit coverage run --rcfile=.coveragerc -m pytest test/paymaster test/tools test/orchestrator test/simulation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 COVERAGE_FILE=.coverage.unit coverage run --rcfile=.coveragerc --append -m pytest tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 COVERAGE_FILE=.coverage.unit coverage run --rcfile=.coveragerc --append -m pytest packages/hgm-core/tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 COVERAGE_FILE=.coverage.unit coverage run --rcfile=.coveragerc --append -m pytest demo/Huxley-Godel-Machine-v0/tests
- COVERAGE_FILE=.coverage.integration PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 coverage run --rcfile=.coveragerc -m pytest test/routes/test_agents.py test/routes/test_analytics.py test/routes/test_onebox_health.py test/demo demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests
- coverage report --rcfile=.coveragerc

------
https://chatgpt.com/codex/tasks/task_e_690a32b1b234833387dd9a1858e5be65