### PR TITLE
Fix owner command center digest invocation in CI v2 pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,11 @@ jobs:
       - name: Render owner command center digest
         run: |
           mkdir -p reports/owner-control
-          npm run owner:command-center -- --network ci --format markdown --out reports/owner-control/command-center.md --no-mermaid
+          npm run owner:command-center -- \
+            --network ci \
+            --format markdown \
+            --out reports/owner-control/command-center.md \
+            --no-mermaid
       - name: Upload owner control artefacts
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02


### PR DESCRIPTION
## Summary
- prevent the CI owner-control job from splitting the `--no-mermaid` flag onto a new line
- ensure the owner command center digest uses explicit line continuations so the command executes as intended

## Testing
- npm run ci:verify-summary-needs
- npm run ci:sync-contexts -- --check
- npm run ci:verify-companion-contexts

------
https://chatgpt.com/codex/tasks/task_e_690a7a5cc1448333bd9211eda1bb420e