### PR TITLE
Add mainnet token guard and refresh deployment docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -38,3 +38,15 @@ This document tracks contract and configuration migrations required when deployi
 
 - All migration-related pull requests must keep the `ci (v2) / HGM guardrails` status check green. The job validates the AGIALPHA profile configuration, runs the HGM regression suites, lints the demo assets, and smoke-tests the guided launcher.
 - Run `ci/hgm-suite.sh` locally (after `npm ci` and `pip install -r requirements-python.txt`) before raising change-control requests so the HGM guardrails job passes deterministically in CI.
+
+## Mainnet deployment guard (AGIALPHA)
+
+Execute these steps when promoting agijobs-sovereign-labor-v0p1 to Ethereum mainnet:
+
+1. **Verify manifests** – `npm run verify:agialpha -- --network mainnet` checks that `config/agialpha.mainnet.json` references the canonical 18-decimal AGIALPHA token (`0xa61a3b3a130a9c20768eebf97e21515a6046a1fa`) and synchronises metadata with on-chain values.【F:scripts/verify-agialpha.ts†L1-L214】【F:config/agialpha.mainnet.json†L1-L26】
+2. **Refresh deployment plan** – Review `deployment-config/mainnet.json` to confirm treasury, pause defaults, and ENS wiring match the release intent. Update the file if governance requested changes, then commit it for auditability.【F:deployment-config/mainnet.json†L1-L43】
+3. **Run Truffle migrations** – `npx truffle migrate --network mainnet --f 1 --to 5` executes the canonical migration suite. Migration `2a_validate_mainnet_token` enforces the token address/decimals, `2_deploy_protocol` deploys the deterministic module set, and `3_wire_protocol` wires governance + ENS roots.【F:migrations/2a_validate_mainnet_token.js†L1-L118】【F:migrations/2_deploy_protocol.js†L1-L45】【F:migrations/3_wire_protocol.js†L1-L120】
+4. **Capture owner artefacts** – `npm run owner:command-center -- --network mainnet --out reports/owner-control` regenerates the governance dossier for compliance archives and the CI owner-control job.【F:package.json†L372-L375】【F:.github/workflows/ci.yml†L414-L439】
+5. **Upload deployment addresses** – Update `docs/deployment-addresses.json` with the emitted contract addresses and commit the change so downstream services align with the new release.【F:migrations/3_wire_protocol.js†L1-L92】
+
+Every step is automated inside CI v2; running the checklist locally ensures the on-chain state matches the manifests before branch protection unlocks the release PR.

--- a/migrations/2a_validate_mainnet_token.js
+++ b/migrations/2a_validate_mainnet_token.js
@@ -1,0 +1,124 @@
+const { ethers } = require('ethers');
+const { loadTokenConfig } = require('../scripts/config');
+
+const CANONICAL_MAINNET_TOKEN = '0xa61a3b3a130a9c20768eebf97e21515a6046a1fa';
+
+const ERC20_METADATA_ABI = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'decimals',
+    outputs: [{ name: '', type: 'uint8' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'symbol',
+    outputs: [{ name: '', type: 'string' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'name',
+    outputs: [{ name: '', type: 'string' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+function normaliseNetworkKey(rawNetwork, resolvedNetwork) {
+  if (resolvedNetwork && resolvedNetwork.trim()) {
+    return resolvedNetwork.trim().toLowerCase();
+  }
+  if (rawNetwork && typeof rawNetwork === 'string') {
+    return rawNetwork.trim().toLowerCase();
+  }
+  return '';
+}
+
+function assertCanonicalAddress(address) {
+  if (!address) {
+    throw new Error('AGIALPHA token address missing from configuration');
+  }
+  const checksum = ethers.getAddress(address);
+  const canonical = ethers.getAddress(CANONICAL_MAINNET_TOKEN);
+  if (checksum !== canonical) {
+    throw new Error(
+      `AGIALPHA token mismatch: configuration points to ${checksum}, expected ${canonical}`
+    );
+  }
+  return checksum;
+}
+
+async function verifyMetadata(web3, address, expected) {
+  const contract = new web3.eth.Contract(ERC20_METADATA_ABI, address);
+  const [decimals, symbol, name] = await Promise.all([
+    contract.methods.decimals().call(),
+    contract.methods.symbol().call(),
+    contract.methods.name().call(),
+  ]);
+
+  const resolvedDecimals = Number(decimals);
+  if (!Number.isFinite(resolvedDecimals)) {
+    throw new Error('Unable to read decimals from AGIALPHA token');
+  }
+  if (resolvedDecimals !== 18) {
+    throw new Error(
+      `AGIALPHA token must expose 18 decimals, got ${resolvedDecimals}`
+    );
+  }
+
+  if (expected.symbol && symbol !== expected.symbol) {
+    console.warn(
+      `Warning: AGIALPHA symbol on-chain (${symbol}) does not match configuration (${expected.symbol}).`
+    );
+  }
+
+  if (expected.name && name !== expected.name) {
+    console.warn(
+      `Warning: AGIALPHA name on-chain (${name}) does not match configuration (${expected.name}).`
+    );
+  }
+
+  return { decimals: resolvedDecimals, symbol, name };
+}
+
+module.exports = async function (_deployer, network) {
+  const { config: tokenConfig, network: resolvedNetwork } = loadTokenConfig({
+    network,
+  });
+  const networkKey = normaliseNetworkKey(network, resolvedNetwork);
+
+  if (networkKey !== 'mainnet') {
+    const printableNetwork = networkKey || 'unknown network';
+    console.log(
+      `Skipping AGIALPHA mainnet validation for ${printableNetwork}.`
+    );
+    return;
+  }
+
+  const address = assertCanonicalAddress(tokenConfig.address);
+
+  const web3Instance =
+    global.web3 || (typeof web3 !== 'undefined' ? web3 : null);
+  if (!web3Instance) {
+    throw new Error(
+      'web3 provider unavailable; unable to validate AGIALPHA token metadata'
+    );
+  }
+
+  const metadata = await verifyMetadata(web3Instance, address, tokenConfig);
+  const { decimals, symbol, name } = metadata;
+  console.log('Validated AGIALPHA mainnet token', {
+    address,
+    decimals,
+    symbol,
+    name,
+  });
+};
+
+module.exports.tags = ['agialpha', 'agialpha-mainnet'];


### PR DESCRIPTION
## Summary
- add a dedicated Truffle migration that validates the canonical AGIALPHA token metadata before running mainnet deployments
- refresh the top-level and contracts documentation with the mainnet autopilot workflow, badges, and guardrail details
- extend the migration runbook with a step-by-step Ethereum mainnet checklist tied to configuration manifests

## Testing
- npx prettier --check README.md contracts/README.md MIGRATION.md

------
https://chatgpt.com/codex/tasks/task_e_690d0d24b16883338cba01dd6fa00869