### PR TITLE
Reduce solidity test warnings

### DIFF
--- a/contracts/legacy/MockRoutingModule.sol
+++ b/contracts/legacy/MockRoutingModule.sol
@@ -10,7 +10,7 @@ contract MockRoutingModule {
         operator = _operator;
     }
 
-    function selectOperator(bytes32, bytes32) external returns (address) {
+    function selectOperator(bytes32, bytes32) external view returns (address) {
         return operator;
     }
 }

--- a/contracts/test/DeterministicValidationModule.sol
+++ b/contracts/test/DeterministicValidationModule.sol
@@ -57,10 +57,10 @@ contract DeterministicValidationModule {
 
     event Finalized(uint256 indexed jobId, bool result);
 
-    function setValidators(address[] calldata validators) external {
+    function setValidators(address[] calldata newValidators) external {
         delete validatorSet;
-        for (uint256 i = 0; i < validators.length; i++) {
-            validatorSet.push(validators[i]);
+        for (uint256 i = 0; i < newValidators.length; i++) {
+            validatorSet.push(newValidators[i]);
         }
     }
 

--- a/contracts/v2/mocks/ValidationStub.sol
+++ b/contracts/v2/mocks/ValidationStub.sol
@@ -32,7 +32,7 @@ contract ValidationStub is IValidationModule {
     function start(
         uint256 jobId,
         uint256 entropy
-    ) external override returns (address[] memory vals) {
+    ) external view override returns (address[] memory vals) {
         vals = selectValidators(jobId, entropy);
     }
 


### PR DESCRIPTION
## Summary
- rename Solidity test helper parameters and locals to avoid shadowing getter names
- tighten mock functions to be view-only for clarity and compiler guidance
- mark validation stub start routine as view to align with intent and reduce warnings

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69320ac3cc508333b1521c806bba789f)