### PR TITLE
Fix validator rounds tuple shadowing in test helper

### DIFF
--- a/contracts/test/DeterministicValidationModule.sol
+++ b/contracts/test/DeterministicValidationModule.sol
@@ -168,7 +168,7 @@ contract DeterministicValidationModule {
         external
         view
         returns (
-            address[] memory validators,
+            address[] memory roundValidators,
             address[] memory participants,
             uint256 commitDeadline,
             uint256 revealDeadline,
@@ -179,7 +179,7 @@ contract DeterministicValidationModule {
         )
     {
         RoundConfig storage config = roundConfig[jobId];
-        validators = validatorSet;
+        roundValidators = validatorSet;
         participants = validatorSet;
         commitDeadline = config.commitDeadline;
         revealDeadline = config.revealDeadline;


### PR DESCRIPTION
## Summary
- rename the `rounds` return variable to `roundValidators` to avoid shadowing the `validators` accessor in the deterministic validation module helper
- keep round metadata accessors aligned without altering behavior

## Testing
- `npx hardhat test test/v2/JobFundedEvent.test.js --no-compile`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932188a437483338efd3fd9df5cd351)