### PR TITLE
chore: speed up hardhat test harness

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -82,6 +82,9 @@ const coverageOnly = process.env.COVERAGE_ONLY === '1';
 const isCoverageRun =
   process.env.HARDHAT_COVERAGE === 'true' ||
   process.env.HARDHAT_COVERAGE === '1';
+const isFastCompile = process.env.HARDHAT_FAST_COMPILE === '1';
+const viaIROverride = process.env.HARDHAT_VIA_IR;
+const viaIR = viaIROverride === undefined ? !isCoverageRun : viaIROverride === 'true';
 
 const SOLIDITY_VERSIONS = ['0.8.25', '0.8.23', '0.8.21'];
 
@@ -93,9 +96,13 @@ const solidityConfig = {
   compilers: solidityVersions.map((version) => ({
     version,
     settings: {
-      optimizer: { enabled: !isCoverageRun, runs: isCoverageRun ? 0 : 200 },
-      viaIR: !isCoverageRun,
+      optimizer: {
+        enabled: !isCoverageRun,
+        runs: isFastCompile ? 50 : isCoverageRun ? 0 : 200,
+      },
+      viaIR,
       evmVersion: 'cancun',
+      metadata: isFastCompile ? { bytecodeHash: 'none' } : undefined,
     },
   })),
 };

--- a/scripts/run-hardhat-tests.cjs
+++ b/scripts/run-hardhat-tests.cjs
@@ -54,12 +54,21 @@ if (reporterOption) {
   process.env.MOCHA_REPORTER_OPTIONS = reporterOption;
 }
 
+const env = { ...process.env };
+
+// Speed up test-time compilation by allowing the Solidity optimizer and viaIR
+// settings to be relaxed when HARDHAT_FAST_COMPILE is set. Default to the
+// faster profile during CI/unit runs to keep the suite responsive.
+if (!env.HARDHAT_FAST_COMPILE) {
+  env.HARDHAT_FAST_COMPILE = '1';
+}
+
 const result = spawnSync(
   'npx',
   ['hardhat', 'test', '--no-compile', ...passthroughArgs],
   {
     stdio: 'inherit',
-    env: process.env,
+    env,
   }
 );
 


### PR DESCRIPTION
## Summary
- add a fast-compilation profile to the Hardhat config with overridable viaIR handling
- default the Hardhat test harness to enable the fast compile profile for CI runs

## Testing
- npm test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693293f9fb1c8333a017a7df9dda3fe2)