### PR TITLE
Disable viaIR for fast Hardhat test compiles

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -84,7 +84,9 @@ const isCoverageRun =
   process.env.HARDHAT_COVERAGE === '1';
 const isFastCompile = process.env.HARDHAT_FAST_COMPILE === '1';
 const viaIROverride = process.env.HARDHAT_VIA_IR;
-const viaIR = viaIROverride === undefined ? !isCoverageRun : viaIROverride === 'true';
+// Keep fast/CI runs responsive by defaulting viaIR off when FAST_COMPILE is set,
+// while still allowing explicit overrides for production builds or coverage.
+const viaIR = viaIROverride === undefined ? !isCoverageRun && !isFastCompile : viaIROverride === 'true';
 
 const SOLIDITY_VERSIONS = ['0.8.25', '0.8.23', '0.8.21'];
 


### PR DESCRIPTION
## Summary
- turn off Hardhat viaIR when FAST_COMPILE mode is enabled so quick test runs avoid the slow IR pipeline
- keep coverage and explicitly requested builds using viaIR untouched

## Testing
- node scripts/run-hardhat-tests.cjs
- npm run webapp:typecheck
- npm run webapp:lint
- npm run webapp:build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932fbadb02c8333bdfba8470131a046)