### PR TITLE
Fix stack depth issues in registry contracts

### DIFF
--- a/contracts/v2/ArtifactRegistry.sol
+++ b/contracts/v2/ArtifactRegistry.sol
@@ -95,17 +95,14 @@ contract ArtifactRegistry is ERC721, Ownable, AccessControl, Pausable, Reentranc
         if (bytes(cid).length == 0) revert EmptyCID();
         if (bytes(kind).length == 0) revert EmptyKind();
 
-        uint256 citationCount = citations.length;
-        if (citationCount > maxCitations) revert MaxCitationsExceeded(citationCount, maxCitations);
+        if (citations.length > maxCitations) revert MaxCitationsExceeded(citations.length, maxCitations);
 
         if (_lineageToToken[lineageHash] != 0) {
             revert LineageHashInUse(lineageHash, _lineageToToken[lineageHash]);
         }
 
-        tokenId = _nextTokenId + 1;
+        tokenId = ++_nextTokenId;
         _enforceCitationInvariants(tokenId, citations);
-
-        _nextTokenId = tokenId;
         Artifact storage artifact = _artifacts[tokenId];
         artifact.cid = cid;
         artifact.kind = kind;


### PR DESCRIPTION
## Summary
- simplify artifact minting to reduce stack usage and keep citation limits intact
- extract a reusable agent identity verification helper and scope submit flow variables to avoid stack depth errors

## Testing
- npx hardhat compile --show-stack-traces
- npx hardhat test --no-compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933094b71d88333a73cf481f0d3ccea)