### PR TITLE
Refine job registry helpers and enable viaIR

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -84,9 +84,10 @@ const isCoverageRun =
   process.env.HARDHAT_COVERAGE === '1';
 const isFastCompile = process.env.HARDHAT_FAST_COMPILE === '1';
 const viaIROverride = process.env.HARDHAT_VIA_IR;
-// Keep fast/CI runs responsive by defaulting viaIR off when FAST_COMPILE is set,
-// while still allowing explicit overrides for production builds or coverage.
-const viaIR = viaIROverride === undefined ? !isCoverageRun && !isFastCompile : viaIROverride === 'true';
+// Prefer viaIR to avoid stack-depth issues in larger contracts. Allow explicit
+// opt-out via HARDHAT_VIA_IR=false, but default to enabling when coverage is
+// not running regardless of FAST_COMPILE.
+const viaIR = viaIROverride === undefined ? !isCoverageRun : viaIROverride === 'true';
 
 const SOLIDITY_VERSIONS = ['0.8.25', '0.8.23', '0.8.21'];
 


### PR DESCRIPTION
## Summary
- add helper structs and functions in JobRegistry to reduce stack depth, defer validation until burn evidence is confirmed, and streamline agent validation and staking workflows
- default Hardhat compilation to use viaIR even during fast compile runs to avoid stack-depth errors

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693313ac1d08833390235928243356ef)