### PR TITLE
Document Node.js installation steps for quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,16 @@ flowchart LR
 The same commands run automatically in the `Owner control assurance` job, so the checks wall refuses a merge unless the owner retains total dominion over pause switches, treasury routing, and upgrade paths.【F:.github/workflows/ci.yml†L393-L443】
 
 ## Quickstart for operators
-1. Use Node.js 20.18.1 (`.nvmrc`) and Python 3.12 to match the automated toolchain.【F:.nvmrc†L1-L1】【F:.github/workflows/ci.yml†L118-L145】
+1. Use Node.js 20.18.1 (`.nvmrc`) and Python 3.12 to match the automated toolchain.【F:.nvmrc†L1-L1】【F:.github/workflows/ci.yml†L118-L145】 If your base image is missing `node`/`npm`, install the pinned version explicitly so tests don’t fall back to distro defaults:
+   ```bash
+   # Debian/Ubuntu
+   curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+   apt-get install -y nodejs
+
+   # or via nvm (honours .nvmrc)
+   command -v nvm >/dev/null || curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+   nvm install
+   ```
 2. Hydrate dependencies (do **not** omit optional packages—the Hardhat toolbox requires the platform-specific `@nomicfoundation/solidity-analyzer-*` binary and will fail exactly like CI if you pass `--omit=optional`):
    ```bash
    npm install


### PR DESCRIPTION
## Summary
- add quickstart guidance for installing the pinned Node.js 20 toolchain when node/npm are absent
- keep the operator runbook aligned with the existing toolchain requirements

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933606c54848333a8a0ef3eae4ac2bb)