### PR TITLE
Extend Hardhat test timeout

### DIFF
--- a/scripts/run-hardhat-tests.cjs
+++ b/scripts/run-hardhat-tests.cjs
@@ -58,8 +58,12 @@ const env = { ...process.env };
 
 // Prevent accidental infinite hangs by enforcing a hard timeout on the
 // Hardhat test runner. Developers can override this via HARDHAT_TEST_TIMEOUT_MS
-// if they need a longer window on constrained machines.
-const hardhatTimeoutMs = Number.parseInt(env.HARDHAT_TEST_TIMEOUT_MS ?? '300000', 10);
+// if they need a longer window on constrained machines. A generous default is
+// required because first-time Solidity compilation can legitimately take
+// several minutes on shared CI hosts; giving Hardhat 10 minutes by default
+// avoids spurious ETIMEDOUT failures while still protecting against runaway
+// jobs.
+const hardhatTimeoutMs = Number.parseInt(env.HARDHAT_TEST_TIMEOUT_MS ?? '600000', 10);
 
 // Speed up test-time compilation by allowing the Solidity optimizer and viaIR
 // settings to be relaxed when HARDHAT_FAST_COMPILE is set. Default to the


### PR DESCRIPTION
## Summary
- increase the default Hardhat test timeout to 10 minutes to accommodate lengthy first-time Solidity compiles and avoid spurious timeouts

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933b9b1c07c8333a8d8926bfdf6626e)