### PR TITLE
Add eth_typing shim to stabilize pytest autoload

### DIFF
--- a/eth_typing.py
+++ b/eth_typing.py
@@ -50,6 +50,19 @@ def _load_backend():
 
 _backend = _load_backend()
 
+# Mirror package metadata so imports of ``eth_typing.<submodule>`` continue to
+# resolve via the backend package.
+__file__ = getattr(_backend, "__file__", None)
+__path__ = list(getattr(_backend, "__path__", []))
+if __spec__ is not None and getattr(_backend, "__spec__", None) is not None:
+    __spec__.submodule_search_locations = getattr(
+        _backend.__spec__, "submodule_search_locations", __path__
+    )
+
+# Keep the backend importable for debugging while the shim stays registered as
+# the public package.
+sys.modules.setdefault("eth_typing.__backend__", _backend)
+
 # Re-export everything from the backend to preserve behaviour for downstream
 # imports. We avoid clobbering dunder attributes to keep module metadata intact.
 for _name in dir(_backend):

--- a/tests/test_eth_typing_shim.py
+++ b/tests/test_eth_typing_shim.py
@@ -14,3 +14,11 @@ def test_backend_metadata_preserved():
     backend = eth_typing.BACKEND_MODULE
     assert backend is not None
     assert getattr(backend, "__version__", None)
+
+
+def test_submodule_imports_resolve():
+    module = __import__("eth_typing.abi", fromlist=["abi"])
+
+    assert module.__name__ == "eth_typing.abi"
+    assert hasattr(eth_typing, "__path__")
+    assert eth_typing.__path__


### PR DESCRIPTION
## Summary
- add a local eth_typing compatibility shim that proxies to the installed package and restores removed aliases
- provide a regression test covering the shim behaviour and metadata exposure

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/demo/test_validator_constellation.py -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_eth_typing_shim.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69346930d8c883339ca8abc0b656c704)