### PR TITLE
Improve Hardhat test harness logging

### DIFF
--- a/scripts/run-hardhat-tests.cjs
+++ b/scripts/run-hardhat-tests.cjs
@@ -38,6 +38,11 @@ for (let i = 0; i < process.argv.length; i += 1) {
     continue;
   }
 
+  if (arg === '--') {
+    // Ignore bare argument separators passed through npm/node runners
+    continue;
+  }
+
   const normalised = arg.toLowerCase();
   if (ignoredPrefixes.some((prefix) => normalised.startsWith(prefix))) {
     if (normalised.startsWith('--listtests')) {
@@ -80,6 +85,11 @@ const hardhatTimeoutMs = Number.parseInt(env.HARDHAT_TEST_TIMEOUT_MS ?? '600000'
 if (!env.HARDHAT_FAST_COMPILE) {
   env.HARDHAT_FAST_COMPILE = '1';
 }
+
+const displayedArgs = passthroughArgs.length === 0 ? '(none)' : passthroughArgs.join(' ');
+console.log(
+  `Running Hardhat tests with HARDHAT_FAST_COMPILE=${env.HARDHAT_FAST_COMPILE} and timeout ${hardhatTimeoutMs}ms (args: ${displayedArgs})`,
+);
 
 const result = spawnSync(
   'npx',


### PR DESCRIPTION
## Summary
- add a descriptive log line to the Hardhat test harness so slow runs surface timeout and argument context
- ignore bare `--` separators when collecting passthrough arguments to avoid unrecognized parameter errors

## Testing
- npm test -- --runInBand
- node scripts/run-hardhat-tests.cjs -- --listTests
- HARDHAT_TEST_TIMEOUT_MS=20000 node scripts/run-hardhat-tests.cjs -- --grep "nonexistent-pattern"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934893d206c8333874e1bdc6947c245)