### PR TITLE
Improve API config validation

### DIFF
--- a/apps/console/src/components/ConnectionPanel.tsx
+++ b/apps/console/src/components/ConnectionPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ApiConfig, useApi } from '../context/ApiContext';
+import { ApiConfig, normalizeBaseUrl, useApi } from '../context/ApiContext';
 
 type WalletStatus =
   | { state: 'idle' }
@@ -57,8 +57,20 @@ export function ConnectionPanel({ onConfigSaved }: ConnectionPanelProps) {
     setSaving(true);
     setMessage(null);
     try {
+      const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+      if (!normalizedBaseUrl) {
+        throw new Error('Provide a valid orchestrator base URL.');
+      }
+      try {
+        new URL(normalizedBaseUrl);
+      } catch {
+        throw new Error(
+          'Base URL must include a valid host (https://example.com).'
+        );
+      }
+
       const cleaned: ApiConfig = {
-        baseUrl: baseUrl.trim(),
+        baseUrl: normalizedBaseUrl,
         token: token.trim(),
       };
       setConfig(cleaned);

--- a/apps/console/src/context/ApiContext.tsx
+++ b/apps/console/src/context/ApiContext.tsx
@@ -28,7 +28,7 @@ const STORAGE_KEY = 'agi-console.api-config';
 
 const ApiContext = createContext<ApiContextValue | undefined>(undefined);
 
-function normalizeBaseUrl(value: string): string {
+export function normalizeBaseUrl(value: string): string {
   const trimmed = value.trim().replace(/\/$/, '');
   if (!trimmed) {
     return '';


### PR DESCRIPTION
## Summary
- expose base URL normalizer from the API context for reuse
- add validation when saving orchestrator connection details to prevent invalid URLs

## Testing
- npm run webapp:lint
- npm run webapp:typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c30f8004833393a9f029b030ffd8)