### PR TITLE
Make Hardhat test runner compile by default

### DIFF
--- a/scripts/run-hardhat-tests.cjs
+++ b/scripts/run-hardhat-tests.cjs
@@ -86,10 +86,15 @@ if (!env.HARDHAT_FAST_COMPILE) {
   env.HARDHAT_FAST_COMPILE = '1';
 }
 
+const skipCompile = env.HARDHAT_SKIP_COMPILE === '1';
+
 const displayedArgs = passthroughArgs.length === 0 ? '(none)' : passthroughArgs.join(' ');
 console.log(
   `Running Hardhat tests with HARDHAT_FAST_COMPILE=${env.HARDHAT_FAST_COMPILE} and timeout ${hardhatTimeoutMs}ms (args: ${displayedArgs})`,
 );
+console.log(skipCompile
+  ? '⚡️ HARDHAT_SKIP_COMPILE=1 detected: assuming existing artifacts and skipping compilation.'
+  : '🧰 Compilation is enabled to ensure artifacts are fresh before running tests.');
 
 const startedAt = Date.now();
 
@@ -99,7 +104,15 @@ console.log(
 
 function runHardhatWithHeartbeat(timeoutMs) {
   return new Promise((resolve) => {
-    const child = spawn('npx', ['hardhat', 'test', '--no-compile', ...passthroughArgs], {
+    const args = ['hardhat', 'test'];
+
+    if (skipCompile) {
+      args.push('--no-compile');
+    }
+
+    args.push(...passthroughArgs);
+
+    const child = spawn('npx', args, {
       stdio: 'inherit',
       env,
     });


### PR DESCRIPTION
## Summary
- allow the Hardhat test harness to compile contracts unless HARDHAT_SKIP_COMPILE is set
- log whether compilation is enabled and build test arguments accordingly

## Testing
- npm run webapp:typecheck
- npm run webapp:lint
- npm run webapp:build
- node --test apps/onebox-static/test/auth-helpers.test.mjs
- node --test demo/One-Box/test/launcher.test.cjs
- node --test demo/One-Box/test/diagnostics.test.cjs
- node --test apps/onebox/test/error-catalog.test.mjs
- npm run test:era-of-experience
- npm run test:validator-constellation:v0
- npm run test:meta-agentic-alpha
- HARDHAT_SKIP_COMPILE=1 node scripts/run-hardhat-tests.cjs --help

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935d5f6cee483339b994b33af485db0)