### PR TITLE
Increase Hardhat test runner timeout default

### DIFF
--- a/scripts/run-hardhat-tests.cjs
+++ b/scripts/run-hardhat-tests.cjs
@@ -116,10 +116,10 @@ const env = { ...process.env };
 // Hardhat test runner. Developers can override this via HARDHAT_TEST_TIMEOUT_MS
 // if they need a longer window on constrained machines. A generous default is
 // required because first-time Solidity compilation can legitimately take
-// several minutes on shared CI hosts; giving Hardhat 10 minutes by default
-// avoids spurious ETIMEDOUT failures while still protecting against runaway
-// jobs.
-const hardhatTimeoutMs = Number.parseInt(env.HARDHAT_TEST_TIMEOUT_MS ?? '600000', 10);
+// several minutes on shared CI hosts; giving Hardhat 15 minutes by default
+// avoids spurious ETIMEDOUT failures on slower builders while still protecting
+// against runaway jobs.
+const hardhatTimeoutMs = Number.parseInt(env.HARDHAT_TEST_TIMEOUT_MS ?? '900000', 10);
 
 // Speed up test-time compilation by allowing the Solidity optimizer and viaIR
 // settings to be relaxed when HARDHAT_FAST_COMPILE is set. Default to the


### PR DESCRIPTION
## Summary
- raise the default Hardhat test timeout to 15 minutes to prevent slow builders from tripping the runner’s watchdog
- update the inline rationale in the runner script to reflect the new default window

## Testing
- HARDHAT_TEST_TIMEOUT_MS=1000 node scripts/run-hardhat-tests.cjs --listTests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69362b1f90608333a0e1a8704c03b843)