### PR TITLE
Stabilize Alpha Node demo pytest setup

### DIFF
--- a/demo/AGI-Alpha-Node-v0/Makefile
+++ b/demo/AGI-Alpha-Node-v0/Makefile
@@ -1,5 +1,8 @@
 .PHONY: bootstrap run metrics compliance test docker
 
+PYTHONPATH := $(abspath ../..)
+TEST_ENV := PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=$(PYTHONPATH)
+
 bootstrap:
 	python -m alpha_node.cli bootstrap
 
@@ -13,7 +16,7 @@ compliance:
 	python -m alpha_node.cli compliance
 
 test:
-	pytest tests
+	$(TEST_ENV) pytest tests
 
 docker:
 	docker build -t agi-alpha-node .

--- a/demo/AGI-Alpha-Node-v0/eth_typing.py
+++ b/demo/AGI-Alpha-Node-v0/eth_typing.py
@@ -1,0 +1,28 @@
+"""Local shim that proxies to the repository-level :mod:`eth_typing` patch."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHIM_PATH = REPO_ROOT / "eth_typing.py"
+if not SHIM_PATH.exists():
+    raise ImportError(f"Shared eth_typing shim missing at {SHIM_PATH}")
+
+_spec = importlib.util.spec_from_file_location("agi_jobs_eth_typing", SHIM_PATH)
+if _spec is None or _spec.loader is None:
+    raise ImportError("Unable to load shared eth_typing shim")
+
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+for _name in dir(_module):
+    if _name.startswith("__"):
+        continue
+    globals()[_name] = getattr(_module, _name)
+
+__all__ = [name for name in globals() if not name.startswith("_")]
+__file__ = str(SHIM_PATH)
+
+# Keep a reference around for debugging.
+BACKEND_MODULE = _module

--- a/demo/AGI-Alpha-Node-v0/sitecustomize.py
+++ b/demo/AGI-Alpha-Node-v0/sitecustomize.py
@@ -1,0 +1,20 @@
+"""Local site customisation for the AGI Alpha Node demo."""
+from __future__ import annotations
+
+import os
+import runpy
+from pathlib import Path
+
+# Ensure pytest does not auto-load globally installed plugins. Some plugins
+# (for example ``web3.tools.pytest_ethereum``) import optional dependencies
+# that are not part of this workspace and will crash test discovery. Setting
+# the environment flag here means ``pytest`` works even when executed from this
+# demo directory directly.
+os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+
+# Reuse the repository-wide sitecustomize so we inherit shared path tweaks and
+# helper configuration when running from this nested demo directory.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_CUSTOMIZE = REPO_ROOT / "sitecustomize.py"
+if SHARED_CUSTOMIZE.exists():
+    runpy.run_path(str(SHARED_CUSTOMIZE))


### PR DESCRIPTION
## Summary
- add a demo-local sitecustomize to disable unwanted pytest plugin autoloading and reuse the shared repo configuration when running from the demo directory
- add a demo-level eth_typing shim that proxies to the repository-wide compatibility layer for ContractName support
- update the demo Makefile test target to export the necessary pytest and PYTHONPATH environment defaults

## Testing
- make test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693641e1cc28833387bcb639a37ba701)