### PR TITLE
Harden Alpha Node demo test runner

### DIFF
--- a/demo/AGI-Alpha-Node-v0/Makefile
+++ b/demo/AGI-Alpha-Node-v0/Makefile
@@ -16,7 +16,7 @@ compliance:
 	python -m alpha_node.cli compliance
 
 test:
-	$(TEST_ENV) pytest tests
+	$(TEST_ENV) python -m pytest tests
 
 docker:
 	docker build -t agi-alpha-node .

--- a/demo/AGI-Alpha-Node-v0/README.md
+++ b/demo/AGI-Alpha-Node-v0/README.md
@@ -24,7 +24,7 @@ flowchart LR
 ## Working With This Module
 1. From the repository root run `npm install` once to hydrate all workspaces.
 2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/AGI-Alpha-Node-v0`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
+3. Run the demo's test suite with `make test` (which invokes `python -m pytest` with plugin autoloading disabled) to avoid interference from globally installed pytest plugins.
 4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
 
 ## Directory Guide


### PR DESCRIPTION
## Summary
- switch the Alpha Node demo Makefile test target to invoke `python -m pytest` with plugin autoload disabled
- document the stabilized test command in the demo README to avoid global plugin interference

## Testing
- make -C demo/AGI-Alpha-Node-v0 test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fbc246648333867e44a1088a0592)