### PR TITLE
Improve demo transcript loading resilience

### DIFF
--- a/demo/agi-labor-market-grand-demo/README.md
+++ b/demo/agi-labor-market-grand-demo/README.md
@@ -23,9 +23,10 @@ flowchart LR
 
 ## Working With This Module
 1. From the repository root run `npm install` once to hydrate all workspaces.
-2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/agi-labor-market-grand-demo`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
-4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
+2. Serve the UI locally from `demo/agi-labor-market-grand-demo/ui` to avoid browser CORS blockers when fetching transcripts. A quick path is `npx --yes http-server -p 8080`.
+3. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/agi-labor-market-grand-demo`.
+4. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
+5. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
 
 ## Directory Guide
 ### Key Directories


### PR DESCRIPTION
## Summary
- strengthen the AGI labor market demo data loader with absolute URLs, clearer errors, and an inline sample fallback notice
- document how to serve the UI locally to avoid browser CORS failures when loading transcripts

## Testing
- not run (local HTTP server dependency failed to start in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371b2c9ed08333858ed67d6f05a4f8)