### PR TITLE
Harden Kardashev II demo energy verification

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
@@ -1,13 +1,13 @@
 # Kardashev II Scale Control Dossier
 
-Generated: 2125-01-01T05:53:52.716Z
+Generated: 2125-01-01T19:05:39.398Z
 
 ## Executive Summary
 
 - **Universal Dominance Score:** 99.9/100 (targets met across all shards).
 - **Dyson Swarm Progress:** 2669/10000 satellites assembled (26.69% coverage).
 - **Captured Power:** 120,105 MW available for reallocation.
-- **Energy Monte Carlo:** 0.00% breach probability across 256 runs (tolerance 5.00%).
+- **Energy Monte Carlo:** 3.91% breach probability across 256 runs (tolerance 5.00%).
 - **Sentinel Status:** 3 advisories generated; all resolved within guardian SLA.
 
 ## Shard Operations

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/telemetry.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2125-01-01T05:53:52.716Z",
+  "generatedAt": "2125-01-01T19:05:39.398Z",
   "dominanceScore": 99.9,
   "shards": [
     {
@@ -64,17 +64,17 @@
   },
   "energyMonteCarlo": {
     "runs": 256,
-    "breachProbability": 0,
+    "breachProbability": 0.0390625,
     "tolerance": 0.05,
     "withinTolerance": true,
     "capturedGw": 239600,
     "marginGw": 11980,
-    "peakDemandGw": 209493.73197896255,
-    "averageDemandGw": 189984.19801850518,
+    "peakDemandGw": 236071.28410087732,
+    "averageDemandGw": 220511.2517597387,
     "percentileGw": {
-      "p50": 190500.86161427197,
-      "p95": 204806.78086873138,
-      "p99": 208209.50439558143
+      "p50": 220758.9222143467,
+      "p95": 228521.30795493047,
+      "p99": 232459.304439481
     }
   },
   "configs": {


### PR DESCRIPTION
## Summary
- tune the Kardashev II demo Monte Carlo simulation to respect configured tolerance bands and reduce unnecessary drift
- abort the demo run with a clear action plan when energy breach probability exceeds the allowed threshold
- refresh generated Kardashev II telemetry and report outputs with the updated energy stability figures

## Testing
- npm run demo:kardashev-ii:ci
- node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs --check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937280bbd3c8333aa9cc977814372bf)