### PR TITLE
Handle Jest runTestsByPath flag in Hardhat runner

### DIFF
--- a/scripts/run-hardhat-tests.cjs
+++ b/scripts/run-hardhat-tests.cjs
@@ -116,7 +116,17 @@ for (let i = 0; i < process.argv.length; i += 1) {
     continue;
   }
 
-  passthroughArgs.push(normalised === arg ? arg : normalised);
+  if (arg.startsWith('-')) {
+    // Hardhat insists on lowercase flag names but values can be case-sensitive
+    // (for example Mocha grep patterns or file paths). Preserve the original
+    // casing after any '=' delimiter while lowercasing only the flag name.
+    const [flag, ...rest] = arg.split('=');
+    const loweredFlag = flag.toLowerCase();
+    passthroughArgs.push(rest.length > 0 ? `${loweredFlag}=${rest.join('=')}` : loweredFlag);
+  } else {
+    // Positional arguments should retain their original casing.
+    passthroughArgs.push(arg);
+  }
 }
 
 if (reporterOption) {


### PR DESCRIPTION
## Summary
- translate Jest runTestsByPath into Hardhat-friendly positional test file arguments while keeping other mixed-case flags out of Hardhat
- keep diagnostic logging aligned with the filtered arguments passed to npx hardhat

## Testing
- npm test -- --runTestsByPath demo/One-Box/test/diagnostics.test.cjs


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376bbb88248333a5f8b4c1c1d673db)