### PR TITLE
Add alpha node test helper target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,7 @@ absolute-zero-demo:
 .PHONY: pytest
 pytest:
 	PYTHONPATH=".:$(PWD)/packages/hgm-core/src" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test
+
+.PHONY: alpha-node-test
+alpha-node-test:
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH="$(PWD)" python -m pytest demo/AGI-Alpha-Node-v0/tests

--- a/demo/AGI-Alpha-Node-v0/README.md
+++ b/demo/AGI-Alpha-Node-v0/README.md
@@ -24,7 +24,7 @@ flowchart LR
 ## Working With This Module
 1. From the repository root run `npm install` once to hydrate all workspaces.
 2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/AGI-Alpha-Node-v0`.
-3. Run the demo's test suite with `make test` (which invokes `python -m pytest` with plugin autoloading disabled) to avoid interference from globally installed pytest plugins. If you need a direct call, use `python run_tests.py` so the environment is pre-seeded with the guardrails (pinned `PYTHONPATH` and `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`).
+3. Run the demo's test suite with `make test` inside this folder or `make alpha-node-test` from the repository root. Both paths invoke `python -m pytest` with plugin autoloading disabled so global plugins cannot break collection, and they pin `PYTHONPATH` so the local `eth_typing` shim loads before third-party packages. If you need a direct call, use `python run_tests.py` so the environment is pre-seeded with the same guardrails.
 4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
 
 ## Directory Guide


### PR DESCRIPTION
## Summary
- add a repository-level make target to run the AGI Alpha Node demo tests with the correct pytest environment
- expand the demo README to highlight the new entrypoint and why the guardrails matter

## Testing
- make alpha-node-test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937a788944083338a7801d58b287ab5)