### PR TITLE
Add offline-safe fallback for labor market demo

### DIFF
--- a/demo/agi-labor-market-grand-demo/ui/styles.css
+++ b/demo/agi-labor-market-grand-demo/ui/styles.css
@@ -708,6 +708,14 @@ main {
   color: #fca5a5;
 }
 
+.notice-inline {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  background: rgba(59, 130, 246, 0.1);
+  border-color: rgba(59, 130, 246, 0.35);
+  color: #bfdbfe;
+}
+
 @media (max-width: 720px) {
   .hero {
     padding: 2.5rem 1.25rem 1.5rem;


### PR DESCRIPTION
## Summary
- add an embedded sample transcript fallback when network transcript fetches fail
- track the transcript source and surface an inline notice when running from sample data
- style the inline notice for clarity in the control room UI

## Testing
- python - <<'PY' ...playwright async launch... (fails in this environment due to Chromium headless shell crashing)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693834da463883339dcc67a629b32666)