### PR TITLE
Add reliable pytest launcher for AGI Alpha Node demo

### DIFF
--- a/demo/AGI-Alpha-Node-v0/README.md
+++ b/demo/AGI-Alpha-Node-v0/README.md
@@ -24,7 +24,7 @@ flowchart LR
 ## Working With This Module
 1. From the repository root run `npm install` once to hydrate all workspaces.
 2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/AGI-Alpha-Node-v0`.
-3. Run the demo's test suite with `make test` inside this folder, `make alpha-node-test` from the repository root, or simply `python run_tests.py`. All three paths invoke `python -m pytest` with plugin autoloading disabled so global plugins cannot break collection, and they pin `PYTHONPATH` so the local `eth_typing` shim loads before third-party packages. The `run_tests.py` helper also defaults to the `tests/` folder when no arguments are provided, mirroring the make target behaviour.
+3. Run the demo's test suite with `make test` inside this folder, `make alpha-node-test` from the repository root, `python run_tests.py`, **or** `./pytest.sh`. All four paths invoke `python -m pytest` with plugin autoloading disabled so global plugins cannot break collection, and they pin `PYTHONPATH` so the local `eth_typing` shim loads before third-party packages. The `run_tests.py` helper also defaults to the `tests/` folder when no arguments are provided, mirroring the make target behaviour, while `pytest.sh` matches that environment even when you reach for the global `pytest` console script out of habit.
 4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
 
 ## Directory Guide

--- a/demo/AGI-Alpha-Node-v0/pytest.sh
+++ b/demo/AGI-Alpha-Node-v0/pytest.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure pytest runs with the same environment assumptions as CI.
+# We explicitly disable third-party plugin autoloading to avoid crashes from
+# globally installed extensions (for example, the web3 pytest helpers that
+# expect legacy eth_typing symbols). We also prepend the repository root to
+# PYTHONPATH so our compatibility shims remain discoverable even when the
+# console-script wrapper sets sys.path[0] to the pyenv bin directory.
+
+REPO_ROOT="$(cd "$(dirname "$0")"/../.. && pwd)"
+export PYTEST_DISABLE_PLUGIN_AUTOLOAD="${PYTEST_DISABLE_PLUGIN_AUTOLOAD:-1}"
+export PYTHONPATH="${PYTHONPATH:-${REPO_ROOT}}"
+
+exec python -m pytest "$@"


### PR DESCRIPTION
## Summary
- add a repo-root aware pytest launcher script for the AGI Alpha Node demo that disables third-party plugin autoloading and sets PYTHONPATH
- document the new test entrypoint alongside existing helpers in the demo README

## Testing
- ./demo/AGI-Alpha-Node-v0/pytest.sh -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693854a8fa34833388d035de621eff77)