### PR TITLE
Improve Tiny Recursive Model CLI default behavior

### DIFF
--- a/demo/Tiny-Recursive-Model-v0/run_demo.py
+++ b/demo/Tiny-Recursive-Model-v0/run_demo.py
@@ -16,7 +16,10 @@ from trm_demo.sentinel import Sentinel
 from trm_demo.simulation import run_simulation
 from trm_demo.thermostat import Thermostat
 
-app = typer.Typer(help="Tiny Recursive Model demo orchestrated by AGI Jobs v0 (v2)")
+app = typer.Typer(
+    help="Tiny Recursive Model demo orchestrated by AGI Jobs v0 (v2)",
+    invoke_without_command=True,
+)
 console = Console()
 
 
@@ -34,6 +37,24 @@ def _ensure_checkpoint(engine: TrmEngine, checkpoint_path: Path) -> None:
         console.print(
             "[yellow]No checkpoint found. Run `python run_demo.py train` first for best results.[/yellow]"
         )
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context) -> None:
+    """Show guidance when no command is provided."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    console.print(
+        """
+[bold cyan]Tiny Recursive Model Demo[/bold cyan]
+This CLI powers the AGI Jobs v0 (v2) Tiny Recursive Model experience. Choose a command:
+• [green]train[/green] — learn a lightweight recursive reasoner on synthetic tasks.
+• [green]simulate[/green] — benchmark TRM versus baselines with guardrails engaged.
+• [green]explain[/green] — recap what operators can do with this demo.
+        """
+    )
+    typer.echo(ctx.get_help())
 
 
 @app.command()

--- a/demo/Tiny-Recursive-Model-v0/tests/test_cli_entrypoint.py
+++ b/demo/Tiny-Recursive-Model-v0/tests/test_cli_entrypoint.py
@@ -1,0 +1,16 @@
+from typer.testing import CliRunner
+
+import run_demo
+
+
+runner = CliRunner()
+
+
+def test_default_invocation_shows_help_and_exits_cleanly():
+    result = runner.invoke(run_demo.app, [])
+
+    assert result.exit_code == 0
+    assert "Tiny Recursive Model" in result.stdout
+    assert "train" in result.stdout
+    assert "simulate" in result.stdout
+    assert "explain" in result.stdout


### PR DESCRIPTION
## Summary
- add a default Tiny Recursive Model CLI callback so running without a subcommand shows guidance instead of an error
- update CLI help text to highlight available demo commands
- add a regression test covering the default invocation path

## Testing
- python -m pytest -q demo/Tiny-Recursive-Model-v0


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69387369a9f08333a0a28d71dc9c425e)