### PR TITLE
Fix Kardashev II cycle limit and add regression test

### DIFF
--- a/demo/Kardashev-II-Omega-Grade-Alpha-AGI-Business-3/kardashev_ii_omega_grade_alpha_agi_business_3/orchestrator.py
+++ b/demo/Kardashev-II-Omega-Grade-Alpha-AGI-Business-3/kardashev_ii_omega_grade_alpha_agi_business_3/orchestrator.py
@@ -142,7 +142,7 @@ class Orchestrator:
         while self._running:
             await self._paused.wait()
             self._cycle += 1
-            if self.config.max_cycles and self._cycle > self.config.max_cycles:
+            if self.config.max_cycles and self._cycle >= self.config.max_cycles:
                 self._info("cycle_limit_reached", cycle=self._cycle)
                 self._running = False
                 self._paused.set()

--- a/demo/Kardashev-II-Omega-Grade-Alpha-AGI-Business-3/tests/test_cycle_limits.py
+++ b/demo/Kardashev-II-Omega-Grade-Alpha-AGI-Business-3/tests/test_cycle_limits.py
@@ -1,0 +1,40 @@
+import asyncio
+from datetime import timedelta
+
+import pytest
+
+from kardashev_ii_omega_grade_alpha_agi_business_3.governance import GovernanceParameters
+from kardashev_ii_omega_grade_alpha_agi_business_3.orchestrator import Orchestrator, OrchestratorConfig
+
+
+@pytest.mark.anyio
+async def test_orchestrator_respects_cycle_limit(tmp_path):
+    governance = GovernanceParameters(
+        validator_commit_window=timedelta(seconds=0.01),
+        validator_reveal_window=timedelta(seconds=0.01),
+        validator_quorum=1,
+    )
+    config = OrchestratorConfig(
+        checkpoint_path=tmp_path / "checkpoint.json",
+        control_channel_file=tmp_path / "control.jsonl",
+        enable_simulation=False,
+        max_cycles=1,
+        cycle_sleep_seconds=0.01,
+        insight_interval_seconds=1_000,
+        checkpoint_interval_seconds=1_000,
+        governance=governance,
+    )
+
+    orchestrator = Orchestrator(config)
+    await orchestrator.start()
+
+    await asyncio.wait_for(_wait_for_stop(orchestrator), timeout=2)
+
+    assert orchestrator._cycle == config.max_cycles
+
+    await orchestrator.shutdown()
+
+
+async def _wait_for_stop(orchestrator: Orchestrator) -> None:
+    while orchestrator._running:
+        await asyncio.sleep(0.01)


### PR DESCRIPTION
## Summary
- fix the Kardashev-II Omega-grade orchestrator to stop when reaching the configured cycle limit
- add a regression test that exercises the cycle cap with fast timing and disabled simulation

## Testing
- python demo/run_demo_tests.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938c42deb708333b3b3b86e84f32c1b)