### PR TITLE
Fix runtime tracking for planetary fabric demo

### DIFF
--- a/demo/Planetary-Orchestrator-Fabric-v0/planetary_fabric/orchestrator.py
+++ b/demo/Planetary-Orchestrator-Fabric-v0/planetary_fabric/orchestrator.py
@@ -28,7 +28,10 @@ class FabricMetrics:
         return self.completed_jobs / self.total_jobs
 
     def runtime_seconds(self) -> float:
-        return max(0.0, self.end_time - self.start_time)
+        if self.start_time <= 0:
+            return 0.0
+        reference_time = self.end_time or time.monotonic()
+        return max(0.0, reference_time - self.start_time)
 
 
 class PlanetaryOrchestrator:

--- a/demo/Planetary-Orchestrator-Fabric-v0/tests/test_simulation.py
+++ b/demo/Planetary-Orchestrator-Fabric-v0/tests/test_simulation.py
@@ -16,6 +16,7 @@ def test_high_load_balance(tmp_path: Path) -> None:
     assert result.completion_rate >= 0.98
     assert result.max_depth_delta() < 250
     assert result.reassigned_jobs / result.total_jobs <= 0.025
+    assert result.total_runtime > 0.0
 
 
 def test_mid_run_checkpoint_recovery(tmp_path: Path) -> None:
@@ -23,3 +24,4 @@ def test_mid_run_checkpoint_recovery(tmp_path: Path) -> None:
     assert result.completion_rate >= 0.98
     assert result.reassigned_jobs / result.total_jobs <= 0.045
     assert result.max_depth_delta() < 300
+    assert result.total_runtime > 0.0


### PR DESCRIPTION
## Summary
- ensure planetary fabric metrics report runtime while orchestrator is active
- add regression coverage asserting demos emit non-zero runtime

## Testing
- python demo/run_demo_tests.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938ed85b0f8833396232c8fbe4c7af3)