### PR TITLE
Support core strategy alias for day-one demo

### DIFF
--- a/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/README.md
@@ -27,6 +27,12 @@ flowchart LR
 3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
 4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
 
+## Quickstart Simulation
+- Run a flagship benchmark from the repo root:
+  - JSON report: `python demo/AGIJobs-Day-One-Utility-Benchmark/demo_runner.py simulate --strategy e2e --format json`
+  - Human-readable narrative: `python demo/AGIJobs-Day-One-Utility-Benchmark/demo_runner.py simulate --strategy e2e --format human`
+- For newcomers, the CLI also accepts `--strategy core` or `--strategy default`, which both map to the canonical `e2e` configuration while still surfacing the correct strategy name in the output payloads.
+
 ## Directory Guide
 ### Key Directories
 - `config`

--- a/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
@@ -77,6 +77,15 @@ def test_unknown_strategy_raises():
         orchestrator.simulate("unknown")
 
 
+def test_core_alias_maps_to_e2e():
+    orchestrator = _orchestrator()
+    core_report = orchestrator.simulate("core")
+    e2e_report = orchestrator.simulate("e2e")
+
+    assert core_report["strategy"] == "e2e"
+    assert core_report["strategy_profile"] == e2e_report["strategy_profile"]
+
+
 def test_owner_reset_restores_defaults():
     orchestrator = _orchestrator()
     orchestrator.update_owner_control("platform_fee_bps", "240")


### PR DESCRIPTION
## Summary
- add friendly strategy aliases (core/default) that map to the flagship e2e benchmark
- improve error messaging when an unknown strategy is requested
- document the quickstart commands and add coverage for the new alias behavior

## Testing
- python -m pytest demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py --import-mode=importlib


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396d46620c83338234bd37cce2f52e)