### PR TITLE
Add wall clock guardrail for Absolute Zero demo

### DIFF
--- a/demo/Absolute-Zero-Reasoner-v0/README.md
+++ b/demo/Absolute-Zero-Reasoner-v0/README.md
@@ -40,6 +40,10 @@ flowchart LR
 - `run_demo.py`
 - `RUNBOOK.md`
 
+## Running the demo safely
+- Use `python run_demo.py --max-seconds 15 --output reports/azr_payload.json` to execute the accelerated Absolute Zero loop with a wall-clock cap and a persisted telemetry payload.
+- The CLI accepts `--progress-interval` to tune how often iteration metrics print to the console and `--quiet` when embedding the demo inside CI without logs.
+
 ## Quality & Governance
 - Every change must land through a pull request with all required checks green (unit, integration, linting, security scan).
 - Reference [`RUNBOOK.md`](../../RUNBOOK.md) and [`OperatorRunbook.md`](../../OperatorRunbook.md) for escalation patterns and owner approvals.

--- a/demo/Absolute-Zero-Reasoner-v0/azr_demo/guardrails.py
+++ b/demo/Absolute-Zero-Reasoner-v0/azr_demo/guardrails.py
@@ -59,6 +59,11 @@ class GuardrailManager:
         if self._state.unsafe_events >= self._unsafe_threshold:
             self._state.paused = True
 
+    def pause(self) -> None:
+        """Force a pause due to external constraints."""
+
+        self._state.paused = True
+
     def should_pause(self) -> bool:
         return self._state.paused
 

--- a/demo/Absolute-Zero-Reasoner-v0/tests/test_azr_runtime.py
+++ b/demo/Absolute-Zero-Reasoner-v0/tests/test_azr_runtime.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+DEMO_ROOT = Path(__file__).resolve().parents[1]
+if str(DEMO_ROOT) not in sys.path:
+    sys.path.insert(0, str(DEMO_ROOT))
+
+from azr_demo.__main__ import AbsoluteZeroReasonerDemo, load_config
+
+
+class _StepClock:
+    def __init__(self, steps: list[float]) -> None:
+        self._steps = steps
+        self._last = steps[-1] if steps else 0.0
+
+    def __call__(self) -> float:
+        if self._steps:
+            self._last = self._steps.pop(0)
+        return self._last
+
+
+def test_demo_respects_wall_clock(monkeypatch):
+    config = load_config(None)
+    config["runtime"]["iterations"] = 5
+    config["runtime"]["tasks_per_iteration"] = 2
+    clock = _StepClock([0.0, 0.0, 0.05, 0.11, 0.11])
+    demo = AbsoluteZeroReasonerDemo(
+        config,
+        max_seconds=0.1,
+        progress_interval=1,
+        verbose=False,
+        clock=clock,
+    )
+
+    def _fast_solve(self, task, temperature: float = 1.0):
+        return {"answer": task.expected_output, "program": task.program}, True
+
+    monkeypatch.setattr(demo.solver, "solve", _fast_solve.__get__(demo.solver))
+    payload = demo.run()
+
+    # The wall-clock guard should stop the loop before consuming all iterations.
+    assert payload["telemetry"]["iterations"] < 5
+    assert payload["guardrails"]["paused"] >= 1.0
+
+
+def test_progress_logging_can_be_quiet(monkeypatch, capsys):
+    config = load_config(None)
+    config["runtime"]["iterations"] = 1
+    config["runtime"]["tasks_per_iteration"] = 1
+    demo = AbsoluteZeroReasonerDemo(
+        config,
+        max_seconds=1.0,
+        progress_interval=1,
+        verbose=False,
+    )
+
+    def _fast_solve(self, task, temperature: float = 1.0):
+        return {"answer": task.expected_output, "program": task.program}, True
+
+    monkeypatch.setattr(demo.solver, "solve", _fast_solve.__get__(demo.solver))
+    demo.run()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""


### PR DESCRIPTION
## Summary
- add wall-clock limiting, progress logging, and CLI controls to the Absolute Zero Reasoner demo
- tighten default runtime parameters and document the safer invocation options
- add regression tests around the runtime guardrail and quiet logging

## Testing
- PYTHONPATH=demo/Absolute-Zero-Reasoner-v0 python -m pytest demo/Absolute-Zero-Reasoner-v0/tests --import-mode=importlib

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693999733070833398cdb970cdc117d2)