### PR TITLE
Update ts-jest configuration for Phase 8 demo tests

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/jest.config.cjs
+++ b/demo/Phase-8-Universal-Value-Dominance/jest.config.cjs
@@ -4,11 +4,14 @@ module.exports = {
   testEnvironment: 'node',
   rootDir: __dirname,
   testMatch: ['<rootDir>/scripts/**/*.test.ts'],
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.test.json',
-      diagnostics: true,
-    },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.test.json',
+        diagnostics: true,
+      },
+    ],
   },
   snapshotFormat: {
     printBasicPrototype: false,


### PR DESCRIPTION
## Summary
- move the Phase 8 demo Jest settings to the recommended ts-jest transform format
- retain diagnostics and test TypeScript config wiring while preparing for future Jest upgrades

## Testing
- npx jest --config jest.config.cjs --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b38723188333b2c91463ae378520)