### PR TITLE
Add Playwright install helper for Phase 8 dashboard tests

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/README.md
+++ b/demo/Phase-8-Universal-Value-Dominance/README.md
@@ -53,3 +53,10 @@ flowchart LR
 - Review this module's issue board for open automation, data, or research threads.
 - Link new deliverables back to the central manifest via `npm run release:manifest`.
 - Publish artefacts (dashboards, mermaid charts, datasets) into `reports/` for downstream intelligence alignment.
+
+## Testing & Playwright Browsers
+
+- Before running `npx playwright test --config=playwright.config.ts`, provision the bundled Chromium binary once with:
+  - `./scripts/install_playwright_browsers.sh`
+- The script installs the headless shell and OS-level dependencies Playwright needs so the dashboard e2e suite runs without manual
+  intervention on fresh machines.

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/install_playwright_browsers.sh
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/install_playwright_browsers.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure Playwright browser binaries are available for the Phase 8 dashboard tests.
+# This script is idempotent and safe to run multiple times.
+
+npx playwright install --with-deps chromium


### PR DESCRIPTION
## Summary
- add a helper script to install Playwright Chromium and OS dependencies for the Phase 8 demo
- document the browser installation requirement and testing command in the Phase 8 README

## Testing
- npx playwright test --config=playwright.config.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939bc4ae7ac8333a6bab01920528d74)