### PR TITLE
Ensure Phase 8 Playwright tests auto-install browsers

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/README.md
+++ b/demo/Phase-8-Universal-Value-Dominance/README.md
@@ -56,7 +56,9 @@ flowchart LR
 
 ## Testing & Playwright Browsers
 
-- Before running `npx playwright test --config=playwright.config.ts`, provision the bundled Chromium binary once with:
+- Before running `npx playwright test --config=playwright.config.ts`, you can provision the bundled Chromium binary once with:
   - `./scripts/install_playwright_browsers.sh`
-- The script installs the headless shell and OS-level dependencies Playwright needs so the dashboard e2e suite runs without manual
-  intervention on fresh machines.
+- The suite also includes a lightweight global setup that will automatically download the Chromium headless shell (via `npx playwrigh
+t install --with-deps chromium`) if it is missing, so CI and fresh environments stay green without extra steps.
+- Both paths install the OS-level dependencies Playwright needs so the dashboard e2e suite runs without manual intervention on fresh
+  machines.

--- a/demo/Phase-8-Universal-Value-Dominance/playwright.config.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  globalSetup: './tests/global-setup.ts',
   timeout: 30_000,
   expect: {
     timeout: 5_000,

--- a/demo/Phase-8-Universal-Value-Dominance/tests/global-setup.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/tests/global-setup.ts
@@ -1,0 +1,14 @@
+import { chromium } from '@playwright/test';
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
+
+function ensureChromium() {
+  const executablePath = chromium.executablePath();
+  if (!executablePath || !existsSync(executablePath)) {
+    execSync('npx playwright install --with-deps chromium', { stdio: 'inherit' });
+  }
+}
+
+export default async function globalSetup() {
+  ensureChromium();
+}


### PR DESCRIPTION
## Summary
- add Playwright global setup to auto-install Chromium before Phase 8 dashboard e2e tests
- wire global setup into Playwright configuration for the Phase 8 demo
- document automatic browser bootstrapping alongside existing install script guidance

## Testing
- npx playwright test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939cf646f948333823c9f6e52f279a6)