### PR TITLE
Add iterations alias to AlphaEvolve runner

### DIFF
--- a/demo/AlphaEvolve-v0/alphaevolve_runner.py
+++ b/demo/AlphaEvolve-v0/alphaevolve_runner.py
@@ -110,7 +110,21 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="AlphaEvolve grand demo")
     sub = parser.add_subparsers(dest="command")
     run_cmd = sub.add_parser("run", help="execute the self-evolution loop")
-    run_cmd.add_argument("--generations", type=int, default=30)
+    run_cmd.add_argument(
+        "--generations",
+        dest="generations",
+        type=int,
+        default=30,
+        help="number of generations to simulate",
+    )
+    # Users frequently reach for --iterations in other demos; support it as an alias
+    # so the CLI is forgiving while still wiring into the same destination.
+    run_cmd.add_argument(
+        "--iterations",
+        dest="generations",
+        type=int,
+        help="alias for --generations",
+    )
     run_cmd.add_argument("--seed", type=int, default=7)
     run_cmd.add_argument("--config", type=str, default=None)
     run_cmd.add_argument("--output", type=str, default="alphaevolve_report.json")
@@ -123,6 +137,8 @@ def main() -> None:
     if args.command != "run":
         parser.print_help()
         return
+    if args.generations < 1:
+        parser.error("--generations/--iterations must be at least 1")
     run_demo(args)
 
 

--- a/demo/AlphaEvolve-v0/tests/test_cli_runner.py
+++ b/demo/AlphaEvolve-v0/tests/test_cli_runner.py
@@ -1,0 +1,22 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from alphaevolve_runner import build_parser, run_demo
+
+
+def test_iterations_alias_creates_report(tmp_path):
+    parser = build_parser()
+    output_path = tmp_path / "report.json"
+
+    args = parser.parse_args(
+        ["run", "--iterations", "1", "--output", str(output_path), "--seed", "13"]
+    )
+
+    run_demo(args)
+
+    payload = json.loads(output_path.read_text())
+    assert payload["history"][0]["generation"] == 1
+    assert payload["champion"]["Utility"] > 0


### PR DESCRIPTION
## Summary
- allow the AlphaEvolve demo runner to accept `--iterations` as an alias for `--generations` and validate positive values
- add a CLI regression test to ensure the alias produces a report successfully

## Testing
- python demo/run_demo_tests.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939e8318c84833381a6bdf915fd7908)