### PR TITLE
Add chromium Playwright project for Phase 8 demo

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/playwright.config.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
@@ -11,6 +11,14 @@ export default defineConfig({
     baseURL: 'http://127.0.0.1:4175',
     trace: 'on-first-retry',
   },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
   webServer: {
     command: 'node tests/server.js',
     port: 4175,


### PR DESCRIPTION
## Summary
- add an explicit chromium Playwright project so the Phase 8 dashboard suite can be targeted with --project
- keep the shared base configuration while layering Desktop Chrome device defaults for browser coverage

## Testing
- python demo/run_demo_tests.py
- npx playwright test --config demo/Phase-8-Universal-Value-Dominance/playwright.config.ts --project=chromium --reporter=list


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f1b79e408333ae7c518fe67bde77)