### PR TITLE
Fix AlphaEvolve iterations alias overriding default

### DIFF
--- a/demo/AlphaEvolve-v0/alphaevolve_runner.py
+++ b/demo/AlphaEvolve-v0/alphaevolve_runner.py
@@ -123,6 +123,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--iterations",
         dest="generations",
         type=int,
+        default=argparse.SUPPRESS,
         help="alias for --generations",
     )
     run_cmd.add_argument("--seed", type=int, default=7)

--- a/demo/AlphaEvolve-v0/tests/test_cli_runner.py
+++ b/demo/AlphaEvolve-v0/tests/test_cli_runner.py
@@ -20,3 +20,11 @@ def test_iterations_alias_creates_report(tmp_path):
     payload = json.loads(output_path.read_text())
     assert payload["history"][0]["generation"] == 1
     assert payload["champion"]["Utility"] > 0
+
+
+def test_default_generations_preserved():
+    parser = build_parser()
+
+    args = parser.parse_args(["run"])
+
+    assert args.generations == 30


### PR DESCRIPTION
## Summary
- prevent the `--iterations` alias from overwriting the default `--generations` value in the AlphaEvolve CLI
- add a regression test to ensure the default generation count is preserved when no flags are provided

## Testing
- python demo/run_demo_tests.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fa4aefa48333b91d560158a1db81)