### PR TITLE
Silence websocket deprecation warnings in demo tests

### DIFF
--- a/demo/AGI-Alpha-Node-v0/pytest.ini
+++ b/demo/AGI-Alpha-Node-v0/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
 addopts = -p no:web3.tools.pytest_ethereum
+filterwarnings =
+    ignore:websockets\.client\.connect is deprecated:DeprecationWarning
+    ignore:websockets\.legacy is deprecated:DeprecationWarning
+    ignore:websockets\.WebSocketClientProtocol is deprecated:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,7 @@ pythonpath = .
 testpaths =
     tests
     test
+filterwarnings =
+    ignore:websockets\.client\.connect is deprecated:DeprecationWarning
+    ignore:websockets\.legacy is deprecated:DeprecationWarning
+    ignore:websockets\.WebSocketClientProtocol is deprecated:DeprecationWarning


### PR DESCRIPTION
## Summary
- add global warning filters to pytest to suppress websocket deprecation noise during demo runs
- align the AGI-Alpha-Node demo pytest settings with the same websocket deprecation filters to keep output clean

## Testing
- python demo/run_demo_tests.py
- PYTHONPATH=grand_demo/alpha_node:grand_demo:src:. pytest tests --import-mode=importlib


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693acfe695488333a696b702253d1838)