### PR TITLE
Fix AlphaEvolve proxy package wiring

### DIFF
--- a/demo/AlphaEvolve_v0/alphaevolve_demo/__init__.py
+++ b/demo/AlphaEvolve_v0/alphaevolve_demo/__init__.py
@@ -1,15 +1,29 @@
 """Proxy module exposing the canonical implementation stored under `AlphaEvolve-v0`."""
 from __future__ import annotations
 
-from importlib import import_module
+from importlib import util
 from pathlib import Path
 import sys
 
-_pkg_dir = Path(__file__).resolve().parents[1] / "AlphaEvolve-v0"
-if str(_pkg_dir) not in sys.path:
-    sys.path.append(str(_pkg_dir))
+_pkg_dir = Path(__file__).resolve().parents[2] / "AlphaEvolve-v0"
+_pkg_init = _pkg_dir / "alphaevolve_demo" / "__init__.py"
 
-_alpha_pkg = import_module("alphaevolve_demo")
+existing = sys.modules.get("alphaevolve_demo")
+if existing and Path(getattr(existing, "__file__", "")).resolve() == _pkg_init:
+    _alpha_pkg = existing
+else:
+    sys.path.insert(0, str(_pkg_dir))
+    spec = util.spec_from_file_location(
+        "alphaevolve_demo",
+        _pkg_init,
+        submodule_search_locations=[str(_pkg_init.parent)],
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load canonical alphaevolve_demo from {_pkg_init}")
+
+    _alpha_pkg = util.module_from_spec(spec)
+    sys.modules["alphaevolve_demo"] = _alpha_pkg
+    spec.loader.exec_module(_alpha_pkg)
 
 for name in getattr(_alpha_pkg, "__all__", []):
     module = getattr(_alpha_pkg, name)

--- a/demo/AlphaEvolve_v0/tests/test_proxy_package.py
+++ b/demo/AlphaEvolve_v0/tests/test_proxy_package.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_proxy_forwards_to_canonical_package(monkeypatch):
+    # Simulate a consumer importing the proxy package from the repo root.
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[2]))
+
+    import alphaevolve_demo
+
+    # The proxy should expose the canonical module contents and definitions.
+    assert set(alphaevolve_demo.__all__), "Expected exported symbols from canonical package"
+
+    agent_path = Path(alphaevolve_demo.agent.__file__).resolve()
+    assert "AlphaEvolve-v0" in agent_path.parts
+    assert agent_path.name == "agent.py"


### PR DESCRIPTION
## Summary
- ensure the AlphaEvolve_v0 proxy loads the canonical AlphaEvolve-v0 package instead of shadowing itself
- add a regression test that verifies the proxy exposes the canonical modules and exports

## Testing
- python demo/run_demo_tests.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae872c3d08333aff99883c9f7c7c0)