### PR TITLE
Allow AZR telemetry to use isolated output paths

### DIFF
--- a/demo/Absolute-Zero-Reasoner-v0/tests/test_loop.py
+++ b/demo/Absolute-Zero-Reasoner-v0/tests/test_loop.py
@@ -6,7 +6,9 @@ from absolute_zero_reasoner_demo.config_loader import load_config
 from absolute_zero_reasoner_demo.loop import AbsoluteZeroDemo
 
 
-def test_demo_runs_short_cycle(tmp_path) -> None:
+def test_demo_runs_short_cycle(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AZR_OUTPUT_DIR", str(tmp_path))
+
     config = load_config()
     config.raw["azr"]["iterations"] = 3
     config.raw["azr"]["tasks_per_iteration"] = 2


### PR DESCRIPTION
## Summary
- add AZR_OUTPUT_DIR override to redirect Absolute Zero Reasoner telemetry outputs away from the repo root when desired
- update the Absolute Zero Reasoner loop test to exercise the demo using an isolated temporary output directory

## Testing
- python demo/run_demo_tests.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aefdedcc483338785365536471aa7)