### PR TITLE
Add safe pytest wrapper for demo suites

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -15,6 +15,8 @@ This deck guides incident commanders through the production controls that keep t
 | 3 | `npm run owner:command-center` | Generates the owner mission briefing, control matrix, and drift analysis so contract owners can approve or pause operations instantly.【F:package.json†L165-L190】【F:scripts/v2/ownerCommandCenter.ts†L1-L210】 |
 | 4 | `make operator:green` | Runs the Day-One utility benchmark to validate treasury uplift and guardrail posture with fresh artefacts.【F:Makefile†L70-L118】【F:tools/operator_banner.py†L1-L148】 |
 
+**Pytest safety harness** — Use `scripts/pytest_safe.sh <path>` when exercising demo suites directly (for example `scripts/pytest_safe.sh demo/AGI-Alpha-Node-v0/tests`). The wrapper disables third-party plugin autoloading and pins `PYTHONPATH` to the repo root so the local `eth_typing` shim and other compatibility layers load before global packages, preventing spurious import errors during collection.【F:scripts/pytest_safe.sh†L1-L24】
+
 Archive the resulting artefacts (`reports/ci/status.*`, `reports/owner-control/**`, demo outputs) with the incident log so every response starts from the same verified baseline.【F:.github/workflows/ci.yml†L393-L440】【F:.github/workflows/ci.yml†L1026-L1155】
 
 ## Incident topology

--- a/scripts/pytest_safe.sh
+++ b/scripts/pytest_safe.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure pytest runs in an isolated, reproducible environment where the local
+# compatibility shims (for example the eth_typing backport) take precedence over
+# globally installed plugins.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Disable third-party plugin autoload to prevent globally installed plugins from
+# breaking collection before our own configuration is applied.
+export PYTEST_DISABLE_PLUGIN_AUTOLOAD="${PYTEST_DISABLE_PLUGIN_AUTOLOAD:-1}"
+
+# Guarantee the repository root is first on sys.path so local shims such as
+# eth_typing.py shadow upstream packages when required by the demos.
+if [[ -n "${PYTHONPATH:-}" ]]; then
+  export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH}"
+else
+  export PYTHONPATH="${REPO_ROOT}"
+fi
+
+exec python -m pytest "$@"


### PR DESCRIPTION
## Summary
- add a shared pytest wrapper that disables third-party plugin autoloading and ensures the repo root is first on PYTHONPATH so local shims take precedence
- document the wrapper in the runbook for running demo suites directly

## Testing
- scripts/pytest_safe.sh demo/AGI-Alpha-Node-v0/test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693af88f53b48333a11b085b2419473a)