### PR TITLE
Fix Omega demo wrapper import and add coverage

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/__init__.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/__init__.py
@@ -1,10 +1,21 @@
-"""Compatibility wrapper for the Omega-grade demo package."""
+"""Compatibility wrapper for the Omega-grade demo package.
+
+This module bridges the top-level ``demo/kardashev_ii_...`` namespace to the
+canonical package that lives under the ``Kardashev-II Omega-Grade-α-AGI
+Business-3`` directory (with spaces and Unicode characters in the path). The
+loader below eagerly imports the real package and re-exports its public API so
+that ``import demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo`` works as
+expected for downstream tooling.
+"""
 
 from __future__ import annotations
 
 import importlib.util
 import sys
 from pathlib import Path
+from types import ModuleType
+from typing import Any
+
 
 _THIS_DIR = Path(__file__).resolve().parent
 _SOURCE_DIR = _THIS_DIR / ".." / "Kardashev-II Omega-Grade-α-AGI Business-3" / "kardashev_ii_omega_grade_alpha_agi_business_3_demo"
@@ -14,9 +25,7 @@ if str(_SOURCE_DIR) not in sys.path:
     sys.path.insert(0, str(_SOURCE_DIR.parent))
 
 _spec = importlib.util.spec_from_file_location(
-    __name__,
-    _SOURCE_DIR / "__init__.py",
-    submodule_search_locations=[str(_SOURCE_DIR)],
+    __name__, _SOURCE_DIR / "__init__.py", submodule_search_locations=[str(_SOURCE_DIR)]
 )
 if _spec is None or _spec.loader is None:  # pragma: no cover - defensive
     raise ImportError("Unable to load Omega-grade demo package")
@@ -24,6 +33,19 @@ _module = importlib.util.module_from_spec(_spec)
 sys.modules[__name__] = _module
 _spec.loader.exec_module(_module)
 
-from .cli import main  # type: ignore[attr-defined]  # noqa: E402  # re-export for convenience
-
 __all__ = getattr(_module, "__all__", [])
+main = getattr(_module, "main")
+
+
+def __getattr__(name: str) -> Any:
+    """Delegate attribute access to the underlying module.
+
+    This keeps the wrapper lightweight while ensuring all public symbols remain
+    available to callers even if new exports are added to the upstream package.
+    """
+
+    return getattr(_module, name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - intellisense helper
+    return sorted(set(__all__) | set(dir(ModuleType)))

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_wrapper_imports.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_wrapper_imports.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_wrapper_delegates_to_source_package(tmp_path: Path) -> None:
+    wrapper = importlib.import_module("demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo")
+
+    source_root = Path(__file__).resolve().parents[2] / "Kardashev-II Omega-Grade-α-AGI Business-3"
+    sys.path.insert(0, str(source_root))
+    try:
+        source_pkg = importlib.import_module("kardashev_ii_omega_grade_alpha_agi_business_3_demo")
+    finally:
+        sys.path.remove(str(source_root))
+
+    assert wrapper.main.__code__.co_filename == source_pkg.main.__code__.co_filename
+    assert callable(wrapper.main)
+    assert "main" in wrapper.__all__


### PR DESCRIPTION
## Summary
- ensure the Omega demo wrapper properly loads and re-exports the upstream package with space/Unicode paths
- add regression coverage for the wrapper to confirm the exposed `main` matches the source package API

## Testing
- python demo/run_demo_tests.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b16ec65f08333b2c18b073e4d2fa9)