### PR TITLE
Fix self-play transitions to store pre-action observations

### DIFF
--- a/demo/MuZero-style-v0/muzero_demo/training.py
+++ b/demo/MuZero-style-v0/muzero_demo/training.py
@@ -80,13 +80,14 @@ class MuZeroTrainer:
             discount_power = 1.0
             episode: List[Transition] = []
             while not env.done:
+                pre_action_observation = observation.vector.tolist()
                 action, policy, meta = planner.plan(env, observation)
                 step = env.step(action)
                 reward = step.reward * discount_power
                 expected_value = float(meta.get("expected_value", reward)) if isinstance(meta, dict) else float(reward)
                 episode.append(
                     Transition(
-                        observation=observation.vector.tolist(),
+                        observation=pre_action_observation,
                         action=action,
                         reward=float(reward),
                         policy=list(policy),


### PR DESCRIPTION
## Summary
- capture the observation before acting so self-play transitions align inputs with the recorded action, policy, and reward
- use the stored pre-action observation when adding transitions to the replay buffer

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b485dd6848333821a0ca6f1090d1d)