### PR TITLE
Handle offline mermaid rendering gracefully in Kardashev UI

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -6,9 +6,10 @@ async function loadMermaid() {
   }
 
   try {
-    mermaidModule = await import(
+    const mermaidNamespace = await import(
       "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs"
     );
+    mermaidModule = mermaidNamespace?.default ?? mermaidNamespace;
   } catch (error) {
     console.error("Failed to load mermaid from CDN", error);
     mermaidModule = null;


### PR DESCRIPTION
## Summary
- add a lazy Mermaid loader with error handling so the Kardashev II dashboard still renders when the CDN is unavailable
- guard diagram rendering with container checks and user-facing warnings instead of hard failures

## Testing
- npm run demo:kardashev -- --check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b574969008333b7586dba5ffcec17)