### PR TITLE
Add human-readable scoreboard summary for AGIJobs demo

### DIFF
--- a/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
@@ -159,6 +159,20 @@ def test_scoreboard_generates_dashboard():
     )
 
 
+def test_scoreboard_human_summary(monkeypatch):
+    base_path = Path(__file__).resolve().parents[1]
+    monkeypatch.chdir(base_path)
+
+    payload, fmt = run_cli(["scoreboard", "--format", "human", "--strategies", "e2e"])
+
+    assert fmt == "human"
+    summary = payload["summary"]
+    assert "Day-One Utility Scoreboard" in summary
+    assert "Utility uplift" in summary
+    assert "Dashboard:" in summary
+    assert "P95 latency" in summary
+
+
 def test_execute_human_format_summary():
     orchestrator = _orchestrator()
     payload, fmt = orchestrator.execute(["simulate", "--strategy", "e2e", "--format", "human"])


### PR DESCRIPTION
## Summary
- add a `--format human` option to the day-one utility benchmark scoreboard CLI
- generate a concise console summary of leaders, aggregates, and guardrail alerts alongside the dashboard path
- cover the new human scoreboard output with regression tests

## Testing
- python demo/run_demo_tests.py --demo AGIJobs-Day-One-Utility-Benchmark


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b62352fd083338eacdeac84858794)