### PR TITLE
Make omega demo cycles finite by default

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cli_defaults.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cli_defaults.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.cli import build_config, parse_args
+
+
+def test_default_cycles_are_finite():
+    args = parse_args([])
+    config = build_config(args)
+
+    assert config.max_cycles == 5
+
+
+def test_zero_cycles_runs_indefinitely():
+    args = parse_args(["--cycles", "0"])
+    config = build_config(args)
+
+    assert config.max_cycles is None


### PR DESCRIPTION
## Summary
- set the omega-grade demo CLI to default to a finite cycle count and expose shared config builder
- keep opt-in indefinite runs while improving help text and configuration handling
- add regression tests to verify default and explicit cycle behaviors

## Testing
- python demo/run_demo_tests.py --demo kardashev-ii

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c1e53917c8333aa874128a026d513)