### PR TITLE
Isolate meta-agentic demo storage during test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ demo/Trustless-Economic-Core-v0/reports/
 demo/superintelligent-empowerment/.venv/
 demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/latest_run_v2.json
 demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/orchestrator_v2/
+demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/runtime/
 demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/ui/dashboard-data.json
 demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v2/storage/
 demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v2/meta_agentic_alpha_v2/

--- a/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/tests/test_meta_agentic_demo.py
+++ b/demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/tests/test_meta_agentic_demo.py
@@ -23,13 +23,14 @@ def test_meta_agentic_demo_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         outcome = run_demo(config, timeout=20.0)
 
         assert outcome.status.run.state == "succeeded"
-        summary_path = working_copy / "storage" / "latest_run.json"
+        storage_root = Path(outcome.metadata["storage_root"])
+        summary_path = storage_root.parent / "latest_run.json"
         summary = json.loads(summary_path.read_text(encoding="utf-8"))
         assert summary["state"] == "succeeded"
         assert summary["completedSteps"] == summary["totalSteps"]
         assert summary["estimatedAlphaProbability"] > 0.5
 
-        scoreboard_path = working_copy / "storage" / "orchestrator" / "scoreboard.json"
+        scoreboard_path = storage_root / "scoreboard.json"
         assert scoreboard_path.exists()
         payload = json.loads(scoreboard_path.read_text(encoding="utf-8"))
         assert isinstance(payload, dict)


### PR DESCRIPTION
## Summary
- run the Meta-Agentic demo inside a per-run runtime storage copy to avoid mutating tracked fixtures
- expose the runtime storage root through the demo outcome and tests
- sandbox demo test suites via run_demo_tests.py to route orchestrator state into temp directories and ignore runtime artefacts

## Testing
- python demo/run_demo_tests.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c2acc98fc83338b8468444e5d8265)