### PR TITLE
Add bootstrap for Validator Constellation v2 demo

### DIFF
--- a/demo/Validator-Constellation-v0/v2/README.md
+++ b/demo/Validator-Constellation-v0/v2/README.md
@@ -22,7 +22,7 @@ flowchart LR
 ```
 
 ## Working With This Module
-1. From the repository root run `npm install` once to hydrate all workspaces.
+1. Run `npm install` inside this module (`demo/Validator-Constellation-v0/v2`) or let the new bootstrap hook handle it automatically when you execute `npm run demo` or `npm test`.
 2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/Validator-Constellation-v0/v2`.
 3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
 4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../../OperatorRunbook.md).

--- a/demo/Validator-Constellation-v0/v2/package.json
+++ b/demo/Validator-Constellation-v0/v2/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predemo": "node scripts/bootstrap.js",
     "build": "tsc -p .",
     "demo": "node --loader ts-node/esm src/demo-runner.ts",
+    "pretest": "node scripts/bootstrap.js",
     "test": "vitest run"
   },
   "dependencies": {

--- a/demo/Validator-Constellation-v0/v2/scripts/bootstrap.js
+++ b/demo/Validator-Constellation-v0/v2/scripts/bootstrap.js
@@ -1,0 +1,15 @@
+import { existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const moduleRoot = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(moduleRoot, '..');
+const nodeModulesPath = join(projectRoot, 'node_modules');
+
+if (!existsSync(nodeModulesPath)) {
+  console.log('🔧 Installing local dependencies for Validator Constellation v2 demo...');
+  execSync('npm ci', { cwd: projectRoot, stdio: 'inherit' });
+} else {
+  console.log('✅ Local dependencies already installed; skipping bootstrap.');
+}


### PR DESCRIPTION
## Summary
- add a bootstrap helper that installs local dependencies before running the Validator Constellation v2 demo or test suite
- wire the bootstrap hook into the demo and test npm scripts and document the updated workflow

## Testing
- npm test (demo/Validator-Constellation-v0/v2)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4ff7eaf48333901c9ed1a75c2b85)