### PR TITLE
Fix Omega-grade demo runner import bootstrap

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/run_demo.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/run_demo.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 
 import importlib
 import sys
+from pathlib import Path
 from typing import Iterable, Optional
 
 
 PACKAGE_NAME = "demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo"
+THIS_DIR = Path(__file__).resolve().parent
+DEMO_ROOT = THIS_DIR.parent
+REPO_ROOT = DEMO_ROOT.parent
 
 
 def _resolve_main():
@@ -41,6 +45,11 @@ def run(argv: Optional[Iterable[str]] = None, *, main_fn=None) -> None:
 
     if argv is None:
         argv = sys.argv[1:]
+
+    for path in (REPO_ROOT, DEMO_ROOT):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
 
     launcher = main_fn or _resolve_main()
     launcher(list(argv))

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_run_demo.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_run_demo.py
@@ -26,7 +26,6 @@ def test_run_forwards_arguments(monkeypatch):
 
 def test_run_as_script_uses_package_main(monkeypatch):
     repo_root = Path(__file__).resolve().parents[3]
-    monkeypatch.syspath_prepend(str(repo_root))
 
     script_path = repo_root / "demo" / "kardashev_ii_omega_grade_alpha_agi_business_3_demo" / "run_demo.py"
 
@@ -45,3 +44,4 @@ def test_run_as_script_uses_package_main(monkeypatch):
     runpy.run_path(str(script_path), run_name="__main__")
 
     assert captured["argv"] == []
+    assert str(repo_root) in sys.path


### PR DESCRIPTION
## Summary
- ensure the Omega-grade demo CLI adds the repository and demo roots to sys.path before importing the canonical package
- update the script execution test to assert sys.path bootstrapping without manual tweaks

## Testing
- python -m pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests
- python demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/run_demo.py --no-sim --cycles 1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cd1eff6f48333b8c82882d94142f6)