### PR TITLE
Add include flag alias for demo test runner

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -121,6 +121,8 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--demo",
+        "--include",
+        dest="demo",
         action="append",
         default=[],
         help=(

--- a/tests/test_run_demo_tests_cli.py
+++ b/tests/test_run_demo_tests_cli.py
@@ -1,0 +1,11 @@
+from demo import run_demo_tests
+
+
+def test_include_alias_populates_demo_list():
+    args = run_demo_tests._parse_args(["--include", "alpha"])
+    assert args.demo == ["alpha"]
+
+
+def test_demo_flag_still_supported():
+    args = run_demo_tests._parse_args(["--demo", "beta"])
+    assert args.demo == ["beta"]


### PR DESCRIPTION
## Summary
- allow `--include` as an alias for the existing `--demo` filter in `demo/run_demo_tests.py`
- add regression tests to confirm both `--include` and `--demo` arguments are parsed correctly

## Testing
- python -m pytest tests/test_run_demo_tests_cli.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cdfdf057c8333ac0cecf5bbbc6b6d)