### PR TITLE
Ensure deterministic demo test discovery ordering

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -119,10 +119,11 @@ def _discover_tests(
         name = path.name.lower()
         return any(token in name for token in include)
 
-    for demo_dir in sorted(p for p in demo_root.iterdir() if p.is_dir()):
+    # Iterate in a deterministic order so CI logs remain stable across runs.
+    for demo_dir in sorted((p for p in demo_root.iterdir() if p.is_dir())):
         if not _matches_filter(demo_dir):
             continue
-        for tests_dir in demo_dir.rglob("tests"):
+        for tests_dir in sorted(demo_dir.rglob("tests")):
             if not tests_dir.is_dir() or "node_modules" in tests_dir.parts:
                 continue
             if not _has_python_tests(tests_dir):


### PR DESCRIPTION
## Summary
- iterate demo directories and test folders in a deterministic order to stabilize demo test runs
- keep demo test discovery logs consistent across environments

## Testing
- python demo/run_demo_tests.py --list --demo alpha

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d861441bc8333bfa2714c5c1398ca)