### PR TITLE
Add demo.py entrypoint for Absolute Zero Reasoner

### DIFF
--- a/demo/Absolute-Zero-Reasoner-v0/demo.py
+++ b/demo/Absolute-Zero-Reasoner-v0/demo.py
@@ -1,0 +1,13 @@
+"""Convenience executable for the Absolute Zero Reasoner demo.
+
+This mirrors :mod:`azr_demo.__main__` so users can simply run
+``python demo.py`` from the demo directory without hunting for the
+package entrypoint.
+"""
+from __future__ import annotations
+
+from azr_demo.__main__ import main
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via integration test
+    main()

--- a/demo/Absolute-Zero-Reasoner-v0/tests/test_entrypoint.py
+++ b/demo/Absolute-Zero-Reasoner-v0/tests/test_entrypoint.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_demo_entrypoint_runs_and_writes_output(tmp_path: Path) -> None:
+    demo_root = Path(__file__).resolve().parents[1]
+    output_path = tmp_path / "telemetry.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(demo_root / "demo.py"),
+            "--max-seconds",
+            "0.01",
+            "--quiet",
+            "--output",
+            str(output_path),
+        ],
+        cwd=demo_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.exists()
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["telemetry"]["iterations"] >= 0
+    assert payload["telemetry"]["success_rate"] >= 0


### PR DESCRIPTION
## Summary
- add a top-level demo.py wrapper so Absolute Zero Reasoner can be run directly
- add a regression test to ensure the entrypoint produces telemetry output

## Testing
- python -m pytest demo/Absolute-Zero-Reasoner-v0/tests -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d98fe65788333915f40329eb3ae5b)