### PR TITLE
Default labor market demo CLI to summarize

### DIFF
--- a/demo/agi-labor-market-grand-demo/run_demo.py
+++ b/demo/agi-labor-market-grand-demo/run_demo.py
@@ -166,12 +166,20 @@ def build_parser() -> argparse.ArgumentParser:
         description="Run the AGI Labor Market Grand Demo utilities",
     )
 
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    # Default to the quick "summarize" path so that `python run_demo.py`
+    # works out-of-the-box without extra flags. This mirrors the ergonomics of
+    # other demos in the repository and avoids surprising argparse failures.
+    parser.set_defaults(command="summarize", transcript=DEFAULT_TRANSCRIPT)
+
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.required = False
+    subparsers.default = "summarize"
 
     summary_parser = subparsers.add_parser(
         "summarize",
         help="Print telemetry derived from the bundled transcript",
     )
+    summary_parser.set_defaults(command="summarize")
     summary_parser.add_argument(
         "--transcript",
         type=Path,
@@ -183,6 +191,7 @@ def build_parser() -> argparse.ArgumentParser:
         "serve",
         help="Serve the static UI from the ui/ directory",
     )
+    serve_parser.set_defaults(command="serve")
     serve_parser.add_argument("--port", type=int, default=8000, help="Port to bind")
     serve_parser.add_argument(
         "--host",

--- a/demo/agi-labor-market-grand-demo/tests/test_run_demo.py
+++ b/demo/agi-labor-market-grand-demo/tests/test_run_demo.py
@@ -54,6 +54,14 @@ def test_format_summary_includes_key_metrics():
         assert phrase in summary
 
 
+def test_main_defaults_to_summarize(capsys):
+    assert run_demo.main([]) == 0
+
+    out = capsys.readouterr().out
+    assert "AGI Labor Market Grand Demo" in out
+    assert "Total jobs" in out
+
+
 def test_create_server_binds_localhost_and_serves_assets():
     with run_demo.create_server("127.0.0.1", 0) as server:
         host, port = server.server_address[:2]


### PR DESCRIPTION
## Summary
- default the AGI Labor Market Grand Demo CLI to the `summarize` path so running the script without arguments works smoothly
- ensure explicit defaults are registered for both subcommands and add regression coverage for the implicit summarize behavior

## Testing
- python demo/run_demo_tests.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da68a750083339382065f0cc22983)