### PR TITLE
Add runnable wrapper for meta-agentic program synthesis demo

### DIFF
--- a/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_run_demo_wrapper.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/meta_agentic_demo/tests/test_run_demo_wrapper.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_wrapper_module():
+    wrapper_path = Path(__file__).resolve().parents[2] / "run_demo.py"
+    spec = importlib.util.spec_from_file_location("meta_agentic_run_demo", wrapper_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader  # for mypy/static checkers
+    spec.loader.exec_module(module)  # type: ignore[call-arg]
+    return module
+
+
+def test_run_demo_forwards_arguments(monkeypatch):
+    wrapper = _load_wrapper_module()
+    captured = {}
+
+    def fake_main():
+        captured["argv"] = list(sys.argv)
+
+    wrapper.run(["--list-scenarios", "--output", "demo_output"], main_fn=fake_main)
+
+    assert captured["argv"][1:] == ["--list-scenarios", "--output", "demo_output"]
+
+
+def test_ensure_sys_path_idempotent():
+    wrapper = _load_wrapper_module()
+    original_sys_path = list(sys.path)
+
+    wrapper._ensure_sys_path()
+    wrapper._ensure_sys_path()
+
+    repo_root = str(wrapper.REPO_ROOT)
+    demo_root = str(wrapper.DEMO_ROOT)
+    assert repo_root in sys.path
+    assert demo_root in sys.path
+    assert sys.path.count(repo_root) == 1
+    assert sys.path.count(demo_root) == 1
+
+    sys.path[:] = original_sys_path

--- a/demo/Meta-Agentic-Program-Synthesis-v0/run_demo.py
+++ b/demo/Meta-Agentic-Program-Synthesis-v0/run_demo.py
@@ -1,0 +1,51 @@
+"""Launch the Meta-Agentic Program Synthesis demo from any working directory.
+
+This wrapper mirrors the other demo entrypoints by forwarding arguments into
+``start_demo.main`` after ensuring the repository and demo roots sit on
+``sys.path``. It keeps the UX symmetric—``python demo/Meta-Agentic-Program-
+Synthesis-v0/run_demo.py`` just works—while still allowing tests to inject a
+custom main callable for fast verification.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+DEMO_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = DEMO_ROOT.parent
+
+
+def _resolve_main():
+    module = importlib.import_module("start_demo")
+    try:
+        return module.main
+    except AttributeError as exc:  # pragma: no cover - defensive
+        raise AttributeError("start_demo does not expose a 'main' callable") from exc
+
+
+def _ensure_sys_path() -> None:
+    for path in reversed((REPO_ROOT, DEMO_ROOT)):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
+
+
+def run(argv: Optional[Iterable[str]] = None, *, main_fn=None) -> None:
+    """Execute the demo with optional argument forwarding."""
+
+    _ensure_sys_path()
+    main_callable = main_fn or _resolve_main()
+    forwarded = list(argv) if argv is not None else sys.argv[1:]
+
+    original_argv = sys.argv
+    sys.argv = [original_argv[0]] + forwarded
+    try:
+        main_callable()
+    finally:
+        sys.argv = original_argv
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add a top-level run_demo wrapper so the Meta-Agentic Program Synthesis demo can be launched directly from the repo root
- guard sys.path setup for the wrapper and make it testable via a hookable main
- add regression tests to confirm argument forwarding and sys.path hygiene

## Testing
- python demo/run_demo_tests.py --demo meta-agentic-program-synthesis
- python demo/Meta-Agentic-Program-Synthesis-v0/run_demo.py --list-scenarios


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dbafeb3e48333a644056a10c7ee32)