### PR TITLE
Add runnable entrypoint for AlphaEvolve demo

### DIFF
--- a/demo/AlphaEvolve-v0/run_demo.py
+++ b/demo/AlphaEvolve-v0/run_demo.py
@@ -1,0 +1,22 @@
+"""AlphaEvolve demo entrypoint.
+
+This thin wrapper keeps the standalone script usable when the
+package has not been installed into the environment. It mirrors
+the rest of the demo gallery's `run_demo.py` convention so operators
+can invoke the experiment with a consistent command.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the demo package is importable when executed directly.
+DEMO_ROOT = Path(__file__).resolve().parent
+if str(DEMO_ROOT) not in sys.path:
+    sys.path.insert(0, str(DEMO_ROOT))
+
+from alphaevolve_runner import main
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via integration test
+    main()

--- a/demo/AlphaEvolve-v0/tests/test_run_demo_entrypoint.py
+++ b/demo/AlphaEvolve-v0/tests/test_run_demo_entrypoint.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_run_demo_script_help(tmp_path):
+    env = os.environ.copy()
+    env.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+
+    result = subprocess.run(
+        [sys.executable, "run_demo.py", "--help"],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "AlphaEvolve grand demo" in result.stdout
+    assert "run" in result.stdout


### PR DESCRIPTION
## Summary
- add a standard run_demo.py wrapper so the AlphaEvolve demo can be invoked like other demos
- ensure the entrypoint sets up sys.path for standalone execution
- add an integration test that exercises the new CLI help output

## Testing
- python demo/run_demo_tests.py --demo AlphaEvolve-v0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693df06315488333a044ef0bc76e1c65)