### PR TITLE
Enhance Phase 8 demo CLI usability

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/tests/test_run_demo_script.py
+++ b/demo/Phase-8-Universal-Value-Dominance/tests/test_run_demo_script.py
@@ -36,3 +36,27 @@ def test_report_addresses_are_normalised():
     for field, value in payload["global"].items():
         assert value.startswith("0x"), f"{field} should look like an address"
         assert value == value.lower()
+
+
+def test_custom_output_and_quiet_mode(tmp_path):
+    custom_output = tmp_path / "custom_report.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--output",
+            str(custom_output),
+            "--quiet",
+        ],
+        cwd=PHASE_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == ""
+    assert custom_output.exists()
+
+    payload = json.loads(custom_output.read_text())
+    assert payload["totals"]["monthlyUSD"] > 0


### PR DESCRIPTION
## Summary
- add CLI options to the Phase 8 Universal Value Dominance demo for custom manifest/output paths and quiet mode
- refactor report writing to target configurable destinations while preserving existing defaults
- expand demo tests to cover the new CLI switches and report generation

## Testing
- python demo/run_demo_tests.py --demo Phase-8-Universal-Value-Dominance


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693df74340a48333bc114c9f74156064)