### PR TITLE
Fix async demo tests to run without pytest plugins

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_validation_task_cleanup.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_validation_task_cleanup.py
@@ -1,8 +1,6 @@
 import asyncio
 from pathlib import Path
 
-import pytest
-
 from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme.config import (
     SupremeDemoConfig,
 )
@@ -12,38 +10,46 @@ from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme.orchestrato
 )
 
 
-@pytest.mark.anyio
-async def test_validation_tasks_cleanup(tmp_path: Path) -> None:
-    config = SupremeDemoConfig(
-        checkpoint_path=tmp_path / "state.json",
-        log_path=tmp_path / "logs.jsonl",
-        bus_history_path=tmp_path / "bus.jsonl",
-        owner_control_path=tmp_path / "owner_control.json",
-        owner_ack_path=tmp_path / "owner_ack.json",
-        structured_metrics_path=tmp_path / "metrics.jsonl",
-        mermaid_dashboard_path=tmp_path / "dashboard.mmd",
-        job_history_path=tmp_path / "history.jsonl",
-        validator_commit_delay_seconds=0,
-        validator_reveal_delay_seconds=0,
-        enable_simulation=False,
-    )
-    orchestrator = SupremeOrchestrator(config)
+def test_validation_tasks_cleanup(tmp_path: Path) -> None:
+    """Ensure background validation tasks are cleaned up after completion.
 
-    spec = JobSpec(
-        title="Test",
-        description="",
-        reward=10,
-        stake_required=0,
-        energy_budget=1.0,
-        compute_budget=1.0,
-        deadline_epoch=0.0,
-        employer="tester",
-    )
-    job = await orchestrator.post_job(spec)
+    Using ``asyncio.run`` keeps the test compatible with the default pytest
+    runner while still exercising the async orchestrator API end-to-end.
+    """
 
-    await orchestrator.mark_job_complete(job.job_id, "result://demo", 1.0, 1.0)
-    # Allow validation tasks to run and cleanup callback to execute.
-    await asyncio.gather(*list(orchestrator._validation_tasks))
-    await asyncio.sleep(0)
+    async def _exercise_validation_cleanup() -> None:
+        config = SupremeDemoConfig(
+            checkpoint_path=tmp_path / "state.json",
+            log_path=tmp_path / "logs.jsonl",
+            bus_history_path=tmp_path / "bus.jsonl",
+            owner_control_path=tmp_path / "owner_control.json",
+            owner_ack_path=tmp_path / "owner_ack.json",
+            structured_metrics_path=tmp_path / "metrics.jsonl",
+            mermaid_dashboard_path=tmp_path / "dashboard.mmd",
+            job_history_path=tmp_path / "history.jsonl",
+            validator_commit_delay_seconds=0,
+            validator_reveal_delay_seconds=0,
+            enable_simulation=False,
+        )
+        orchestrator = SupremeOrchestrator(config)
 
-    assert orchestrator._validation_tasks == []
+        spec = JobSpec(
+            title="Test",
+            description="",
+            reward=10,
+            stake_required=0,
+            energy_budget=1.0,
+            compute_budget=1.0,
+            deadline_epoch=0.0,
+            employer="tester",
+        )
+        job = await orchestrator.post_job(spec)
+
+        await orchestrator.mark_job_complete(job.job_id, "result://demo", 1.0, 1.0)
+        # Allow validation tasks to run and cleanup callback to execute.
+        await asyncio.gather(*list(orchestrator._validation_tasks))
+        await asyncio.sleep(0)
+
+        assert orchestrator._validation_tasks == []
+
+    asyncio.run(_exercise_validation_cleanup())

--- a/demo/Kardashev-II-Omega-Grade-Alpha-AGI-Business-3/tests/test_cycle_limits.py
+++ b/demo/Kardashev-II-Omega-Grade-Alpha-AGI-Business-3/tests/test_cycle_limits.py
@@ -1,38 +1,43 @@
 import asyncio
 from datetime import timedelta
 
-import pytest
-
 from kardashev_ii_omega_grade_alpha_agi_business_3.governance import GovernanceParameters
-from kardashev_ii_omega_grade_alpha_agi_business_3.orchestrator import Orchestrator, OrchestratorConfig
+from kardashev_ii_omega_grade_alpha_agi_business_3.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
 
 
-@pytest.mark.anyio
-async def test_orchestrator_respects_cycle_limit(tmp_path):
-    governance = GovernanceParameters(
-        validator_commit_window=timedelta(seconds=0.01),
-        validator_reveal_window=timedelta(seconds=0.01),
-        validator_quorum=1,
-    )
-    config = OrchestratorConfig(
-        checkpoint_path=tmp_path / "checkpoint.json",
-        control_channel_file=tmp_path / "control.jsonl",
-        enable_simulation=False,
-        max_cycles=1,
-        cycle_sleep_seconds=0.01,
-        insight_interval_seconds=1_000,
-        checkpoint_interval_seconds=1_000,
-        governance=governance,
-    )
+def test_orchestrator_respects_cycle_limit(tmp_path):
+    """Run the async orchestrator lifecycle under the default pytest runner."""
 
-    orchestrator = Orchestrator(config)
-    await orchestrator.start()
+    async def _run_cycle_limit_check():
+        governance = GovernanceParameters(
+            validator_commit_window=timedelta(seconds=0.01),
+            validator_reveal_window=timedelta(seconds=0.01),
+            validator_quorum=1,
+        )
+        config = OrchestratorConfig(
+            checkpoint_path=tmp_path / "checkpoint.json",
+            control_channel_file=tmp_path / "control.jsonl",
+            enable_simulation=False,
+            max_cycles=1,
+            cycle_sleep_seconds=0.01,
+            insight_interval_seconds=1_000,
+            checkpoint_interval_seconds=1_000,
+            governance=governance,
+        )
 
-    await asyncio.wait_for(_wait_for_stop(orchestrator), timeout=2)
+        orchestrator = Orchestrator(config)
+        await orchestrator.start()
 
-    assert orchestrator._cycle == config.max_cycles
+        await asyncio.wait_for(_wait_for_stop(orchestrator), timeout=2)
 
-    await orchestrator.shutdown()
+        assert orchestrator._cycle == config.max_cycles
+
+        await orchestrator.shutdown()
+
+    asyncio.run(_run_cycle_limit_check())
 
 
 async def _wait_for_stop(orchestrator: Orchestrator) -> None:


### PR DESCRIPTION
## Summary
- run async Kardashev II demo tests using asyncio.run so they work with the default pytest runner
- keep validation cleanup and cycle limit checks intact while avoiding anyio-specific marks

## Testing
- python demo/run_demo_tests.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dfcbfe6208333aa8c65d85de5f77a)