### PR TITLE
Fix Alpha Node demo runner and specialist initialization

### DIFF
--- a/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/ai/specialists/biotech.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/ai/specialists/biotech.py
@@ -2,16 +2,14 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
 from typing import Dict
 
 from .base import Specialist, SpecialistContext
 from .results import ExecutionResult
 
 
-@dataclass(slots=True)
 class BiotechSynthesist(Specialist):
-    synthesis_efficiency: float = 0.82
+    __slots__ = ("synthesis_efficiency",)
 
     def __init__(self, name: str = "biotech-synthesist", synthesis_efficiency: float = 0.82) -> None:
         super().__init__(name)

--- a/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/ai/specialists/finance.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/ai/specialists/finance.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 
 import math
 import random
-from dataclasses import dataclass
 from typing import Dict
 
 from .base import Specialist, SpecialistContext
 from .results import ExecutionResult
 
 
-@dataclass(slots=True)
 class FinanceStrategist(Specialist):
-    risk_aversion: float = 0.35
+    __slots__ = ("risk_aversion",)
 
     def __init__(self, name: str = "finance-strategist", risk_aversion: float = 0.35) -> None:
         super().__init__(name)

--- a/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/ai/specialists/manufacturing.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/ai/specialists/manufacturing.py
@@ -2,16 +2,14 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
 from typing import Dict
 
 from .base import Specialist, SpecialistContext
 from .results import ExecutionResult
 
 
-@dataclass(slots=True)
 class ManufacturingOptimizer(Specialist):
-    automation_factor: float = 0.78
+    __slots__ = ("automation_factor",)
 
     def __init__(self, name: str = "manufacturing-optimizer", automation_factor: float = 0.78) -> None:
         super().__init__(name)

--- a/demo/AGI-Alpha-Node-v0/grand_demo/scripts/run_demo.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/scripts/run_demo.py
@@ -1,25 +1,109 @@
-"""Executable script to run the AGI Alpha Node demo end-to-end."""
+"""Executable script to run the AGI Alpha Node demo end-to-end.
+
+The script now bootstraps its own import paths so operators can execute it
+directly (``python demo/AGI-Alpha-Node-v0/grand_demo/scripts/run_demo.py``)
+without manually exporting ``PYTHONPATH``. It also allows tests to bypass the
+Uvicorn server so the deterministic demo flow can be exercised without opening
+network sockets.
+"""
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
+import sys
+from pathlib import Path
+from typing import Awaitable, Callable, Optional
 
-import uvicorn
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent
+REPO_ROOT = PROJECT_ROOT.parent
 
-from alpha_node.console.cli import demo_job
-from alpha_node.web.app import app
+
+def _bootstrap_sys_path() -> None:
+    """Ensure local packages import cleanly when executed directly."""
+
+    for path in (REPO_ROOT, PROJECT_ROOT):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
 
 
-async def main() -> None:
+_bootstrap_sys_path()
+
+import uvicorn  # noqa: E402  (import after path bootstrap)
+from alpha_node.console.cli import demo_job  # noqa: E402
+from alpha_node.web.app import app  # noqa: E402
+
+
+def _build_server(app_obj: object, *, host: str, port: int) -> uvicorn.Server:
+    return uvicorn.Server(
+        uvicorn.Config(app_obj, host=host, port=port, loop="asyncio", lifespan="off")
+    )
+
+
+def _resolve_config_path(config_path: Optional[Path]) -> Optional[Path]:
+    if config_path is None:
+        candidate = PROJECT_ROOT / "config" / "alpha-node.config.yaml"
+        return candidate if candidate.exists() else None
+    return config_path
+
+
+def _supports_config_path(fn: Callable[..., object]) -> bool:
+    try:
+        import inspect
+
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return False
+
+    return any(
+        param.name == "config_path" and param.kind in {param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY}
+        for param in sig.parameters.values()
+    )
+
+
+async def _run_demo_job(
+    demo_job_fn: Callable[..., Awaitable[None] | None],
+    *,
+    config_path: Optional[Path],
+) -> None:
+    kwargs = {}
+    resolved = _resolve_config_path(config_path)
+    if resolved is not None and _supports_config_path(demo_job_fn):
+        kwargs["config_path"] = resolved
+
+    result = demo_job_fn(**kwargs)
+    if inspect.isawaitable(result):  # type: ignore[name-defined]
+        await result  # type: ignore[arg-type]
+
+
+async def main(
+    *,
+    host: str = "0.0.0.0",
+    port: int = 8080,
+    run_server: bool = True,
+    demo_job_fn: Callable[..., Awaitable[None] | None] = demo_job,
+    app_obj: object = app,
+    config_path: Optional[Path] = None,
+) -> None:
+    """Launch the demo job and, optionally, the local Uvicorn service."""
+
     logging.basicConfig(level=logging.INFO)
-    server = uvicorn.Server(uvicorn.Config(app, host="0.0.0.0", port=8080, loop="asyncio"))
 
-    async def start_server() -> None:
-        await server.serve()
+    server = _build_server(app_obj, host=host, port=port) if run_server else None
+    server_task = asyncio.create_task(server.serve()) if server else None
 
-    loop = asyncio.get_running_loop()
-    loop.create_task(start_server())
-    demo_job()
+    try:
+        await _run_demo_job(demo_job_fn, config_path=config_path)
+    finally:
+        if server and server_task:
+            server.should_exit = True
+            server.force_exit = True
+            try:
+                await server_task
+            except asyncio.CancelledError:
+                logging.debug("Uvicorn server cancelled during shutdown", exc_info=True)
 
 
 if __name__ == "__main__":

--- a/demo/AGI-Alpha-Node-v0/grand_demo/tests/test_script_run_demo.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/tests/test_script_run_demo.py
@@ -1,0 +1,60 @@
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "run_demo.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("alpha_node_run_demo", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_path():
+    original = list(sys.path)
+    yield
+    sys.path[:] = original
+
+
+def test_bootstrap_allows_direct_execution(monkeypatch):
+    # Remove project paths to ensure the module re-injects them.
+    sys.path = [p for p in sys.path if "AGI-Alpha-Node-v0" not in p]
+    module = _load_module()
+
+    assert str(module.PROJECT_ROOT) in sys.path
+    assert str(module.REPO_ROOT) in sys.path
+
+
+def test_demo_job_runs_without_server(monkeypatch):
+    module = _load_module()
+
+    calls = {
+        "demo_job": 0,
+        "served": 0,
+    }
+
+    async def fake_demo_job():
+        calls["demo_job"] += 1
+
+    class DummyServer:
+        def __init__(self):
+            calls["served"] += 1
+            self.should_exit = False
+
+        async def serve(self):
+            while not self.should_exit:
+                await asyncio.sleep(0)
+
+    monkeypatch.setattr(module, "_build_server", lambda *_, **__: DummyServer())
+
+    asyncio.run(module.main(run_server=True, demo_job_fn=fake_demo_job))
+
+    assert calls["demo_job"] == 1
+    assert calls["served"] == 1


### PR DESCRIPTION
## Summary
- bootstrap the Alpha Node grand demo runner so it resolves its own config, paths, and optional server lifecycle
- harden the specialist implementations with simple slots-based classes instead of dataclasses to fix super() initialization
- add regression tests that cover the runner bootstrap logic and headless execution path

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/AGI-Alpha-Node-v0/grand_demo/tests/test_script_run_demo.py
- python demo/AGI-Alpha-Node-v0/grand_demo/scripts/run_demo.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e08327d84833380dd0068a891eb6a)