### PR TITLE
Add Jest-style flag compatibility to Validator Constellation v2 tests

### DIFF
--- a/demo/Validator-Constellation-v0/v2/README.md
+++ b/demo/Validator-Constellation-v0/v2/README.md
@@ -24,7 +24,7 @@ flowchart LR
 ## Working With This Module
 1. Run `npm install` inside this module (`demo/Validator-Constellation-v0/v2`) or let the new bootstrap hook handle it automatically when you execute `npm run demo` or `npm test`.
 2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/Validator-Constellation-v0/v2`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
+3. Execute `npm test` (Jest-style flags like `--runInBand` are honored for serial runs) and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
 4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../../OperatorRunbook.md).
 
 ## Directory Guide

--- a/demo/Validator-Constellation-v0/v2/package.json
+++ b/demo/Validator-Constellation-v0/v2/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p .",
     "demo": "node --loader ts-node/esm src/demo-runner.ts",
     "pretest": "node scripts/bootstrap.js",
-    "test": "vitest run"
+    "test": "node scripts/run-tests.js"
   },
   "dependencies": {
     "merkletreejs": "^0.3.11",

--- a/demo/Validator-Constellation-v0/v2/scripts/run-tests.js
+++ b/demo/Validator-Constellation-v0/v2/scripts/run-tests.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Thin Vitest wrapper that tolerates Jest-style flags (e.g. --runInBand) so
+ * developers can reuse familiar commands without tripping CAC's unknown option
+ * errors. When requested, tests are forced into single-thread mode to mirror
+ * Jest's serial execution semantics.
+ */
+const rawArgs = process.argv.slice(2);
+const translatedArgs = [];
+let requestSerial = false;
+
+for (const arg of rawArgs) {
+  if (['--runInBand', '--run-in-band', '-i'].includes(arg)) {
+    requestSerial = true;
+    continue;
+  }
+  translatedArgs.push(arg);
+}
+
+if (requestSerial) {
+  translatedArgs.push('--pool', 'threads', '--poolOptions.threads.singleThread', 'true');
+}
+
+const result = spawnSync('npx', ['vitest', 'run', ...translatedArgs], {
+  stdio: 'inherit',
+  env: { ...process.env, FORCE_COLOR: '1' },
+});
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- add a vitest wrapper that accepts Jest-style serial flags and forces single-thread execution when requested
- wire npm test to the wrapper and document the compatibility in the module README

## Testing
- npm test -- --runInBand (in demo/Validator-Constellation-v0/v2)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f02e0dd5083339e92fccd094a1ea7)