### PR TITLE
Ensure demo suites use distinct sandboxes

### DIFF
--- a/tests/test_demo_run_isolation.py
+++ b/tests/test_demo_run_isolation.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from demo import run_demo_tests
+
+
+def test_suite_runtime_root_is_unique(tmp_path: Path) -> None:
+    """Ensure demo sandboxes do not collide when test paths share names."""
+
+    demo_a = tmp_path / "demo_a"
+    demo_b = tmp_path / "demo_b"
+    tests_dir_a = demo_a / "grand_demo" / "tests"
+    tests_dir_b = demo_b / "grand_demo" / "tests"
+
+    # The directories don't need real content; we just need representative paths
+    # for the relative path calculation inside ``_suite_runtime_root``.
+    tests_dir_a.mkdir(parents=True)
+    tests_dir_b.mkdir(parents=True)
+
+    runtime_root = tmp_path / "runtime"
+
+    path_a = run_demo_tests._suite_runtime_root(runtime_root, demo_a, tests_dir_a)
+    path_b = run_demo_tests._suite_runtime_root(runtime_root, demo_b, tests_dir_b)
+
+    assert path_a != path_b
+    assert path_a == runtime_root / "demo_a" / "grand_demo" / "tests"
+    assert path_b == runtime_root / "demo_b" / "grand_demo" / "tests"


### PR DESCRIPTION
## Summary
- add a helper to build unique runtime sandboxes per demo test suite
- include regression test ensuring suites with identical directory names do not collide
- rerun the demo test harness to verify isolation change

## Testing
- pytest tests/test_demo_run_isolation.py
- python demo/run_demo_tests.py --fail-fast

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f1dcbdc1883339bf4de1aa771604e)