### PR TITLE
Harden demo test discovery against virtualenvs

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -125,6 +125,9 @@ def _has_python_tests(tests_dir: Path) -> bool:
     return False
 
 
+_SKIP_TEST_PARTS = {"node_modules", ".venv", "venv", ".tox", ".git"}
+
+
 def _discover_tests(
     demo_root: Path, *, include: set[str] | None = None
 ) -> Iterable[tuple[Path, Path]]:
@@ -139,7 +142,9 @@ def _discover_tests(
         if not _matches_filter(demo_dir):
             continue
         for tests_dir in sorted(demo_dir.rglob("tests")):
-            if not tests_dir.is_dir() or "node_modules" in tests_dir.parts:
+            if not tests_dir.is_dir():
+                continue
+            if any(part in _SKIP_TEST_PARTS for part in tests_dir.parts):
                 continue
             if not _has_python_tests(tests_dir):
                 print(f"→ Skipping {tests_dir} (no Python test files found)")

--- a/demo/tests/test_run_demo_tests_runner.py
+++ b/demo/tests/test_run_demo_tests_runner.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from demo import run_demo_tests
+
+
+def test_discover_tests_skips_virtualenvs(tmp_path: Path) -> None:
+    demo_root = tmp_path / "demo-root"
+    good_suite = demo_root / "alpha"
+    good_tests = good_suite / "tests"
+    good_tests.mkdir(parents=True)
+    (good_tests / "test_ok.py").write_text("def test_ok():\n    assert True\n")
+
+    venv_tests = demo_root / ".venv" / "pkg" / "tests"
+    venv_tests.mkdir(parents=True)
+    (venv_tests / "test_ignore.py").write_text("def test_ignore():\n    assert False\n")
+
+    discovered = list(run_demo_tests._discover_tests(demo_root))
+
+    assert discovered == [(good_suite, good_tests)]


### PR DESCRIPTION
## Summary
- skip demo test directories that live inside virtual environments, git metadata, and other noisy paths to keep discovery fast and hermetic
- add regression test proving the runner ignores virtualenv suites while still picking up real demos

## Testing
- pytest demo/tests/test_run_demo_tests_runner.py
- python demo/run_demo_tests.py --list

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f4e748bcc8333897f90776cb55c68)