### PR TITLE
Improve AGI OS demo CLI usability

### DIFF
--- a/scripts/v2/__tests__/agiOsFirstClassDemo.test.ts
+++ b/scripts/v2/__tests__/agiOsFirstClassDemo.test.ts
@@ -1,0 +1,23 @@
+import { buildUsage, parseArgs } from '../agiOsFirstClassDemo';
+
+describe('parseArgs', () => {
+  it('recognises help flags before prompting', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+  });
+
+  it('collects keyed values and boolean switches', () => {
+    const args = parseArgs(['--network', 'sepolia', '--yes', '--compose']);
+    expect(args.network).toBe('sepolia');
+    expect(args.yes).toBe(true);
+    expect(args.compose).toBe(true);
+  });
+});
+
+describe('buildUsage', () => {
+  it('highlights the core command options', () => {
+    const usage = buildUsage();
+    expect(usage).toContain('--network');
+    expect(usage).toContain('--help');
+  });
+});

--- a/scripts/v2/agiOsFirstClassDemo.ts
+++ b/scripts/v2/agiOsFirstClassDemo.ts
@@ -126,11 +126,14 @@ type ManifestReport = {
   entries?: ManifestEntry[];
 };
 
-function parseArgs(): CliArgs {
-  const argv = process.argv.slice(2);
+function parseArgs(argv: string[] = process.argv.slice(2)): CliArgs {
   const result: CliArgs = {};
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
+    if (['-h', '-?', '--help'].includes(token)) {
+      result.help = true;
+      continue;
+    }
     if (!token.startsWith('--')) continue;
     const key = token.slice(2);
     const next = argv[i + 1];
@@ -152,6 +155,30 @@ function parseBool(value: string | boolean | undefined): boolean | undefined {
     if (['0', 'false', 'no', 'n', 'off'].includes(normalised)) return false;
   }
   return undefined;
+}
+
+function printUsage(): void {
+  console.log(buildUsage());
+}
+
+function buildUsage(): string {
+  return [
+    'Astral Omnidominion Operating System Demo',
+    '',
+    'Usage: ts-node scripts/v2/agiOsFirstClassDemo.ts [options]',
+    '',
+    'Options:',
+    '  -h, --help                 Show this help message and exit.',
+    '  --network <name>           Select network preset (localhost | sepolia).',
+    '  --yes, --non-interactive   Assume defaults for all prompts.',
+    '  --compose                  Launch Docker Compose automatically.',
+    '  --no-compose               Skip Docker Compose auto-launch.',
+    '  --skip-deploy              Run demo steps without the deployment wizard.',
+    '',
+    'Examples:',
+    '  ts-node ... --help',
+    '  ts-node ... --network localhost --yes --compose',
+  ].join('\n');
 }
 
 async function promptYesNo(
@@ -595,6 +622,10 @@ async function ensureEnvFile(envPath: string): Promise<void> {
 
 async function main() {
   const args = parseArgs();
+  if (args.help) {
+    printUsage();
+    return;
+  }
   const autoYes = Boolean(
     parseBool(args.yes) ?? parseBool(args['non-interactive'])
   );
@@ -955,7 +986,11 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error('Fatal error running Astral Omnidominion demo:', error);
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Fatal error running Astral Omnidominion demo:', error);
+    process.exitCode = 1;
+  });
+}
+
+export { buildUsage, parseArgs, printUsage };


### PR DESCRIPTION
## Summary
- add a proper help/usage path to the Astral Omnidominion demo CLI and gate execution when imported
- expand the argument parser with help aliases and usage text for non-interactive runs
- add Jest coverage for the parser and usage builder helpers

## Testing
- npx jest scripts/v2/__tests__/agiOsFirstClassDemo.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f5fe3e718833383f3bbd7d647a8ca)