### PR TITLE
Add input validation to Omega-grade demo CLI

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
@@ -13,6 +13,26 @@ from .governance import GovernanceParameters
 from .orchestrator import Orchestrator, OrchestratorConfig
 
 
+def _require_positive(value: float, *, field: str, allow_zero: bool = False) -> None:
+    """Validate that numeric CLI arguments remain within safe bounds.
+
+    Args:
+        value: The numeric value to validate.
+        field: Human-readable field label for error messages.
+        allow_zero: Whether zero is considered a valid value.
+
+    Raises:
+        ValueError: If the value is outside the allowed range.
+    """
+
+    if allow_zero:
+        if value < 0:
+            raise ValueError(f"{field} must be non-negative (got {value})")
+    else:
+        if value <= 0:
+            raise ValueError(f"{field} must be positive (got {value})")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run the Kardashev-II Omega-Grade α-AGI Business 3 demo")
     parser.add_argument(
@@ -120,6 +140,18 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
                 gov_data["validator_reveal_window"] = timedelta(seconds=float(gov_data["validator_reveal_window"]))
             data["governance"] = GovernanceParameters(**gov_data)
         overrides.update(data)
+
+    _require_positive(args.cycles, field="cycles", allow_zero=True)
+    _require_positive(args.insight_interval, field="insight_interval_seconds")
+    _require_positive(args.simulation_tick, field="simulation_tick_seconds")
+    _require_positive(args.simulation_hours, field="simulation_hours_per_tick")
+    _require_positive(args.simulation_energy_scale, field="simulation_energy_scale")
+    _require_positive(args.simulation_compute_scale, field="simulation_compute_scale")
+    _require_positive(args.heartbeat_interval, field="heartbeat_interval_seconds")
+    _require_positive(args.heartbeat_timeout, field="heartbeat_timeout_seconds")
+    _require_positive(args.health_check_interval, field="health_check_interval_seconds")
+    _require_positive(args.integrity_interval, field="integrity_check_interval_seconds")
+    _require_positive(args.energy_oracle_interval, field="energy_oracle_interval_seconds")
 
     params = {
         "max_cycles": args.cycles or None,

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cli_defaults.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cli_defaults.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.cli import build_config, parse_args
 
 
@@ -15,3 +17,17 @@ def test_zero_cycles_runs_indefinitely():
     config = build_config(args)
 
     assert config.max_cycles is None
+
+
+@pytest.mark.parametrize(
+    "flag,value,message",
+    [
+        ("--cycles", "-1", "non-negative"),
+        ("--heartbeat-interval", "0", "positive"),
+    ],
+)
+def test_invalid_numeric_inputs_raise(flag: str, value: str, message: str) -> None:
+    args = parse_args([flag, value])
+
+    with pytest.raises(ValueError, match=message):
+        build_config(args)


### PR DESCRIPTION
## Summary
- add positive/non-negative validation for Kardashev-II Omega-grade demo CLI inputs to keep runs safe
- extend CLI default tests to cover invalid numeric arguments

## Testing
- python demo/run_demo_tests.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69401496b1c88333894f958464b5e1f2)