### PR TITLE
Add dry-run support for governance alpha v17 demo

### DIFF
--- a/demo/agi-governance/alpha-v17/scripts/__tests__/runMission.test.ts
+++ b/demo/agi-governance/alpha-v17/scripts/__tests__/runMission.test.ts
@@ -1,0 +1,41 @@
+import { jest } from "@jest/globals";
+import { mkdtemp, readdir, stat } from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { generateGovernanceDemo } from "../../../scripts/executeDemo";
+
+const missionFile = path.resolve(__dirname, "../../config/mission@v17.json");
+
+jest.setTimeout(180_000);
+
+describe("alpha-v17 runMission", () => {
+  it("honors --dry-run by avoiding disk writes", async () => {
+    const tempDir = await fsSafeTempDir();
+
+    await generateGovernanceDemo({
+      missionFile,
+      reportDir: tempDir,
+      reportFile: path.join(tempDir, "dry-run-report.md"),
+      summaryFile: path.join(tempDir, "dry-run-summary.json"),
+      dashboardFile: path.join(tempDir, "dry-run-dashboard.html"),
+      ownerMatrixJsonFile: path.join(tempDir, "dry-run-owner.json"),
+      ownerMatrixMarkdownFile: path.join(tempDir, "dry-run-owner.md"),
+      dryRun: true,
+    });
+
+    const contents = await readdir(tempDir);
+    expect(contents).toHaveLength(0);
+  });
+});
+
+async function fsSafeTempDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "agi-governance-dry-run-"));
+  const stats = await stat(dir);
+
+  if (!stats.isDirectory()) {
+    throw new Error(`Expected temp path to be a directory: ${dir}`);
+  }
+
+  return dir;
+}

--- a/demo/agi-governance/alpha-v17/scripts/runMission.ts
+++ b/demo/agi-governance/alpha-v17/scripts/runMission.ts
@@ -9,17 +9,21 @@ const SUMMARY_FILE = path.join(REPORT_DIR, "governance-demo-summary-v17.json");
 const DASHBOARD_FILE = path.join(REPORT_DIR, "governance-demo-dashboard-v17.html");
 
 async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run") || process.argv.includes("--dryRun") || process.argv.includes("--dryrun");
+
   const options: GovernanceDemoOptions = {
     missionFile: MISSION_FILE,
     reportDir: REPORT_DIR,
     reportFile: REPORT_FILE,
     summaryFile: SUMMARY_FILE,
     dashboardFile: DASHBOARD_FILE,
+    dryRun,
   };
 
   await generateGovernanceDemo(options);
 
-  console.log("✅ α-field v17 Singularity Dominion dossier generated.");
+  const prefix = dryRun ? "(dry run)" : "";
+  console.log(`✅ ${prefix} α-field v17 Singularity Dominion dossier generated.`.trim());
   console.log(`   Mission: ${MISSION_FILE}`);
   console.log(`   Report: ${REPORT_FILE}`);
   console.log(`   Summary: ${SUMMARY_FILE}`);

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,8 @@ module.exports = {
     "^.+\\.(ts|tsx)$": ["ts-jest", { tsconfig: "tsconfig.json", diagnostics: false }],
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  modulePathIgnorePatterns: [
+    "<rootDir>/services/culture-graph-indexer/package.json",
+    "<rootDir>/demo/CULTURE-v0/indexers/culture-graph-indexer/package.json",
+  ],
 };


### PR DESCRIPTION
## Summary
- add dry-run support to the alpha-v17 governance dossier generator and CLI wrapper
- log dry-run destinations without writing artifacts and improve Jest config to avoid package name collisions
- add regression coverage ensuring dry-run runs leave no filesystem side effects

## Testing
- npx jest --runInBand --runTestsByPath demo/agi-governance/alpha-v17/scripts/__tests__/runMission.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69401b8a6f588333887b1ba7a2ee5a26)