### PR TITLE
Fix ultra demo wrapper entrypoint and add tests

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/__init__.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/__init__.py
@@ -28,6 +28,15 @@ _module = importlib.util.module_from_spec(_spec)
 sys.modules[__name__] = _module
 _spec.loader.exec_module(_module)
 
+# Ensure helper modules that live alongside this wrapper stay importable. Without
+# this, Python would only search the Unicode-heavy source directory for
+# submodules, preventing convenience entrypoints from being discovered.
+if hasattr(_module, "__path__"):
+    package_path = str(_THIS_DIR)
+    if package_path not in _module.__path__:
+        _module.__path__.append(package_path)
+
 from .cli import main  # type: ignore[attr-defined]  # noqa: E402
+from . import run_demo  # noqa: E402,F401  (re-exported for convenience)
 
 __all__ = getattr(_module, "__all__", [])

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/__main__.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/__main__.py
@@ -1,4 +1,20 @@
-from .cli import main
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+if __package__ in {None, ""}:  # Allow execution as a standalone script
+    this_dir = Path(__file__).resolve().parent
+    for path in (this_dir.parent, this_dir.parent.parent):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
+
+run_demo = importlib.import_module(
+    "demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra.run_demo"
+)
 
 if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
-    main()
+    run_demo.run()

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/run_demo.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/run_demo.py
@@ -1,0 +1,62 @@
+"""Executable entrypoint for the ultra-grade business demo wrapper.
+
+This mirrors the ASCII-safe shim used by other Omega-grade demos. It ensures
+operators can launch the canonical CLI that lives under
+``demo/Kardashev-II Omega-Grade-α-AGI Business-3`` even when invoking the
+wrapper file directly (for example
+``python demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/run_demo.py``).
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+PACKAGE_NAME = "demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra"
+THIS_DIR = Path(__file__).resolve().parent
+DEMO_ROOT = THIS_DIR.parent
+REPO_ROOT = DEMO_ROOT.parent
+
+
+def _resolve_main():
+    package_name = __package__ or PACKAGE_NAME
+    package = importlib.import_module(package_name)
+
+    if hasattr(package, "main"):
+        return package.main
+
+    cli = importlib.import_module(f"{package_name}.cli")
+    if hasattr(cli, "main"):
+        return cli.main
+
+    raise AttributeError(f"{package_name} does not expose a 'main' callable")
+
+
+def run(argv: Optional[Iterable[str]] = None, *, main_fn=None) -> None:
+    """Execute the canonical demo CLI with optional arguments.
+
+    Args:
+        argv: Optional iterable of CLI arguments to forward. If omitted, the
+            current process arguments (excluding the interpreter and script
+            name) are forwarded unchanged.
+        main_fn: Optional override for the CLI entrypoint, enabling tests or
+            higher-level orchestrators to inject a shim without mutating the
+            underlying package state.
+    """
+
+    if argv is None:
+        argv = sys.argv[1:]
+
+    for path in (REPO_ROOT, DEMO_ROOT):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
+
+    launcher = main_fn or _resolve_main()
+    launcher(list(argv))
+
+
+if __name__ == "__main__":
+    run()

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/tests/test_run_demo_entrypoint.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/tests/test_run_demo_entrypoint.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra import run_demo
+
+
+def test_run_forwards_arguments(monkeypatch):
+    captured = {}
+
+    def fake_main(argv):
+        captured["argv"] = argv
+
+    run_demo.run(["launch", "--cycles", "2"], main_fn=fake_main)
+    assert captured["argv"] == ["launch", "--cycles", "2"]
+
+
+def test_main_module_executes_as_script(tmp_path):
+    script = Path(__file__).resolve().parent.parent / "__main__.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert "Kardashev-II Omega-Grade Ultra Mission orchestrator" in result.stdout


### PR DESCRIPTION
## Summary
- add a robust run_demo entrypoint for the ultra demo wrapper
- ensure running __main__.py works when invoked as a script
- cover wrapper behavior with new smoke tests

## Testing
- python demo/run_demo_tests.py --demo ultra

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69402239c70c8333b393ac59dee09e3c)