### PR TITLE
Add Python entrypoint for Astral Omnidominion demo

### DIFF
--- a/demo/astral-omnidominion-operating-system/README.md
+++ b/demo/astral-omnidominion-operating-system/README.md
@@ -26,6 +26,7 @@ flowchart LR
 2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/astral-omnidominion-operating-system`.
 3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
 4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
+5. Run the demo locally with `python demo/astral-omnidominion-operating-system/run_demo.py --help` to mirror the TypeScript workflow via the Python-friendly entrypoint.
 
 ## Directory Guide
 ### Key Directories

--- a/demo/astral-omnidominion-operating-system/run_demo.py
+++ b/demo/astral-omnidominion-operating-system/run_demo.py
@@ -1,0 +1,57 @@
+"""Entry point for the Astral Omnidominion Operating System demo.
+
+This wrapper keeps the execution experience consistent with other demos by
+invoking the underlying TypeScript implementation via ``npm run``. It is
+intentionally lightweight: the Python layer only assembles the command,
+ensures we execute from the repository root, and forwards any user-supplied
+arguments verbatim.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Protocol
+
+
+class _Runner(Protocol):
+    def __call__(self, cmd: list[str], *, check: bool, cwd: str | os.PathLike[str]) -> subprocess.CompletedProcess:
+        ...
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def build_command(args: Iterable[str]) -> list[str]:
+    """Construct the npm command that drives the demo."""
+
+    return ["npm", "run", "demo:agi-os:first-class", "--", *args]
+
+
+def run(argv: Iterable[str] | None = None, *, runner: _Runner | None = None) -> int:
+    """Execute the Astral Omnidominion demo through npm.
+
+    Args:
+        argv: Optional iterable of CLI arguments to forward to the demo.
+        runner: Optional callable used to execute the command. Defaults to
+            :func:`subprocess.run` and primarily exists to keep tests fast and
+            deterministic.
+
+    Returns:
+        The exit code from the underlying npm script.
+    """
+
+    args = list(argv) if argv is not None else sys.argv[1:]
+    cmd = build_command(args)
+    runner = runner or subprocess.run
+    result = runner(cmd, check=False, cwd=str(REPO_ROOT))
+    return result.returncode
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/astral-omnidominion-operating-system/tests/test_run_demo.py
+++ b/demo/astral-omnidominion-operating-system/tests/test_run_demo.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import demo.astral_omnidominion_operating_system.run_demo as run_demo
+
+
+def test_build_command_forwards_args() -> None:
+    cmd = run_demo.build_command(["--network", "localhost", "--yes"])
+
+    assert cmd[:3] == ["npm", "run", "demo:agi-os:first-class"]
+    assert cmd[3:] == ["--", "--network", "localhost", "--yes"]
+
+
+def test_run_invokes_runner(monkeypatch) -> None:
+    calls: list[tuple[list[str], str]] = []
+
+    class DummyResult:
+        def __init__(self, returncode: int) -> None:
+            self.returncode = returncode
+
+    def fake_runner(cmd, *, check, cwd):
+        calls.append((cmd, cwd))
+        return DummyResult(0)
+
+    exit_code = run_demo.run(["--help"], runner=fake_runner)
+
+    assert exit_code == 0
+    assert calls[0][0][:4] == ["npm", "run", "demo:agi-os:first-class", "--"]
+    assert Path(calls[0][1]) == run_demo.REPO_ROOT
+
+
+def test_run_propagates_exit_code(monkeypatch) -> None:
+    def failing_runner(cmd, *, check, cwd):  # noqa: ARG001
+        class DummyResult:
+            returncode = 7
+
+        return DummyResult()
+
+    assert run_demo.run([], runner=failing_runner) == 7

--- a/demo/astral_omnidominion_operating_system/__init__.py
+++ b/demo/astral_omnidominion_operating_system/__init__.py
@@ -1,0 +1,24 @@
+"""Python import shim for the Astral Omnidominion demo utilities."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_run_demo_module():
+    module_path = Path(__file__).resolve().parent.parent / "astral-omnidominion-operating-system" / "run_demo.py"
+    spec = importlib.util.spec_from_file_location("astral_omnidominion.run_demo", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError(f"Unable to load run_demo from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    sys.modules[f"{__name__}.run_demo"] = module
+    return module
+
+
+run_demo = _load_run_demo_module()
+
+__all__ = ["run_demo"]


### PR DESCRIPTION
## Summary
- add a Python run_demo wrapper that shells out to the Astral Omnidominion npm demo
- expose an import shim so the hyphenated demo directory can be imported in tests
- document the new entrypoint and cover it with focused unit tests

## Testing
- python demo/run_demo_tests.py --demo astral-omnidominion-operating-system
- python demo/astral-omnidominion-operating-system/run_demo.py --help


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694042c6925483339e5fdfb69786acba)