### PR TITLE
Add finite default runtime for Omega demo CLI

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/README.md
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/README.md
@@ -26,6 +26,7 @@ flowchart LR
 2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega`.
 3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
 4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../../OperatorRunbook.md).
+5. When running the demo interactively, the CLI now defaults to a 10-second showcase window; pass `--duration 0` for open-ended, Kardashev-scale simulations.
 
 ## Directory Guide
 ### Key Directories

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_omega_cli_duration.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_omega_cli_duration.py
@@ -1,0 +1,23 @@
+"""Runtime guardrails for the Omega demo CLI."""
+
+from kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega.cli import (
+    _resolve_duration,
+)
+
+
+def test_default_duration_is_finite():
+    """Default runs should finish on their own to avoid hanging demo sessions."""
+
+    assert _resolve_duration(None) == 10.0
+
+
+def test_zero_duration_runs_indefinitely():
+    """Operators can still opt into an open-ended run by passing zero."""
+
+    assert _resolve_duration(0) is None
+
+
+def test_positive_duration_passthrough():
+    """Explicit durations are preserved for deterministic scheduling."""
+
+    assert _resolve_duration(42) == 42.0


### PR DESCRIPTION
## Summary
- default the Omega demo CLI to a 10-second showcase window with an opt-in indefinite mode
- add duration-resolution helper tests to guard against regressions
- document the runtime expectation in the demo README

## Testing
- python demo/run_demo_tests.py --fail-fast --demo omega


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694053dc02708333a5218ce8f1272450)