### PR TITLE
Ensure deterministic seeding for TRM simulation

### DIFF
--- a/demo/Tiny-Recursive-Model-v0/trm_demo/simulation.py
+++ b/demo/Tiny-Recursive-Model-v0/trm_demo/simulation.py
@@ -98,6 +98,10 @@ def run_simulation(
     seed: int = 0,
 ) -> SimulationSummary:
     rng = random.Random(seed)
+    # Ensure deterministic behavior across numpy, torch, and Python's RNG so
+    # the sentinel consistently reflects guardrail breaches during testing.
+    np.random.seed(seed)
+    torch.manual_seed(seed)
     greedy = GreedyBaseline()
     llm = LLMBaseline(rng=rng)
 


### PR DESCRIPTION
## Summary
- seed the Tiny Recursive Model simulation across Python, NumPy, and PyTorch to stabilize guardrail evaluations
- keep sentinel behavior deterministic so safety checks reliably trigger in short trial runs

## Testing
- pytest tests -q
- python demo/run_demo_tests.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694087b20ac083338aa75208deb97456)