### PR TITLE
Skip runtime sandbox creation when listing demo suites

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -225,6 +225,15 @@ def main(argv: list[str] | None = None, demo_root: Path | None = None) -> int:
     demo_root = demo_root or Path(__file__).resolve().parent
     suites = list(_discover_tests(demo_root, include=include))
 
+    if args.list:
+        if not suites:
+            print("No demo test suites found for the provided filters.")
+            return 1
+        print("Discovered demo test suites:")
+        for _, tests_dir in suites:
+            print(f" - {tests_dir}")
+        return 0
+
     runtime_context: contextlib.AbstractContextManager[str]
     if args.runtime_dir:
         runtime_dir = args.runtime_dir.expanduser().resolve()
@@ -235,15 +244,6 @@ def main(argv: list[str] | None = None, demo_root: Path | None = None) -> int:
 
     with runtime_context as runtime_dir:
         runtime_root = Path(runtime_dir)
-
-        if args.list:
-            if not suites:
-                print("No demo test suites found for the provided filters.")
-                return 1
-            print("Discovered demo test suites:")
-            for _, tests_dir in suites:
-                print(f" - {tests_dir}")
-            return 0
 
         if not suites:
             print("No demo test suites found for the provided filters.")

--- a/demo/tests/test_run_demo_tests_runner.py
+++ b/demo/tests/test_run_demo_tests_runner.py
@@ -54,3 +54,19 @@ def test_main_clears_existing_runtime_dir(tmp_path: Path) -> None:
 
     assert exit_code == 0
     assert not stale_artifact.exists()
+
+
+def test_list_mode_does_not_create_runtime_artifacts(tmp_path: Path) -> None:
+    demo_root = tmp_path / "demo"
+    tests_dir = demo_root / "example" / "tests"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test_ok.py").write_text("def test_ok():\n    assert True\n")
+
+    runtime_dir = tmp_path / "runtime"
+
+    exit_code = run_demo_tests.main(
+        ["--list", "--runtime-dir", str(runtime_dir)], demo_root=demo_root
+    )
+
+    assert exit_code == 0
+    assert not runtime_dir.exists()


### PR DESCRIPTION
## Summary
- avoid constructing temporary runtime directories when demo runner is invoked with `--list`
- keep listing output unchanged while preventing side effects when a custom runtime directory is provided
- add regression test to ensure listing mode does not create sandbox artifacts

## Testing
- python -m pytest demo/tests/test_run_demo_tests_runner.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69408e0a3ed4833392bc3e4c7ea5a22e)