### PR TITLE
Make astral OS demo default to non-interactive automation

### DIFF
--- a/demo/astral-omnidominion-operating-system/tests/test_run_demo.py
+++ b/demo/astral-omnidominion-operating-system/tests/test_run_demo.py
@@ -36,3 +36,30 @@ def test_run_propagates_exit_code(monkeypatch) -> None:
         return DummyResult()
 
     assert run_demo.run([], runner=failing_runner) == 7
+
+
+def test_run_autofills_non_interactive_defaults(monkeypatch) -> None:
+    recorded: list[list[str]] = []
+
+    def fake_runner(cmd, *, check, cwd):  # noqa: ARG001
+        recorded.append(cmd)
+
+        class DummyResult:
+            returncode = 0
+
+        return DummyResult()
+
+    def always_false():
+        return False
+
+    run_demo.run([], runner=fake_runner, is_interactive=always_false)
+
+    assert recorded[0][:3] == ["npm", "run", "demo:agi-os:first-class"]
+    assert recorded[0][3:] == [
+        "--",
+        "--network",
+        "localhost",
+        "--yes",
+        "--no-compose",
+        "--skip-deploy",
+    ]


### PR DESCRIPTION
## Summary
- default the Astral Omnidominion demo runner to automated localhost settings when stdin is not interactive
- allow tests to inject interactivity checks and verify fallback arguments
- add coverage ensuring the wrapper stays non-blocking in headless runs

## Testing
- python demo/run_demo_tests.py --demo astral-omnidominion-operating-system --fail-fast

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940d8e947148333be4edb83da8ec075)