### PR TITLE
Add compatibility wrapper for Astral Omnidominion demo

### DIFF
--- a/demo/astral_omnidominion_operating_system/run_demo.py
+++ b/demo/astral_omnidominion_operating_system/run_demo.py
@@ -1,0 +1,59 @@
+"""Compatibility launcher for the Astral Omnidominion Operating System demo.
+
+This shim preserves the underscore-style package name while delegating to the
+canonical hyphenated demo located at
+``demo/astral-omnidominion-operating-system/run_demo.py``. By reusing the
+primary entrypoint, we avoid diverging behaviours and keep a single source of
+truth for command construction and ergonomics.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Iterable, Protocol
+
+PRIMARY_DEMO_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "astral-omnidominion-operating-system"
+    / "run_demo.py"
+)
+
+
+class _Runner(Protocol):
+    def __call__(self, cmd: list[str], *, check: bool, cwd: str | Path):
+        ...
+
+
+class _InteractiveProbe(Protocol):
+    def __call__(self) -> bool: ...
+
+
+def _load_primary_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "astral_omnidominion_operating_system_primary", PRIMARY_DEMO_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load primary demo from {PRIMARY_DEMO_PATH}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run(
+    argv: Iterable[str] | None = None,
+    *,
+    runner: _Runner | None = None,
+    is_interactive: _InteractiveProbe | None = None,
+) -> int:
+    primary = _load_primary_module()
+    return primary.run(argv=argv, runner=runner, is_interactive=is_interactive)
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/astral_omnidominion_operating_system/tests/test_run_demo.py
+++ b/demo/astral_omnidominion_operating_system/tests/test_run_demo.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+PACKAGE_PARENT = Path(__file__).resolve().parents[2]
+if str(PACKAGE_PARENT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_PARENT))
+
+import astral_omnidominion_operating_system.run_demo as compatibility
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, cmd, *, check, cwd):
+        self.calls.append((cmd, check, cwd))
+        return SimpleNamespace(returncode=42)
+
+
+def test_run_delegates_to_primary_entrypoint(tmp_path):
+    runner = _Recorder()
+    exit_code = compatibility.run(["--mission", "alpha"], runner=runner, is_interactive=lambda: True)
+
+    assert exit_code == 42
+    assert runner.calls, "run() should invoke the provided runner"
+    cmd, check, cwd = runner.calls[0]
+    assert cmd[:3] == ["npm", "run", "demo:agi-os:first-class"]
+    assert cmd[-2:] == ["--mission", "alpha"]
+    assert check is False
+    # The primary wrapper pins the working directory to the repository root.
+    assert Path(cwd).resolve() == Path(__file__).resolve().parents[3]
+
+
+def test_run_honors_non_interactive_defaults():
+    runner = _Recorder()
+    exit_code = compatibility.run([], runner=runner, is_interactive=lambda: False)
+
+    assert exit_code == 42
+    cmd, *_ = runner.calls[0]
+    assert cmd[-5:] == ["--network", "localhost", "--yes", "--no-compose", "--skip-deploy"]


### PR DESCRIPTION
## Summary
- add a compatibility launcher so the underscore demo delegates to the canonical Astral Omnidominion entrypoint
- cover the wrapper with tests for both interactive and non-interactive invocation paths

## Testing
- python demo/run_demo_tests.py --demo astral_omnidominion_operating_system --fail-fast

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940e4661db88333946a27387569221d)