### PR TITLE
Add runnable command theatre demo report

### DIFF
--- a/demo/astral-omnidominion-operating-system-command-theatre/README.md
+++ b/demo/astral-omnidominion-operating-system-command-theatre/README.md
@@ -7,6 +7,10 @@
 - **Module Focus:** Anchors Demo → Astral Omnidominion Operating System Command Theatre inside the AGI Jobs v0 (v2) lattice so teams can orchestrate economic, governance, and operational missions with deterministic guardrails.
 - **Integration Role:** Interfaces with the unified owner control plane, telemetry mesh, and contract registry to deliver end-to-end resilience.
 
+### Quick start
+- `python demo/astral-omnidominion-operating-system-command-theatre/run_demo.py` produces a non-interactive JSON readiness report under `reports/astral-omnidominion-operating-system-command-theatre/`.
+- The runner is sandboxed and does not require Docker or blockchain endpoints, making it suitable for CI smoke checks.
+
 ## Capabilities
 - Provides opinionated configuration and assets tailored to `demo/astral-omnidominion-operating-system-command-theatre` while remaining interoperable with the global AGI Jobs v0 (v2) runtime.
 - Ships with safety-first defaults so non-technical operators can activate the experience without compromising security or compliance.

--- a/demo/astral-omnidominion-operating-system-command-theatre/run_demo.py
+++ b/demo/astral-omnidominion-operating-system-command-theatre/run_demo.py
@@ -1,0 +1,162 @@
+"""Run the Astral Omnidominion Operating System Command Theatre demo.
+
+This lightweight runner keeps the experience hermetic and non-interactive so
+it can be executed in CI or local sandboxes without hidden dependencies. The
+script surfaces a concise mission-readiness report that references the
+available playbooks and governance guides while computing deterministic
+resilience metrics inspired by coordination theory.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+# The core documents that anchor this demo. If additional guidance is added in
+# the future, extend this tuple to keep the report aligned with the catalogue.
+DOC_FILES: tuple[str, ...] = (
+    "README.md",
+    "ci-green-operations.md",
+    "launch-playbook.md",
+    "mission-review-checklist.md",
+    "owner-control-field-guide.md",
+)
+
+
+@dataclass(frozen=True)
+class MissionDocument:
+    """Metadata extracted from a demo document."""
+
+    name: str
+    path: Path
+    line_count: int
+    title: str
+
+
+@dataclass(frozen=True)
+class DemoReport:
+    """Structured payload persisted by the runner."""
+
+    generated_at: str
+    documents: list[MissionDocument]
+    coverage: float
+    scores: dict[str, float]
+
+
+def _read_document(base_dir: Path, filename: str) -> MissionDocument | None:
+    path = base_dir / filename
+    if not path.exists():
+        return None
+
+    content = path.read_text(encoding="utf-8").splitlines()
+    title = next((line.strip("# ") for line in content if line.strip()), "Untitled")
+    return MissionDocument(
+        name=filename,
+        path=path.resolve(),
+        line_count=len(content),
+        title=title,
+    )
+
+
+def _load_documents(base_dir: Path) -> list[MissionDocument]:
+    docs: list[MissionDocument] = []
+    for filename in DOC_FILES:
+        doc = _read_document(base_dir, filename)
+        if doc:
+            docs.append(doc)
+    return docs
+
+
+def _bounded_score(value: float, *, floor: float = 0.0, ceiling: float = 1.0) -> float:
+    return max(floor, min(ceiling, value))
+
+
+def _compute_scores(documents: Iterable[MissionDocument]) -> dict[str, float]:
+    docs = list(documents)
+    if not docs:
+        # With no documents available, the system has no signal; return neutral
+        # scores so downstream tooling can detect the gap without crashing.
+        return {
+            "coordination_hamiltonian": 0.0,
+            "gibbs_free_energy_surplus": 0.0,
+            "game_theory_payoff": 0.0,
+        }
+
+    avg_lines = sum(doc.line_count for doc in docs) / len(docs)
+    coordination = 1 - math.exp(-avg_lines / 100)
+    gibbs_surplus = math.log1p(len(docs)) / math.log(10)
+    payoff = 0.5 + 0.5 * (len([d for d in docs if d.line_count > 0]) / len(DOC_FILES))
+
+    return {
+        "coordination_hamiltonian": _bounded_score(coordination),
+        "gibbs_free_energy_surplus": _bounded_score(gibbs_surplus),
+        "game_theory_payoff": _bounded_score(payoff),
+    }
+
+
+def build_report(base_dir: Path) -> DemoReport:
+    documents = _load_documents(base_dir)
+    coverage = len(documents) / len(DOC_FILES)
+    scores = _compute_scores(documents)
+    generated_at = datetime.now(timezone.utc).isoformat()
+    return DemoReport(
+        generated_at=generated_at,
+        documents=documents,
+        coverage=coverage,
+        scores=scores,
+    )
+
+
+def _serialise_report(report: DemoReport) -> dict:
+    return {
+        "generated_at": report.generated_at,
+        "coverage": report.coverage,
+        "scores": report.scores,
+        "documents": [
+            {
+                "name": doc.name,
+                "path": str(doc.path),
+                "line_count": doc.line_count,
+                "title": doc.title,
+            }
+            for doc in report.documents
+        ],
+    }
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("reports/astral-omnidominion-operating-system-command-theatre/report.json"),
+        help="Destination for the JSON report.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None, base_dir: Path | None = None) -> int:
+    args = _parse_args(argv)
+    base_dir = base_dir or Path(__file__).resolve().parent
+
+    report = build_report(base_dir)
+    output_path: Path = args.output.expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(_serialise_report(report), indent=2), encoding="utf-8")
+
+    print("🌠 Astral Omnidominion Operating System Command Theatre")
+    print(f"   • Documents inspected : {len(report.documents)} of {len(DOC_FILES)}")
+    print(f"   • Coordination metric : {report.scores['coordination_hamiltonian']:.3f}")
+    print(f"   • Gibbs surplus       : {report.scores['gibbs_free_energy_surplus']:.3f}")
+    print(f"   • Game theory payoff  : {report.scores['game_theory_payoff']:.3f}")
+    print(f"   • Report              : {output_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demo/astral-omnidominion-operating-system-command-theatre/tests/test_run_demo.py
+++ b/demo/astral-omnidominion-operating-system-command-theatre/tests/test_run_demo.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import run_demo
+
+
+def test_build_report_contains_documents():
+    base_dir = Path(__file__).resolve().parents[1]
+    report = run_demo.build_report(base_dir)
+
+    assert report.documents, "expected demo documents to be discovered"
+    assert 0 < report.coverage <= 1
+    assert set(run_demo.DOC_FILES).issuperset({doc.name for doc in report.documents})
+
+    scores = report.scores
+    for key in ("coordination_hamiltonian", "gibbs_free_energy_surplus", "game_theory_payoff"):
+        assert key in scores
+        assert 0 <= scores[key] <= 1
+
+
+def test_main_writes_report(tmp_path: Path, monkeypatch):
+    output = tmp_path / "report.json"
+    exit_code = run_demo.main(["--output", str(output)])
+    assert exit_code == 0
+    assert output.exists()
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["documents"], "report should enumerate scanned documents"
+    assert payload["scores"]["coordination_hamiltonian"] >= 0


### PR DESCRIPTION
## Summary
- add a non-interactive run_demo.py for the Astral Omnidominion Operating System Command Theatre demo that builds a readiness report
- cover the new runner with tests that validate document discovery and scoring outputs
- document the quickstart command for generating the JSON report

## Testing
- python demo/run_demo_tests.py --demo astral-omnidominion-operating-system-command-theatre

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941765cf31c8333a3f6e3403e604a95)