### PR TITLE
Add module entrypoint for omega-grade demo CLI

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/__main__.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/__main__.py
@@ -1,0 +1,20 @@
+"""Module entrypoint for the Kardashev-II Omega-Grade α-AGI Business 3 demo.
+
+This keeps ``python -m demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo``
+compatible with the ASCII-safe wrapper by delegating to the same CLI launcher
+used by ``run_demo.py``. Keeping the invocation path uniform avoids surprises
+for operators who expect the ``-m`` idiom to work across demos.
+"""
+from __future__ import annotations
+
+from .run_demo import run
+
+
+def main() -> None:
+    """Invoke the demo's CLI and exit with an appropriate status code."""
+
+    run()
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via subprocess
+    main()

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_run_demo.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_run_demo.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib
+import os
 import runpy
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -45,3 +47,23 @@ def test_run_as_script_uses_package_main(monkeypatch):
 
     assert captured["argv"] == []
     assert str(repo_root) in sys.path
+
+def test_module_entrypoint_invokable():
+    repo_root = Path(__file__).resolve().parents[3]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        segment
+        for segment in [str(repo_root), env.get("PYTHONPATH", "")]
+        if segment
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo", "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Kardashev-II Omega-Grade" in result.stdout


### PR DESCRIPTION
## Summary
- add a __main__ module so `python -m demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo` invokes the demo CLI
- extend the demo tests to exercise the new module entrypoint via a subprocess help call

## Testing
- python demo/run_demo_tests.py --demo kardashev_ii_omega_grade_alpha_agi_business_3_demo --fail-fast


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694194d13be88333bed37086884f6a31)