### PR TITLE
Default ultra demo wrapper to CI run

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/run_demo.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/run_demo.py
@@ -34,6 +34,9 @@ def _resolve_main():
     raise AttributeError(f"{package_name} does not expose a 'main' callable")
 
 
+DEFAULT_COMMAND = "ci"
+
+
 def run(argv: Optional[Iterable[str]] = None, *, main_fn=None) -> None:
     """Execute the canonical demo CLI with optional arguments.
 
@@ -46,8 +49,13 @@ def run(argv: Optional[Iterable[str]] = None, *, main_fn=None) -> None:
             underlying package state.
     """
 
-    if argv is None:
-        argv = sys.argv[1:]
+    args = list(sys.argv[1:] if argv is None else argv)
+
+    # Provide a deterministic fast path when the operator hasn't supplied a
+    # subcommand. Defaulting to the CI-grade mission mirrors other demos and
+    # keeps ``python run_demo.py`` usable without memorizing the full CLI.
+    if not args:
+        args = [DEFAULT_COMMAND]
 
     for path in (REPO_ROOT, DEMO_ROOT):
         path_str = str(path)
@@ -55,7 +63,7 @@ def run(argv: Optional[Iterable[str]] = None, *, main_fn=None) -> None:
             sys.path.insert(0, path_str)
 
     launcher = main_fn or _resolve_main()
-    launcher(list(argv))
+    launcher(args)
 
 
 if __name__ == "__main__":

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/tests/test_run_demo_entrypoint.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra/tests/test_run_demo_entrypoint.py
@@ -17,6 +17,16 @@ def test_run_forwards_arguments(monkeypatch):
     assert captured["argv"] == ["launch", "--cycles", "2"]
 
 
+def test_run_defaults_to_ci(monkeypatch):
+    captured = {}
+
+    def fake_main(argv):
+        captured["argv"] = argv
+
+    run_demo.run([], main_fn=fake_main)
+    assert captured["argv"] == ["ci"]
+
+
 def test_main_module_executes_as_script(tmp_path):
     script = Path(__file__).resolve().parent.parent / "__main__.py"
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- default the ultra demo wrapper to the fast CI mission when no command is provided
- add regression coverage to assert the wrapper forwards the implicit CI command

## Testing
- python demo/run_demo_tests.py --demo kardashev_ii_omega_grade_alpha_agi_business_3_demo_ultra --fail-fast

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941e7c18a8083338e18bbf88df7d635)