### PR TITLE
Make demo filter matching path-aware

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -220,8 +220,14 @@ def _discover_tests(
     def _matches_filter(path: Path) -> bool:
         if include is None:
             return True
+
         name = path.name.lower()
-        return any(token in name for token in include)
+        relative = str(path.relative_to(demo_root)).lower()
+
+        return any(
+            token in name or token in relative or relative in token
+            for token in include
+        )
 
     # Iterate in a deterministic order so CI logs remain stable across runs.
     for demo_dir in sorted((p for p in demo_root.iterdir() if p.is_dir())):

--- a/demo/tests/test_run_demo_tests_runner.py
+++ b/demo/tests/test_run_demo_tests_runner.py
@@ -90,6 +90,30 @@ def test_top_level_tests_directory_is_discovered(tmp_path: Path) -> None:
     ]
 
 
+def test_include_filter_matches_relative_paths(tmp_path: Path) -> None:
+    demo_root = tmp_path / "demo"
+    alpha_tests = demo_root / "alpha" / "tests"
+    beta_tests = demo_root / "beta" / "nested" / "tests"
+    alpha_tests.mkdir(parents=True)
+    beta_tests.mkdir(parents=True)
+    (alpha_tests / "test_alpha.py").write_text("def test_alpha():\n    assert True\n")
+    (beta_tests / "test_beta.py").write_text("def test_beta():\n    assert True\n")
+
+    suites = list(
+        run_demo_tests._discover_tests(
+            demo_root, include={"beta/nested", "does-not-match"}
+        )
+    )
+
+    assert suites == [
+        run_demo_tests.Suite(
+            demo_root=demo_root / "beta",
+            tests_dir=beta_tests,
+            runner="python",
+        )
+    ]
+
+
 def test_top_level_tests_pythonpath_includes_demo_root(tmp_path: Path) -> None:
     demo_root = tmp_path / "demo"
     tests_dir = demo_root / "tests"


### PR DESCRIPTION
## Summary
- allow demo filters to match relative paths within demo/test directories for more intuitive selection
- add regression coverage to ensure filtered discovery respects nested path tokens

## Testing
- python -m pytest demo/tests/test_run_demo_tests_runner.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941ec44071c83339cc949862f0a0caa)