### PR TITLE
Fix resource ledger accounting for omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_resource_manager.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_resource_manager.py
@@ -1,0 +1,18 @@
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.resources import ResourceManager
+
+
+def test_ensure_account_mints_when_topping_up_existing_account():
+    resources = ResourceManager(energy_capacity=1.0, compute_capacity=1.0, base_token_supply=100.0)
+
+    account = resources.ensure_account("operator", 100.0)
+    assert account.tokens == 100.0
+    assert resources.token_supply == 100.0
+
+    resources.debit_tokens("operator", 60.0)
+    assert resources.get_account("operator").tokens == 40.0
+    assert resources.token_supply == 40.0
+
+    # Topping up should mint the delta and keep the ledger balanced.
+    resources.ensure_account("operator", 80.0)
+    assert resources.get_account("operator").tokens == 80.0
+    assert resources.token_supply == 80.0


### PR DESCRIPTION
## Summary
- update the omega-grade resource manager to mint token supply when topping up existing accounts so ledger integrity stays balanced
- add regression test ensuring account top-ups keep token supply aligned with balances

## Testing
- pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests" -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941f24c926483338fc62c1f6e7e1175)