### PR TITLE
Handle missing node runner in demo test harness

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -142,6 +142,14 @@ def _run_suite(
 
     try:
         result = subprocess.run(cmd, **run_kwargs)
+    except FileNotFoundError:
+        missing_binary = cmd[0]
+        print(
+            f"⛔️  Required executable '{missing_binary}' is not available on PATH "
+            f"while running {suite.tests_dir}. Install it or adjust PATH to "
+            "continue."
+        )
+        return 1
     except subprocess.TimeoutExpired:
         print(
             f"⏰  Timed out running {suite.tests_dir} after {timeout}s; "


### PR DESCRIPTION
## Summary
- add explicit error handling when required executables like npm are missing for demo suites
- document behavior with a regression test that simulates a missing node runner

## Testing
- python -m pytest demo/tests/test_run_demo_tests_runner.py -k missing_runner


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942171248548333a2779d264eb76fe8)