### PR TITLE
Fix astral command theatre demo test imports

### DIFF
--- a/demo/astral-omnidominion-operating-system-command-theatre/tests/conftest.py
+++ b/demo/astral-omnidominion-operating-system-command-theatre/tests/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the demo's root directory is importable when running tests directly
+# from the repository root (outside the curated demo runner). This mirrors the
+# PYTHONPATH adjustments that ``demo.run_demo_tests`` performs for isolated
+# suites so imports like ``import run_demo`` resolve consistently.
+DEMO_ROOT = Path(__file__).resolve().parents[1]
+if str(DEMO_ROOT) not in sys.path:
+    sys.path.insert(0, str(DEMO_ROOT))


### PR DESCRIPTION
## Summary
- add a conftest to ensure the astral omnidominion command theatre demo tests can import the local run_demo module when executed directly

## Testing
- python -m pytest demo/astral-omnidominion-operating-system-command-theatre/tests -q
- python demo/run_demo_tests.py --include astral-omnidominion-operating-system-command-theatre --fail-fast


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429142e24c8333abced75dc5992196)