### PR TITLE
Add hardhat test skip toggle for One-Box

### DIFF
--- a/demo/One-Box/README.md
+++ b/demo/One-Box/README.md
@@ -24,7 +24,9 @@ flowchart LR
 ## Working With This Module
 1. From the repository root run `npm install` once to hydrate all workspaces.
 2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/One-Box`.
-3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
+3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal. When
+   you only need a fast smoke pass and already trust the Solidity artifacts, set `SKIP_HARDHAT_TESTS=1 npm test` to bypass the
+   Hardhat suite without touching the other checks.
 4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../OperatorRunbook.md).
 
 ## Directory Guide

--- a/scripts/run-hardhat-tests.cjs
+++ b/scripts/run-hardhat-tests.cjs
@@ -133,6 +133,11 @@ if (reporterOption) {
   process.env.MOCHA_REPORTER_OPTIONS = reporterOption;
 }
 
+if (process.env.SKIP_HARDHAT_TESTS === '1' || process.env.HARDHAT_TESTS_ENABLED === '0') {
+  console.log('⏩ Skipping Hardhat test run because SKIP_HARDHAT_TESTS=1 was set.');
+  process.exit(0);
+}
+
 if (shouldSkipHardhat) {
   console.log('Skipping Hardhat test run because --listTests is a Jest-only flag.');
   process.exit(0);


### PR DESCRIPTION
## Summary
- add an opt-out flag so developers can bypass the Hardhat Solidity suite when running the shared test harness
- document the skip option in the One-Box demo README for quicker smoke runs

## Testing
- node --test demo/One-Box/test/launcher.test.cjs
- SKIP_HARDHAT_TESTS=1 node scripts/run-hardhat-tests.cjs --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942e1c7062c833398d0e05048f08c3c)