### PR TITLE
Harden Alpha Node demo imports and test harness

### DIFF
--- a/demo/AGI-Alpha-Node-v0/pytest.sh
+++ b/demo/AGI-Alpha-Node-v0/pytest.sh
@@ -9,7 +9,22 @@ set -euo pipefail
 # console-script wrapper sets sys.path[0] to the pyenv bin directory.
 
 REPO_ROOT="$(cd "$(dirname "$0")"/../.. && pwd)"
+DEMO_ROOT="${REPO_ROOT}/demo/AGI-Alpha-Node-v0"
+
 export PYTEST_DISABLE_PLUGIN_AUTOLOAD="${PYTEST_DISABLE_PLUGIN_AUTOLOAD:-1}"
-export PYTHONPATH="${PYTHONPATH:-${REPO_ROOT}}"
+
+DEMO_PATHS=(
+  "${DEMO_ROOT}"
+  "${DEMO_ROOT}/src"
+  "${DEMO_ROOT}/grand_demo"
+  "${DEMO_ROOT}/grand_demo/alpha_node"
+  "${DEMO_ROOT}/grandiose_alpha_demo/src"
+  "${REPO_ROOT}"
+  "${REPO_ROOT}/packages/hgm-core/src"
+)
+
+# Prepend demo paths so imports work even when pytest is executed from the
+# repository root via the console script wrapper.
+export PYTHONPATH="$(IFS=:; echo "${DEMO_PATHS[*]}")${PYTHONPATH:+:${PYTHONPATH}}"
 
 exec python -m pytest "$@"

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -17,6 +17,11 @@ ROOT = os.path.dirname(__file__)
 EXTRA_PATHS = [
     ROOT,
     os.path.join(ROOT, "packages", "hgm-core", "src"),
+    os.path.join(ROOT, "demo", "AGI-Alpha-Node-v0"),
+    os.path.join(ROOT, "demo", "AGI-Alpha-Node-v0", "src"),
+    os.path.join(ROOT, "demo", "AGI-Alpha-Node-v0", "grand_demo"),
+    os.path.join(ROOT, "demo", "AGI-Alpha-Node-v0", "grand_demo", "alpha_node"),
+    os.path.join(ROOT, "demo", "AGI-Alpha-Node-v0", "grandiose_alpha_demo", "src"),
 ]
 
 for _path in EXTRA_PATHS:


### PR DESCRIPTION
## Summary
- ensure the Alpha Node CLI loads its modules directly from local paths to avoid import failures when invoked via importlib
- expand shared sitecustomize and the demo pytest helper to prepend the demo’s package paths and disable unwanted plugins during test runs

## Testing
- demo/AGI-Alpha-Node-v0/pytest.sh demo/AGI-Alpha-Node-v0/tests -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942effbfc0083339862472ce36b0fa0)