### PR TITLE
Fix ASI takeoff demo hardhat invocation

### DIFF
--- a/scripts/v2/asiTakeoffDemo.ts
+++ b/scripts/v2/asiTakeoffDemo.ts
@@ -52,6 +52,7 @@ const SUMMARY_MD_PATH = path.join(REPORT_ROOT, 'summary.md');
 const SUMMARY_JSON_PATH = path.join(REPORT_ROOT, 'summary.json');
 const BUNDLE_ROOT = path.join(REPORT_ROOT, 'mission-bundle');
 const SKIP_FLAGSHIP_ONCHAIN = process.env.AGIJOBS_FLAGSHIP_SKIP_ONCHAIN === 'true';
+const HARDHAT_ENV = { HARDHAT_DISABLE_TELEMETRY: '1' };
 
 function prefixedWrite(prefix: string, data: Buffer): void {
   const text = data.toString();
@@ -290,6 +291,7 @@ async function main(): Promise<void> {
       key: 'compile',
       title: 'Compile protocol',
       command: ['npx', 'hardhat', 'compile'],
+      env: HARDHAT_ENV,
     },
     {
       key: 'dry-run',
@@ -318,6 +320,7 @@ async function main(): Promise<void> {
         'hardhat',
       ],
       env: {
+        ...HARDHAT_ENV,
         THERMODYNAMICS_REPORT_FORMAT: 'json',
         THERMODYNAMICS_REPORT_OUT: THERMODYNAMICS_PATH,
       },
@@ -356,6 +359,7 @@ async function main(): Promise<void> {
         '--network',
         'hardhat',
       ],
+      env: HARDHAT_ENV,
     },
   ];
 

--- a/scripts/v2/owner-dashboard.ts
+++ b/scripts/v2/owner-dashboard.ts
@@ -43,6 +43,8 @@ const ADDRESS_BOOK = path.join(
 );
 
 const ROLE_LABELS = ['Agent', 'Validator', 'Operator', 'Employer'] as const;
+const VALIDATION_MODULE_ARTIFACT =
+  'contracts/v2/ValidationModule.sol:ValidationModule';
 
 function parseBooleanEnv(value?: string | null): boolean | undefined {
   if (value === undefined || value === null) {
@@ -444,7 +446,7 @@ async function collectValidationModuleSummary(
   address: string
 ): Promise<ModuleSummary> {
   const validationModule = await ethers.getContractAt(
-    'ValidationModule',
+    VALIDATION_MODULE_ARTIFACT,
     address
   );
   const [ownerAddress, reputationEngine, committee] = await Promise.all([


### PR DESCRIPTION
## Summary
- add hardhat telemetry suppression to ASI takeoff orchestration steps so the demo can run non-interactively
- load the fully-qualified ValidationModule artifact in the owner dashboard to avoid HH701 ambiguity errors

## Testing
- demo/infinity-symphony/bin/infinity-symphony-local.sh --ci
- npx ts-node --compiler-options '{"module":"commonjs"}' scripts/v2/ownerMissionControl.ts --network hardhat --format markdown --out /tmp/mc.md --bundle /tmp/mc-bundle --bundle-name test-bundle --skip-surface


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69430b4f52148333b7b423abab375978)