### PR TITLE
Harden demo test discovery for node suites

### DIFF
--- a/tests/test_demo_run_isolation.py
+++ b/tests/test_demo_run_isolation.py
@@ -18,9 +18,9 @@ def test_suite_runtime_root_is_unique(tmp_path: Path) -> None:
 
     runtime_root = tmp_path / "runtime"
 
-    path_a = run_demo_tests._suite_runtime_root(runtime_root, demo_a, tests_dir_a)
-    path_b = run_demo_tests._suite_runtime_root(runtime_root, demo_b, tests_dir_b)
+    path_a = run_demo_tests._suite_runtime_root(runtime_root, demo_a, tests_dir_a, runner="python")
+    path_b = run_demo_tests._suite_runtime_root(runtime_root, demo_b, tests_dir_b, runner="python")
 
     assert path_a != path_b
-    assert path_a == runtime_root / "demo_a" / "grand_demo" / "tests"
-    assert path_b == runtime_root / "demo_b" / "grand_demo" / "tests"
+    assert path_a == runtime_root / "demo_a" / "grand_demo" / "tests" / "python"
+    assert path_b == runtime_root / "demo_b" / "grand_demo" / "tests" / "python"


### PR DESCRIPTION
## Summary
- allow the demo test runner to discover additional test directories while isolating runtime sandboxes per runner
- restrict node suites to npm-managed projects with generated Prisma clients and select vitest-friendly flags automatically
- expand runner unit coverage for shared python/node suites, vitest args, and adjusted sandbox paths

## Testing
- python -m pytest demo/tests/test_run_demo_tests_runner.py tests/test_demo_run_isolation.py
- python demo/run_demo_tests.py --fail-fast


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69432f30c4108333b8d2b9be88d31a68)