### PR TITLE
Add output directory override to day-one utility demo CLI

### DIFF
--- a/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
@@ -72,6 +72,17 @@ def test_owner_set_updates_fee():
     assert report["owner_controls"]["platform_fee_bps"] == 220
 
 
+def test_cli_output_dir_override(tmp_path: Path):
+    payload, fmt = run_cli(["simulate", "--output-dir", str(tmp_path)])
+
+    assert fmt == "json"
+    assert Path(payload["outputs"]["dashboard"]).parent == tmp_path
+
+    # Ensure key artefacts land in the requested directory for reproducible ops
+    assert (tmp_path / "report_e2e.json").exists()
+    assert (tmp_path / "owner_controls_snapshot.json").exists()
+
+
 def test_unknown_strategy_raises():
     orchestrator = _orchestrator()
     with pytest.raises(StrategyNotFoundError):


### PR DESCRIPTION
## Summary
- allow the AGI Jobs day-one utility demo to accept an --output-dir flag across commands and route artefacts into that location
- add test coverage to guarantee CLI runs honor the caller-provided output directory

## Testing
- python demo/run_demo_tests.py --demo AGIJobs-Day-One-Utility-Benchmark --fail-fast

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694342bfa20c833390773f547da2a535)