### PR TITLE
Enhance demo test runner for Node suites

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -275,9 +275,8 @@ def _requires_prisma_generation(package_meta: dict[str, object]) -> bool:
 
 def _has_prisma_client(package_root: Path) -> bool:
     node_modules = package_root / "node_modules"
-    legacy = node_modules / ".prisma" / "client"
-    modern = node_modules / "@prisma" / "client" / "runtime"
-    return legacy.exists() or modern.exists()
+    generated = node_modules / ".prisma" / "client"
+    return generated.exists()
 
 
 def _ensure_prisma_client(package_root: Path) -> bool:

--- a/demo/tests/test_run_demo_tests_runner.py
+++ b/demo/tests/test_run_demo_tests_runner.py
@@ -310,6 +310,19 @@ def test_prisma_client_generation_is_triggered(
     assert calls == [project_dir]
 
 
+def test_prisma_client_detection_requires_generated_artifacts(tmp_path: Path) -> None:
+    project_dir = tmp_path / "node-demo"
+    runtime = project_dir / "node_modules" / "@prisma" / "client" / "runtime"
+    runtime.mkdir(parents=True)
+
+    assert run_demo_tests._has_prisma_client(project_dir) is False
+
+    generated = project_dir / "node_modules" / ".prisma" / "client"
+    generated.mkdir(parents=True)
+
+    assert run_demo_tests._has_prisma_client(project_dir) is True
+
+
 def test_empty_suite_fails_without_allow_empty(tmp_path: Path) -> None:
     demo_root = tmp_path / "demo"
     tests_dir = demo_root / "example" / "tests"


### PR DESCRIPTION
## Summary
- expand the demo test runner to recognize npm, pnpm, and yarn suites while isolating pnpm workspace roots and handling Prisma setup automatically
- update Prisma client detection to work with modern installs and generate artifacts when needed before running tests
- broaden the runner test coverage to reflect new managers, workspace skipping, and Prisma generation hooks

## Testing
- python -m pytest demo/tests/test_run_demo_tests_runner.py
- python demo/run_demo_tests.py --demo culture

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69434e34022c8333a0dde63264a2d613)