### PR TITLE
Fix AGI Alpha Node demo test path resolution

### DIFF
--- a/demo/AGI-Alpha-Node-v0/run_alpha_node.py
+++ b/demo/AGI-Alpha-Node-v0/run_alpha_node.py
@@ -2,10 +2,20 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 import textwrap
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Callable, Iterable, Optional
+
+THIS_DIR = Path(__file__).resolve().parent
+DEMO_ROOT = THIS_DIR
+DEMO_PARENT = DEMO_ROOT.parent
+
+for path in (DEMO_ROOT, DEMO_PARENT):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
 
 from alpha_node.config import AlphaNodeConfig
 from alpha_node.node import AlphaNode


### PR DESCRIPTION
## Summary
- ensure the AGI Alpha Node CLI explicitly prepends its demo directories to sys.path so imports succeed when launched from any working directory
- update the demo test runner to build a focused PYTHONPATH and always target the suite when only flags are passed

## Testing
- python demo/AGI-Alpha-Node-v0/run_tests.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447269f30c833397828d7ba459e400)