### PR TITLE
Make Astral Omnidominion demo automation-friendly by default

### DIFF
--- a/demo/astral-omnidominion-operating-system/run_demo.py
+++ b/demo/astral-omnidominion-operating-system/run_demo.py
@@ -70,9 +70,11 @@ def _normalize_args(
     args = [arg for arg in args if arg != AUTO_FLAG]
 
     if not args:
-        if requested or not is_interactive():
-            return DEFAULT_ARGS, requested
-        return args, requested
+        # Default to the automation-friendly profile even in interactive
+        # shells so ``python run_demo.py`` never blocks on nested prompts.
+        # The caller can still override the behavior by explicitly passing
+        # interactive flags.
+        return DEFAULT_ARGS, requested or not is_interactive()
 
     if requested:
         args = _merge_defaults(args)

--- a/demo/astral-omnidominion-operating-system/tests/test_run_demo.py
+++ b/demo/astral-omnidominion-operating-system/tests/test_run_demo.py
@@ -38,6 +38,33 @@ def test_run_propagates_exit_code(monkeypatch) -> None:
     assert run_demo.run([], runner=failing_runner) == 7
 
 
+def test_run_defaults_to_auto_profile_even_when_interactive(monkeypatch) -> None:
+    recorded: list[list[str]] = []
+
+    def fake_runner(cmd, *, check, cwd):  # noqa: ARG001
+        recorded.append(cmd)
+
+        class DummyResult:
+            returncode = 0
+
+        return DummyResult()
+
+    def always_true():
+        return True
+
+    run_demo.run([], runner=fake_runner, is_interactive=always_true)
+
+    assert recorded[0][:3] == ["npm", "run", "demo:agi-os:first-class"]
+    assert recorded[0][3:] == [
+        "--",
+        "--network",
+        "localhost",
+        "--yes",
+        "--no-compose",
+        "--skip-deploy",
+    ]
+
+
 def test_run_autofills_non_interactive_defaults(monkeypatch) -> None:
     recorded: list[list[str]] = []
 


### PR DESCRIPTION
## Summary
- default the Astral Omnidominion demo wrapper to the automation profile even when invoked interactively, preventing unexpected prompts
- add non-interactive detection to the TypeScript driver so CI and non-TTY runs pick localhost without user input
- extend the run_demo tests to cover the new default behavior

## Testing
- python -m pytest demo/astral-omnidominion-operating-system/tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944901216d88333987d119f269d390f)