### PR TITLE
Use local solcjs for CULTURE hardhat tests

### DIFF
--- a/demo/CULTURE-v0/hardhat.config.ts
+++ b/demo/CULTURE-v0/hardhat.config.ts
@@ -1,11 +1,38 @@
 import '@nomicfoundation/hardhat-toolbox';
 import 'hardhat-contract-sizer';
 import 'solidity-coverage';
+import { TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD } from 'hardhat/builtin-tasks/task-names';
+import { subtask } from 'hardhat/config';
 import type { HardhatUserConfig } from 'hardhat/config';
+import type { SolcBuild } from 'hardhat/types';
+
+const SOLIDITY_VERSION = '0.8.25';
+const LOCAL_SOLC_JS_PATH = require.resolve('solc/soljson.js');
+
+subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD).setAction(
+  async ({ solcVersion }: { solcVersion: string }, _hre, runSuper) => {
+    if (solcVersion !== SOLIDITY_VERSION) {
+      return runSuper({ solcVersion });
+    }
+
+    const localSolc = require('solc');
+    const localVersion: string = typeof localSolc.version === 'function' ? localSolc.version() : SOLIDITY_VERSION;
+    const normalizedVersion = localVersion.startsWith(SOLIDITY_VERSION) ? localVersion : `solc-js-${SOLIDITY_VERSION}`;
+
+    const build: SolcBuild = {
+      version: SOLIDITY_VERSION,
+      longVersion: normalizedVersion,
+      compilerPath: LOCAL_SOLC_JS_PATH,
+      isSolcJs: true
+    };
+
+    return build;
+  }
+);
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: '0.8.25',
+    version: SOLIDITY_VERSION,
     settings: {
       optimizer: {
         enabled: true,

--- a/demo/CULTURE-v0/hardhat/package-lock.json
+++ b/demo/CULTURE-v0/hardhat/package-lock.json
@@ -12,6 +12,7 @@
         "ethers": "^6.15.0",
         "hardhat": "^2.26.1",
         "hardhat-contract-sizer": "^2.10.0",
+        "solc": "^0.8.25",
         "solidity-coverage": "^0.8.12",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"

--- a/demo/CULTURE-v0/hardhat/package.json
+++ b/demo/CULTURE-v0/hardhat/package.json
@@ -14,6 +14,7 @@
     "hardhat": "^2.26.1",
     "hardhat-contract-sizer": "^2.10.0",
     "solidity-coverage": "^0.8.12",
+    "solc": "^0.8.25",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"
   }


### PR DESCRIPTION
## Summary
- ensure the CULTURE Hardhat suite uses a locally bundled solc-js compiler instead of downloading it at runtime
- add the solc dependency to the suite so tests run without external compiler fetches

## Testing
- python demo/run_demo_tests.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69449fda1c4083338640e1d230b3becd)