### PR TITLE
chore: ignore generated demo artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,5 +81,8 @@ demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/storage/ui/dashboard-data.json
 demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v2/storage/
 demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v2/meta_agentic_alpha_v2/
 demo/Meta-Agentic-ALPHA-AGI-Jobs-v0/meta_agentic_alpha_v2/reports/generated/
+demo/CULTURE-v0/typechain-types/
+demo/CULTURE-v0/hardhat/gasReporterOutput.json
+demo/Phase-8-Universal-Value-Dominance/test-results/
 __pycache__/
 **/__pycache__/


### PR DESCRIPTION
## Summary
- ignore CULTURE hardhat typechain and gas reporter artifacts generated by demo tests
- ignore Phase-8 Universal Value Dominance Playwright test results to keep the workspace clean after runs

## Testing
- python demo/run_demo_tests.py --fail-fast


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944c88acdc48333ae41e586cfbdf13e)