### PR TITLE
Harden Phase 8 manifest validation

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/tests/test_run_demo_script.py
+++ b/demo/Phase-8-Universal-Value-Dominance/tests/test_run_demo_script.py
@@ -9,6 +9,7 @@ from pathlib import Path
 PHASE_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = PHASE_ROOT / "run_demo.py"
 OUTPUT_PATH = PHASE_ROOT / "output" / "phase8_run_report.json"
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
 def test_run_demo_script_generates_report():
@@ -36,6 +37,13 @@ def test_report_addresses_are_normalised():
     for field, value in payload["global"].items():
         assert value.startswith("0x"), f"{field} should look like an address"
         assert value == value.lower()
+    for domain in payload["domains"]:
+        assert domain["slug"]
+        for field, value in domain.items():
+            if field == "slug":
+                continue
+            assert value.startswith("0x"), f"{field} should look like an address"
+            assert value == value.lower()
 
 
 def test_custom_output_and_quiet_mode(tmp_path):
@@ -60,3 +68,33 @@ def test_custom_output_and_quiet_mode(tmp_path):
 
     payload = json.loads(custom_output.read_text())
     assert payload["totals"]["monthlyUSD"] > 0
+
+
+def test_invalid_addresses_surface_in_report(tmp_path):
+    manifest_data = json.loads((PHASE_ROOT / "config" / "universal.value.manifest.json").read_text())
+    manifest_data["domains"][0]["orchestrator"] = "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+
+    bad_manifest = tmp_path / "bad_manifest.json"
+    bad_manifest.write_text(json.dumps(manifest_data))
+    bad_output = tmp_path / "bad_report.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--manifest",
+            str(bad_manifest),
+            "--output",
+            str(bad_output),
+            "--quiet",
+        ],
+        cwd=PHASE_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(bad_output.read_text())
+    assert result.returncode == 1
+    assert payload["domains"][0]["orchestrator"] == ZERO_ADDRESS
+    assert payload["addressAudit"]["invalidCount"] == 1
+    assert any("domains[0].orchestrator" in path for path in payload["addressAudit"]["invalidPaths"])


### PR DESCRIPTION
## Summary
- normalize and audit all address-like fields in the Phase 8 universal value manifest
- include domain contract addresses and address audit metadata in the generated report
- add regression coverage to surface invalid addresses and ensure normalization

## Testing
- python -m pytest demo/Phase-8-Universal-Value-Dominance/tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944d01eaa84833389d278c07ad5545e)