### PR TITLE
Clarify Phase-8 Playwright setup guidance

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/README.md
+++ b/demo/Phase-8-Universal-Value-Dominance/README.md
@@ -58,7 +58,6 @@ flowchart LR
 
 - Before running `npx playwright test --config=playwright.config.ts`, you can provision the bundled Chromium binary once with:
   - `./scripts/install_playwright_browsers.sh`
-- The suite also includes a lightweight global setup that will automatically download the Chromium headless shell (via `npx playwrigh
-t install --with-deps chromium`) if it is missing, so CI and fresh environments stay green without extra steps.
-- Both paths install the OS-level dependencies Playwright needs so the dashboard e2e suite runs without manual intervention on fresh
-  machines.
+- The suite also includes a lightweight global setup that will automatically download the Chromium headless shell (via `npx playwright install --with-deps chromium`) if it is missing, so CI and fresh environments stay green without extra steps.
+- Both paths install the OS-level dependencies Playwright needs so the dashboard e2e suite runs without manual intervention on fresh machines.
+- Expect the first run to download browser artefacts and apt packages (fonts, headless display libraries). Subsequent runs reuse the cached binaries under `~/.cache/ms-playwright`, so reruns stay fast without additional flags.


### PR DESCRIPTION
## Summary
- Clarify the Phase-8 Playwright documentation so the automatic Chromium install path and caching behaviour are explicit.
- Explain the first-run download expectations and reuse of cached browser binaries to help operators keep the e2e suite green.

## Testing
- python demo/run_demo_tests.py --fail-fast


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945906ddcf08333aeda65ec2660c3da)