### PR TITLE
Add runnable Node test harness for AGI Alpha Node demo

### DIFF
--- a/demo/AGI-Alpha-Node-v0/package-lock.json
+++ b/demo/AGI-Alpha-Node-v0/package-lock.json
@@ -1,0 +1,235 @@
+{
+  "name": "agi-alpha-node-v0",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agi-alpha-node-v0",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/node": "^20.12.12",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.2"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
+      "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/demo/AGI-Alpha-Node-v0/package.json
+++ b/demo/AGI-Alpha-Node-v0/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "agi-alpha-node-v0",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Alpha Node demo test harness",
+  "packageManager": "npm@11.4.2",
+  "type": "commonjs",
+  "scripts": {
+    "test": "TS_NODE_PROJECT=tsconfig.build.json node --test -r ts-node/register/transpile-only test/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.12",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2"
+  }
+}

--- a/demo/AGI-Alpha-Node-v0/test/config.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/config.test.ts
@@ -1,12 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import path from 'node:path';
 import { loadAlphaNodeConfig, makeEnsName } from '../src/config';
-
-const fixturePath = path.resolve('demo/AGI-Alpha-Node-v0/config/mainnet.guide.json');
+import { fixturePath } from './test-utils';
 
 test('loads and normalises alpha node config', async () => {
-  const config = await loadAlphaNodeConfig(fixturePath);
+  const config = await loadAlphaNodeConfig(fixturePath('mainnet.guide.json'));
   assert.equal(makeEnsName(config), `${config.operator.ensLabel}.${config.operator.ensRoot}`);
   assert.equal(typeof config.operator.minimumStakeWei, 'bigint');
   assert.equal(typeof config.ai.reinvestThresholdWei, 'bigint');

--- a/demo/AGI-Alpha-Node-v0/test/governance.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/governance.test.ts
@@ -1,19 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import path from 'node:path';
 import { JsonRpcProvider, Wallet, parseEther } from 'ethers';
 import { loadAlphaNodeConfig } from '../src/config';
 import {
   applyGovernanceUpdate,
   loadGovernanceUpdate,
 } from '../src/blockchain/governance';
+import { fixturePath } from './test-utils';
 
-const CONFIG_PATH = path.resolve(
-  'demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'
-);
-const GOVERNANCE_MANIFEST_PATH = path.resolve(
-  'demo/AGI-Alpha-Node-v0/config/governance.update.guide.json'
-);
+const CONFIG_PATH = fixturePath('mainnet.guide.json');
+const GOVERNANCE_MANIFEST_PATH = fixturePath('governance.update.guide.json');
 
 function createOfflineWallet(): Wallet {
   const provider = new JsonRpcProvider('http://127.0.0.1:8545');

--- a/demo/AGI-Alpha-Node-v0/test/identity.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/identity.test.ts
@@ -1,9 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import path from 'node:path';
 import { loadAlphaNodeConfig } from '../src/config';
 import { verifyNodeIdentity } from '../src/identity/verify';
 import type { EnsLookup, EnsResolution } from '../src/identity/types';
+import { fixturePath } from './test-utils';
 
 class StubLookup implements EnsLookup {
   constructor(private readonly resolution: EnsResolution) {}
@@ -13,7 +13,7 @@ class StubLookup implements EnsLookup {
 }
 
 test('identity verification succeeds for matching owner', async () => {
-  const config = await loadAlphaNodeConfig(path.resolve('demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'));
+  const config = await loadAlphaNodeConfig(fixturePath('mainnet.guide.json'));
   const lookup = new StubLookup({
     owner: config.operator.address,
     wrapperOwner: config.operator.address,
@@ -27,7 +27,7 @@ test('identity verification succeeds for matching owner', async () => {
 });
 
 test('identity verification reports mismatches', async () => {
-  const config = await loadAlphaNodeConfig(path.resolve('demo/AGI-Alpha-Node-v0/config/mainnet.guide.json'));
+  const config = await loadAlphaNodeConfig(fixturePath('mainnet.guide.json'));
   const lookup = new StubLookup({
     owner: '0x0000000000000000000000000000000000000001',
     wrapperOwner: '0x0000000000000000000000000000000000000001',

--- a/demo/AGI-Alpha-Node-v0/test/jobs.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/jobs.test.ts
@@ -1,11 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import path from 'node:path';
 import { Wallet } from 'ethers';
 import { loadAlphaNodeConfig } from '../src/config';
 import { JobLifecycle, JobLifecycleContext } from '../src/blockchain/jobs';
-
-const fixturePath = path.resolve('demo/AGI-Alpha-Node-v0/config/mainnet.guide.json');
+import { fixturePath } from './test-utils';
 
 class FakeTx {
   constructor(readonly hash: string) {}
@@ -69,7 +67,7 @@ function makeWallet(): Wallet {
 }
 
 async function makeLifecycle(registry: FakeJobRegistry): Promise<JobLifecycle> {
-  const config = await loadAlphaNodeConfig(fixturePath);
+  const config = await loadAlphaNodeConfig(fixturePath('mainnet.guide.json'));
   const context: JobLifecycleContext = { signer: makeWallet(), config, registry: registry as any };
   return new JobLifecycle(context);
 }

--- a/demo/AGI-Alpha-Node-v0/test/planner.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/planner.test.ts
@@ -1,13 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import path from 'node:path';
 import { loadAlphaNodeConfig } from '../src/config';
 import { AlphaPlanner, JobOpportunity } from '../src/ai/planner';
-
-const fixturePath = path.resolve('demo/AGI-Alpha-Node-v0/config/mainnet.guide.json');
+import { fixturePath } from './test-utils';
 
 async function makePlanner(): Promise<AlphaPlanner> {
-  const config = await loadAlphaNodeConfig(fixturePath);
+  const config = await loadAlphaNodeConfig(fixturePath('mainnet.guide.json'));
   return new AlphaPlanner(config);
 }
 

--- a/demo/AGI-Alpha-Node-v0/test/reinvest.test.ts
+++ b/demo/AGI-Alpha-Node-v0/test/reinvest.test.ts
@@ -1,13 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import path from 'node:path';
 import { Wallet } from 'ethers';
 import { loadAlphaNodeConfig } from '../src/config';
 import { reinvestRewards } from '../src/blockchain/reinvest';
 import type { RewardSnapshot } from '../src/blockchain/rewards';
 import type { StakeSnapshot } from '../src/blockchain/staking';
-
-const fixturePath = path.resolve('demo/AGI-Alpha-Node-v0/config/mainnet.guide.json');
+import { fixturePath } from './test-utils';
 
 class FakeTx {
   constructor(readonly hash: string) {}
@@ -79,7 +77,7 @@ function makeStakeSnapshot(): StakeSnapshot {
 }
 
 test('reinvestRewards skips when pending is below threshold', async () => {
-  const config = await loadAlphaNodeConfig(fixturePath);
+  const config = await loadAlphaNodeConfig(fixturePath('mainnet.guide.json'));
   const wallet = makeWallet();
   const pending = config.ai.reinvestThresholdWei - 1n;
   const report = await reinvestRewards(
@@ -102,7 +100,7 @@ test('reinvestRewards skips when pending is below threshold', async () => {
 });
 
 test('reinvestRewards dry run reports intended actions', async () => {
-  const config = await loadAlphaNodeConfig(fixturePath);
+  const config = await loadAlphaNodeConfig(fixturePath('mainnet.guide.json'));
   const wallet = makeWallet();
   const pending = config.ai.reinvestThresholdWei + 10n;
   const report = await reinvestRewards(
@@ -126,7 +124,7 @@ test('reinvestRewards dry run reports intended actions', async () => {
 });
 
 test('reinvestRewards claims and deposits with injected contracts', async () => {
-  const config = await loadAlphaNodeConfig(fixturePath);
+  const config = await loadAlphaNodeConfig(fixturePath('mainnet.guide.json'));
   const wallet = makeWallet();
   const feePool = new FakeFeePool();
   const stakeManager = new FakeStakeManager();

--- a/demo/AGI-Alpha-Node-v0/test/test-utils.ts
+++ b/demo/AGI-Alpha-Node-v0/test/test-utils.ts
@@ -1,0 +1,7 @@
+import path from 'node:path';
+
+export const FIXTURE_ROOT = path.resolve(__dirname, '..', 'config');
+
+export function fixturePath(fileName: string): string {
+  return path.join(FIXTURE_ROOT, fileName);
+}


### PR DESCRIPTION
## Summary
- add an npm test harness so the AGI Alpha Node demo’s Node-based specs run under the shared demo test runner
- factor shared fixture path resolution into a helper and update the Node tests to use stable config locations

## Testing
- python demo/run_demo_tests.py --demo AGI-Alpha-Node-v0 --fail-fast


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ad94656483338aa05bcdb5f73a98)