### PR TITLE
Improve Playwright install handling for Phase 8 demo

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js
@@ -1,6 +1,17 @@
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 
+const DEFAULT_PLAYWRIGHT_BROWSERS_PATH = process.env.PLAYWRIGHT_BROWSERS_PATH ?? '0';
+
+function buildPlaywrightEnv({ autoInstall, env = process.env }) {
+  const browsersPath = env.PLAYWRIGHT_BROWSERS_PATH ?? DEFAULT_PLAYWRIGHT_BROWSERS_PATH;
+  return {
+    PLAYWRIGHT_BROWSERS_PATH: browsersPath,
+    PLAYWRIGHT_AUTO_INSTALL: autoInstall ? '1' : '0',
+    ...(autoInstall ? {} : { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' }),
+  };
+}
+
 function runStep(command, args, options = {}) {
   const result = spawnSync(command, args, {
     stdio: 'inherit',
@@ -12,7 +23,17 @@ function runStep(command, args, options = {}) {
   }
 }
 
-function ensureChromiumAvailable({ autoInstall, installWithDeps }) {
+function ensureChromiumAvailable({
+  autoInstall,
+  installWithDeps,
+  browsersPath = DEFAULT_PLAYWRIGHT_BROWSERS_PATH,
+}) {
+  // Keep Playwright downloads scoped to the project directory unless callers
+  // explicitly override the location. This avoids writing into system
+  // directories on locked-down hosts and makes the cache easier to persist in
+  // CI.
+  process.env.PLAYWRIGHT_BROWSERS_PATH = browsersPath;
+
   const { chromium } = require('@playwright/test');
   const executablePath = chromium.executablePath();
   if (executablePath && fs.existsSync(executablePath)) {
@@ -24,7 +45,11 @@ function ensureChromiumAvailable({ autoInstall, installWithDeps }) {
     if (installWithDeps) {
       installArgs.push('--with-deps');
     }
-    runStep('npx', installArgs);
+    runStep('npx', installArgs, {
+      env: {
+        PLAYWRIGHT_BROWSERS_PATH: browsersPath,
+      },
+    });
     return;
   }
 
@@ -40,23 +65,36 @@ function ensureChromiumAvailable({ autoInstall, installWithDeps }) {
   }
 }
 
-// Forward npm-provided args to the Jest suite (demo runner passes --runInBand)
-const forwardedArgs = process.argv.slice(2);
-const playwrightAutoInstall = process.env.PLAYWRIGHT_AUTO_INSTALL !== '0';
-const playwrightInstallWithDeps = process.env.PLAYWRIGHT_INSTALL_WITH_DEPS !== '0';
+function main() {
+  // Forward npm-provided args to the Jest suite (demo runner passes --runInBand)
+  const forwardedArgs = process.argv.slice(2);
+  const playwrightAutoInstall = process.env.PLAYWRIGHT_AUTO_INSTALL !== '0';
+  const playwrightInstallWithDeps = process.env.PLAYWRIGHT_INSTALL_WITH_DEPS !== '0';
 
-runStep('npm', ['run', 'test:unit', '--', ...forwardedArgs]);
-// Default to auto-installing Chromium so the Playwright suite actually runs in
-// CI and local environments without extra flags. Allows opt-out by explicitly
-// setting PLAYWRIGHT_AUTO_INSTALL=0 while still validating that a browser is
-// present.
-ensureChromiumAvailable({
-  autoInstall: playwrightAutoInstall,
-  installWithDeps: playwrightInstallWithDeps,
-});
-runStep('npm', ['run', 'test:e2e'], {
-  env: {
-    PLAYWRIGHT_AUTO_INSTALL: playwrightAutoInstall ? '1' : '0',
-    ...(playwrightAutoInstall ? {} : { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' }),
-  },
-});
+  const playwrightEnv = buildPlaywrightEnv({ autoInstall: playwrightAutoInstall });
+
+  runStep('npm', ['run', 'test:unit', '--', ...forwardedArgs]);
+  // Default to auto-installing Chromium so the Playwright suite actually runs in
+  // CI and local environments without extra flags. Allows opt-out by explicitly
+  // setting PLAYWRIGHT_AUTO_INSTALL=0 while still validating that a browser is
+  // present.
+  ensureChromiumAvailable({
+    autoInstall: playwrightAutoInstall,
+    installWithDeps: playwrightInstallWithDeps,
+    browsersPath: playwrightEnv.PLAYWRIGHT_BROWSERS_PATH,
+  });
+  runStep('npm', ['run', 'test:e2e'], {
+    env: playwrightEnv,
+  });
+}
+
+module.exports = {
+  buildPlaywrightEnv,
+  ensureChromiumAvailable,
+  runStep,
+  main,
+};
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add reusable helpers to centralize Playwright environment configuration
- scope browser downloads to the demo directory and honor existing PLAYWRIGHT_BROWSERS_PATH
- keep CLI runnable as a module while preserving automatic Chromium installation behavior

## Testing
- npm test -- --runInBand (demo/Phase-8-Universal-Value-Dominance)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c8d13ca083338f5da813a177c2c4)