### PR TITLE
Improve Phase-8 Playwright bootstrapping

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
@@ -1,0 +1,116 @@
+import { jest } from '@jest/globals';
+import type { SpyInstance } from 'jest-mock';
+
+jest.mock('node:fs', () => ({
+  existsSync: jest.fn(),
+}));
+
+jest.mock('@playwright/test', () => ({
+  chromium: {
+    executablePath: jest.fn(),
+  },
+}));
+
+const spawnSync = jest.fn();
+
+jest.mock('node:child_process', () => ({
+  spawnSync: (...args: unknown[]) => spawnSync(...args),
+}));
+
+const fs = require('node:fs') as { existsSync: jest.Mock };
+const { chromium } = require('@playwright/test') as {
+  chromium: { executablePath: jest.Mock };
+};
+
+describe('ensureChromiumAvailable', () => {
+  let exitSpy: SpyInstance;
+  let consoleErrorSpy: SpyInstance;
+
+  beforeEach(() => {
+    jest.resetModules();
+    spawnSync.mockReset();
+    fs.existsSync.mockReset();
+    chromium.executablePath.mockReset();
+    chromium.executablePath.mockReturnValue('/tmp/chromium');
+    spawnSync.mockReturnValue({ status: 0 });
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('skips installation when a working chromium is already present', () => {
+    const { ensureChromiumAvailable } = require('../run-tests.js');
+    const installer = jest.fn();
+    const prober = jest.fn().mockReturnValue(true);
+
+    ensureChromiumAvailable({
+      autoInstall: true,
+      installWithDeps: true,
+      browsersPath: '.local-browsers',
+      installer,
+      prober,
+    });
+
+    expect(installer).not.toHaveBeenCalled();
+    expect(prober).toHaveBeenCalledTimes(1);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test('installs chromium once when the binary becomes available without deps', () => {
+    const { ensureChromiumAvailable } = require('../run-tests.js');
+    const installer = jest.fn();
+    const prober = jest
+      .fn()
+      .mockImplementationOnce(() => false)
+      .mockImplementation(() => true);
+
+    ensureChromiumAvailable({
+      autoInstall: true,
+      installWithDeps: true,
+      browsersPath: '.local-browsers',
+      installer,
+      prober,
+    });
+
+    expect(installer).toHaveBeenCalledTimes(1);
+    expect(installer).toHaveBeenCalledWith(
+      expect.objectContaining({ withDeps: false, browsersPath: '.local-browsers' }),
+    );
+    expect(prober).toHaveBeenCalledTimes(2);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test('falls back to installing chromium with deps when the first probe fails', () => {
+    const { ensureChromiumAvailable } = require('../run-tests.js');
+    const installer = jest.fn();
+    const prober = jest
+      .fn()
+      .mockImplementationOnce(() => false)
+      .mockImplementationOnce(() => false)
+      .mockImplementation(() => true);
+
+    ensureChromiumAvailable({
+      autoInstall: true,
+      installWithDeps: true,
+      browsersPath: '.local-browsers',
+      installer,
+      prober,
+    });
+
+    expect(installer).toHaveBeenCalledTimes(2);
+    expect(installer).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ withDeps: false, browsersPath: '.local-browsers' }),
+    );
+    expect(installer).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ withDeps: true, browsersPath: '.local-browsers' }),
+    );
+    expect(prober).toHaveBeenCalledTimes(3);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Refine the Phase-8 Playwright bootstrapper to probe existing Chromium builds before reinstalling and make the installer/prober injectable for easier testing.
- Export the new helpers and add targeted unit coverage for chromium availability flows.

## Testing
- npx jest scripts/__tests__/run-tests.unit.test.ts --runInBand
- python demo/run_demo_tests.py --demo Phase-8-Universal-Value-Dominance --fail-fast


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d0cc452483339e62279ebafe4885)