### PR TITLE
Enhance Kardashev II demo thermodynamic telemetry

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
@@ -9,6 +9,7 @@ Generated: 2125-01-01T19:05:39.398Z
 - **Captured Power:** 120,105 MW available for reallocation.
 - **Energy Monte Carlo:** 3.91% breach probability across 256 runs (tolerance 5.00%).
 - **Sentinel Status:** 3 advisories generated; all resolved within guardian SLA.
+- **Thermodynamic headroom:** 8.97% reserve (77359363.46 MJ Gibbs-equivalent) after buffers.
 
 ## Shard Operations
 
@@ -45,4 +46,3 @@ Generated: 2125-01-01T19:05:39.398Z
 - Energy per satellite: 45 MW
 
 A detailed task hierarchy diagram is available at `output/mermaid/dyson-hierarchy.mmd`.
-

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
@@ -1570,11 +1570,23 @@
       "breachProbability": 0,
       "tolerance": 0.01,
       "withinTolerance": true,
+      "capturedGw": 239600,
+      "reserveGw": 2400,
+      "marginGw": 11980,
+      "peakDemandGw": 236071.28410087732,
+      "averageDemandGw": 220511.2517597387,
       "percentileGw": {
         "p50": 236349.67577342957,
         "p95": 252189.138782289,
         "p99": 255160.81119188174
       }
+    },
+    "thermodynamicHeadroom": {
+      "availableGw": 21488.74824026131,
+      "peakBufferGw": 5928.715899122675,
+      "gibbsFreeEnergyMj": 77359363.46,
+      "headroomPct": 8.97,
+      "peakBufferPct": 2.47
     },
     "energyFeeds": {
       "tolerancePct": 5,

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -218,7 +218,7 @@ function computeThermodynamicHeadroom({ capturedGw, reserveGw, averageDemandGw, 
   const availableGw = Math.max(0, capturedGw + reserveGw - averageDemandGw);
   const peakBufferGw = Math.max(0, capturedGw + reserveGw - peakDemandGw);
   const gibbsFreeEnergyMj = round(
-    Math.max(0, availableGw * 3_600 - 310 * 0.42),
+    Math.max(0, availableGw * 3_600_000 - 310 * 0.42),
     2
   );
   return {

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -200,6 +200,7 @@ function simulateEnergyMonteCarlo(fabric, energyFeeds, energyConfig, rng, runs =
     tolerance: safetyMarginPct,
     withinTolerance: breachProbability <= safetyMarginPct,
     capturedGw,
+    reserveGw,
     marginGw,
     peakDemandGw: peakDemand,
     averageDemandGw: samples.length === 0 ? 0 : totalDemand / samples.length,
@@ -211,6 +212,22 @@ function simulateEnergyMonteCarlo(fabric, energyFeeds, energyConfig, rng, runs =
   };
   debugLog('energy-monte-carlo', summary);
   return summary;
+}
+
+function computeThermodynamicHeadroom({ capturedGw, reserveGw, averageDemandGw, peakDemandGw }) {
+  const availableGw = Math.max(0, capturedGw + reserveGw - averageDemandGw);
+  const peakBufferGw = Math.max(0, capturedGw + reserveGw - peakDemandGw);
+  const gibbsFreeEnergyMj = round(
+    Math.max(0, availableGw * 3_600 - 310 * 0.42),
+    2
+  );
+  return {
+    availableGw,
+    peakBufferGw,
+    gibbsFreeEnergyMj,
+    headroomPct: round(capturedGw > 0 ? (availableGw / capturedGw) * 100 : 0, 2),
+    peakBufferPct: round(capturedGw > 0 ? (peakBufferGw / capturedGw) * 100 : 0, 2),
+  };
 }
 
 function buildMermaidTaskHierarchy(dyson) {
@@ -316,6 +333,12 @@ function main() {
   const shardMetrics = fabric.shards.map((shard) => computeShardMetrics(shard, energy.feeds, rng));
   const dyson = simulateDysonSwarm(rng);
   const energyMonteCarlo = simulateEnergyMonteCarlo(fabric, energy.feeds, energy, rng);
+  const thermodynamicHeadroom = computeThermodynamicHeadroom({
+    capturedGw: energyMonteCarlo.capturedGw,
+    reserveGw: energyMonteCarlo.reserveGw,
+    averageDemandGw: energyMonteCarlo.averageDemandGw,
+    peakDemandGw: energyMonteCarlo.peakDemandGw,
+  });
   const generatedAt = new Date(
     Date.UTC(2125, 0, 1) + Math.floor(rng() * 86_400_000)
   ).toISOString();
@@ -360,6 +383,9 @@ function main() {
   );
   reportLines.push(
     `- **Sentinel Status:** ${sentinelFindings.length} advisories generated; all resolved within guardian SLA.`
+  );
+  reportLines.push(
+    `- **Thermodynamic headroom:** ${thermodynamicHeadroom.headroomPct.toFixed(2)}% reserve (${thermodynamicHeadroom.gibbsFreeEnergyMj.toFixed(2)} MJ Gibbs-equivalent) after buffers.`
   );
   reportLines.push('');
 
@@ -423,6 +449,7 @@ function main() {
     sentinelFindings,
     dyson,
     energyMonteCarlo,
+    thermodynamicHeadroom,
     configs: {
       knowledgeGraph: fabric.knowledgeGraph,
       energyOracle: fabric.energyOracle,

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -48,3 +48,6 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     telemetry_payload = json.loads(telemetry.read_text())
     assert telemetry_payload.get("energyMonteCarlo", {}).get("withinTolerance") is True
     assert telemetry_payload.get("dominanceScore")
+    thermodynamic = telemetry_payload.get("thermodynamicHeadroom", {})
+    assert thermodynamic.get("headroomPct") and thermodynamic["headroomPct"] > 0
+    assert thermodynamic.get("gibbsFreeEnergyMj") and thermodynamic["gibbsFreeEnergyMj"] > 0


### PR DESCRIPTION
## Summary
- add a thermodynamic headroom calculation to the Kardashev II demo, covering reserve buffers and Gibbs-equivalent free energy
- surface the new headroom metric in the generated report and reference telemetry artefact for clearer operator signals
- extend the demo test to assert the presence of the thermodynamic reserves in the telemetry payload

## Testing
- python -m pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945f75b31a88333b086c1bba612ec60)