### PR TITLE
Require Phase 8 e2e coverage in CI

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/README.md
+++ b/demo/Phase-8-Universal-Value-Dominance/README.md
@@ -58,6 +58,6 @@ flowchart LR
 
 - Before running `npx playwright test --config=playwright.config.ts`, you can provision the bundled Chromium binary once with:
   - `./scripts/install_playwright_browsers.sh`
-- The suite includes a lightweight global setup that will automatically download Chromium if it is missing and has the privileges to install its OS-level dependencies. When the runner cannot install those dependencies (e.g., locked-down containers), it will skip the e2e suite instead of hard-failing; set `PLAYWRIGHT_OPTIONAL_E2E=0` to force a failure when the browser cannot be installed.
+- The suite includes a lightweight global setup that will automatically download Chromium if it is missing and has the privileges to install its OS-level dependencies. E2E checks are enforced by default in CI; locally you can opt out by setting `PLAYWRIGHT_OPTIONAL_E2E=1` or force a hard failure with `PLAYWRIGHT_OPTIONAL_E2E=0` when the browser cannot be installed.
 - Both paths install the OS-level dependencies Playwright needs so the dashboard e2e suite runs without manual intervention on fresh machines when permission is available.
 - Expect the first run to download browser artefacts and, when allowed, apt packages (fonts, headless display libraries). Subsequent runs reuse the cached binaries under `~/.cache/ms-playwright`, so reruns stay fast without additional flags.

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
@@ -182,3 +182,46 @@ describe('canInstallPlaywrightDeps', () => {
     expect(spawnSync).not.toHaveBeenCalledWith('which', ['apt-get'], expect.anything());
   });
 });
+
+describe('isOptionalE2E', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('defaults to required in CI', () => {
+    process.env.CI = '1';
+    const { isOptionalE2E } = require('../run-tests.js');
+
+    expect(isOptionalE2E()).toBe(false);
+  });
+
+  test('defaults to optional outside CI', () => {
+    delete process.env.CI;
+    const { isOptionalE2E } = require('../run-tests.js');
+
+    expect(isOptionalE2E()).toBe(true);
+  });
+
+  test('respects explicit opt-out flag', () => {
+    process.env.CI = '1';
+    process.env.PLAYWRIGHT_OPTIONAL_E2E = '1';
+    const { isOptionalE2E } = require('../run-tests.js');
+
+    expect(isOptionalE2E()).toBe(true);
+  });
+
+  test('respects explicit hard-fail flag', () => {
+    process.env.CI = '0';
+    process.env.PLAYWRIGHT_OPTIONAL_E2E = '0';
+    const { isOptionalE2E } = require('../run-tests.js');
+
+    expect(isOptionalE2E()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce Phase 8 Playwright e2e coverage in CI by default while keeping local opt-outs explicit
- document the new environment toggle behavior for the demo runner
- extend unit coverage of the test harness to verify the optional-e2e decision matrix

## Testing
- npm run test:unit -- scripts/__tests__/run-tests.unit.test.ts
- python demo/run_demo_tests.py --demo Phase-8-Universal-Value-Dominance --fail-fast

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b49db5fc83338ea72101c3c5b5c0)