### PR TITLE
Fix omega demo cycle limit handling

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
@@ -152,10 +152,17 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
     _require_positive(args.health_check_interval, field="health_check_interval_seconds")
     _require_positive(args.integrity_interval, field="integrity_check_interval_seconds")
     _require_positive(args.energy_oracle_interval, field="energy_oracle_interval_seconds")
+    checkpoint_interval = float(
+        overrides.get("checkpoint_interval_seconds", OrchestratorConfig.checkpoint_interval_seconds)
+    )
+    _require_positive(checkpoint_interval, field="checkpoint_interval_seconds")
+    cycle_sleep = float(overrides.get("cycle_sleep_seconds", OrchestratorConfig.cycle_sleep_seconds))
+    _require_positive(cycle_sleep, field="cycle_sleep_seconds")
 
     params = {
         "max_cycles": args.cycles or None,
         "checkpoint_path": args.checkpoint,
+        "checkpoint_interval_seconds": checkpoint_interval,
         "resume_from_checkpoint": not args.no_resume,
         "enable_simulation": not args.no_sim,
         "control_channel_file": args.control,
@@ -164,6 +171,7 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
         "simulation_hours_per_tick": args.simulation_hours,
         "simulation_energy_scale": args.simulation_energy_scale,
         "simulation_compute_scale": args.simulation_compute_scale,
+        "cycle_sleep_seconds": cycle_sleep,
         "audit_log_path": args.audit_log,
         "status_output_path": args.status_output,
         "energy_oracle_path": args.energy_oracle,
@@ -174,6 +182,8 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
         "integrity_check_interval_seconds": args.integrity_interval,
     }
     params.update(overrides)
+    params["checkpoint_interval_seconds"] = checkpoint_interval
+    params["cycle_sleep_seconds"] = cycle_sleep
 
     return OrchestratorConfig(**params)
 

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -356,11 +356,15 @@ class Orchestrator:
     async def _cycle_loop(self) -> None:
         while self._running:
             await self._paused.wait()
-            self._cycle += 1
-            if self.config.max_cycles and self._cycle > self.config.max_cycles:
+            if (
+                self.config.max_cycles is not None
+                and self.config.max_cycles > 0
+                and self._cycle >= self.config.max_cycles
+            ):
                 self._info("cycle_limit_reached", cycle=self._cycle)
                 asyncio.create_task(self.shutdown(), name="shutdown-from-cycle")
                 break
+            self._cycle += 1
             await asyncio.sleep(self.config.cycle_sleep_seconds)
 
     async def _insight_loop(self) -> None:
@@ -1269,4 +1273,3 @@ class Orchestrator:
             await self._paused.wait()
             await self._run_integrity_suite()
             await asyncio.sleep(interval)
-

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cycle_loop.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cycle_loop.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
+
+
+@pytest.mark.anyio
+async def test_cycle_loop_respects_max_cycles(tmp_path: Path) -> None:
+    config = OrchestratorConfig(
+        max_cycles=1,
+        cycle_sleep_seconds=0.01,
+        checkpoint_interval_seconds=1,
+        enable_simulation=False,
+        control_channel_file=tmp_path / "control.jsonl",
+        checkpoint_path=tmp_path / "checkpoint.json",
+        status_output_path=None,
+        audit_log_path=None,
+        energy_oracle_path=None,
+    )
+    orchestrator = Orchestrator(config)
+    try:
+        await orchestrator.start()
+        await asyncio.wait_for(orchestrator.wait_until_stopped(), timeout=5)
+        assert orchestrator._cycle == 1
+    finally:
+        await orchestrator.shutdown()


### PR DESCRIPTION
## Summary
- validate omega demo interval inputs to prevent zero or negative durations from config overrides
- correct the cycle loop off-by-one so shutdown triggers exactly at the requested max cycle count
- add an async regression test covering the fast cycle-stop scenario

## Testing
- pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946de09a7ac8333b501b1faec85b60a)