### PR TITLE
Fix Kardashev-II cycle loop async test setup

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cycle_loop.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cycle_loop.py
@@ -11,23 +11,25 @@ from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import
 )
 
 
-@pytest.mark.anyio
-async def test_cycle_loop_respects_max_cycles(tmp_path: Path) -> None:
-    config = OrchestratorConfig(
-        max_cycles=1,
-        cycle_sleep_seconds=0.01,
-        checkpoint_interval_seconds=1,
-        enable_simulation=False,
-        control_channel_file=tmp_path / "control.jsonl",
-        checkpoint_path=tmp_path / "checkpoint.json",
-        status_output_path=None,
-        audit_log_path=None,
-        energy_oracle_path=None,
-    )
-    orchestrator = Orchestrator(config)
-    try:
-        await orchestrator.start()
-        await asyncio.wait_for(orchestrator.wait_until_stopped(), timeout=5)
-        assert orchestrator._cycle == 1
-    finally:
-        await orchestrator.shutdown()
+def test_cycle_loop_respects_max_cycles(tmp_path: Path) -> None:
+    async def _run() -> None:
+        config = OrchestratorConfig(
+            max_cycles=1,
+            cycle_sleep_seconds=0.01,
+            checkpoint_interval_seconds=1,
+            enable_simulation=False,
+            control_channel_file=tmp_path / "control.jsonl",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            status_output_path=None,
+            audit_log_path=None,
+            energy_oracle_path=None,
+        )
+        orchestrator = Orchestrator(config)
+        try:
+            await orchestrator.start()
+            await asyncio.wait_for(orchestrator.wait_until_stopped(), timeout=5)
+            assert orchestrator._cycle == 1
+        finally:
+            await orchestrator.shutdown()
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- refactor the cycle loop test to run via `asyncio.run` so it no longer depends on an async pytest plugin
- keep the orchestrator lifecycle assertion and shutdown guardrails intact for the Kardashev-II Omega-Grade demo

## Testing
- pytest tests/test_cycle_loop.py
- pytest tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e67df56483339f0ff0736475e59e)