### PR TITLE
Make Phase 8 Playwright deps opt-in locally

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/README.md
+++ b/demo/Phase-8-Universal-Value-Dominance/README.md
@@ -59,5 +59,6 @@ flowchart LR
 - Before running `npx playwright test --config=playwright.config.ts`, you can provision the bundled Chromium binary once with:
   - `./scripts/install_playwright_browsers.sh`
 - The suite includes a lightweight global setup that will automatically download Chromium if it is missing and has the privileges to install its OS-level dependencies. E2E checks are enforced by default in CI; locally you can opt out by setting `PLAYWRIGHT_OPTIONAL_E2E=1` or force a hard failure with `PLAYWRIGHT_OPTIONAL_E2E=0` when the browser cannot be installed.
+- System dependency installation (`playwright install --with-deps`) defaults to **on in CI** and **off locally** to avoid surprise `apt` prompts. If your first local run is missing the required X/GTK/font packages, set `PLAYWRIGHT_INSTALL_WITH_DEPS=1` (or run the install script above) to bootstrap them explicitly.
 - Both paths install the OS-level dependencies Playwright needs so the dashboard e2e suite runs without manual intervention on fresh machines when permission is available.
 - Expect the first run to download browser artefacts and, when allowed, apt packages (fonts, headless display libraries). Subsequent runs reuse the cached binaries under `~/.cache/ms-playwright`, so reruns stay fast without additional flags.

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
@@ -225,3 +225,46 @@ describe('isOptionalE2E', () => {
     expect(isOptionalE2E()).toBe(false);
   });
 });
+
+describe('shouldInstallPlaywrightDeps', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('defaults to installing deps in CI environments', () => {
+    process.env.CI = 'true';
+    const { shouldInstallPlaywrightDeps } = require('../run-tests.js');
+
+    expect(shouldInstallPlaywrightDeps()).toBe(true);
+  });
+
+  test('defaults to skipping system deps locally to avoid unexpected apt installs', () => {
+    delete process.env.CI;
+    const { shouldInstallPlaywrightDeps } = require('../run-tests.js');
+
+    expect(shouldInstallPlaywrightDeps()).toBe(false);
+  });
+
+  test('respects explicit opt-in flag even outside CI', () => {
+    delete process.env.CI;
+    process.env.PLAYWRIGHT_INSTALL_WITH_DEPS = '1';
+    const { shouldInstallPlaywrightDeps } = require('../run-tests.js');
+
+    expect(shouldInstallPlaywrightDeps()).toBe(true);
+  });
+
+  test('respects explicit opt-out flag even in CI', () => {
+    process.env.CI = '1';
+    process.env.PLAYWRIGHT_INSTALL_WITH_DEPS = '0';
+    const { shouldInstallPlaywrightDeps } = require('../run-tests.js');
+
+    expect(shouldInstallPlaywrightDeps()).toBe(false);
+  });
+});

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js
@@ -135,11 +135,19 @@ function ensureChromiumAvailable({
   return false;
 }
 
+function shouldInstallPlaywrightDeps(env = process.env) {
+  const raw = env.PLAYWRIGHT_INSTALL_WITH_DEPS;
+  if (raw !== undefined) {
+    return raw !== '0' && raw.toString().toLowerCase() !== 'false';
+  }
+  return isCi(env);
+}
+
 function main() {
   // Forward npm-provided args to the Jest suite (demo runner passes --runInBand)
   const forwardedArgs = process.argv.slice(2);
   const playwrightAutoInstall = process.env.PLAYWRIGHT_AUTO_INSTALL !== '0';
-  const playwrightInstallWithDeps = process.env.PLAYWRIGHT_INSTALL_WITH_DEPS !== '0';
+  const playwrightInstallWithDeps = shouldInstallPlaywrightDeps();
 
   const playwrightEnv = buildPlaywrightEnv({ autoInstall: playwrightAutoInstall });
 
@@ -181,6 +189,7 @@ module.exports = {
   runStep,
   main,
   isOptionalE2E,
+  shouldInstallPlaywrightDeps,
 };
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- default Playwright system dependency installs to CI-only unless explicitly enabled
- add coverage for the new install decision helper and document the local opt-in path

## Testing
- python demo/run_demo_tests.py --demo Phase-8-Universal-Value-Dominance --timeout 180 --fail-fast

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69471f88ffd48333a8efbffe4124b08c)