### PR TITLE
Add free-energy margin guardrails to Kardashev demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -24,6 +24,7 @@ def test_run_demo_check_mode(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     assert "validated (check mode)" in result.stdout
+    assert "Free energy margin" in result.stdout
 
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
@@ -48,3 +49,8 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     telemetry_payload = json.loads(telemetry.read_text())
     assert telemetry_payload.get("energyMonteCarlo", {}).get("withinTolerance") is True
     assert telemetry_payload.get("dominanceScore")
+
+    energy = telemetry_payload["energyMonteCarlo"]
+    assert energy["maintainsBuffer"] is True
+    assert energy["freeEnergyMarginGw"] > 0
+    assert 0 < energy["freeEnergyMarginPct"] <= 1


### PR DESCRIPTION
## Summary
- compute free-energy margin metrics for the Kardashev II demo, surfacing them in reports and CLI output
- fail fast when the buffer corridor is breached to guard system stability
- extend demo tests to assert the new telemetry fields and output messaging

## Testing
- python demo/run_demo_tests.py --demo AGI-Jobs-Platform-at-Kardashev-II-Scale

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69473f269e28833383ec2b8efd99534a)