### PR TITLE
Harden demo node runner installs

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -162,6 +162,10 @@ def _run_suite(
         playwright_cache.mkdir(parents=True, exist_ok=True)
         env.setdefault("PLAYWRIGHT_BROWSERS_PATH", str(playwright_cache))
         env.setdefault("PLAYWRIGHT_INSTALL_WITH_DEPS", "0")
+        # Ensure any system package installs triggered by Playwright or other
+        # tooling run non-interactively. This prevents hangs in CI when apt
+        # prompts for locale/timezone configuration or sudo escalation.
+        env.setdefault("DEBIAN_FRONTEND", "noninteractive")
         if "Phase-8-Universal-Value-Dominance" in str(suite.demo_root):
             # The Phase-8 demo exercises a browser-backed validation path; it
             # needs Playwright's system dependencies available even in CI-like


### PR DESCRIPTION
## Summary
- add a non-interactive install guard for node-based demo suites so Playwright dependency installs cannot hang waiting for apt prompts
- rerun the Phase-8 universal value dominance demo tests to confirm the updated runner remains healthy

## Testing
- python demo/run_demo_tests.py --demo "Phase-8-Universal-Value-Dominance"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69477ca762008333bc0c392dac0c2e04)