### PR TITLE
Pin eth-typing for AGI Alpha Node tests

### DIFF
--- a/demo/AGI-Alpha-Node-v0/requirements.txt
+++ b/demo/AGI-Alpha-Node-v0/requirements.txt
@@ -6,3 +6,8 @@ rich>=13.7
 typer[all]>=0.9
 uvicorn[standard]>=0.23
 web3>=6.11
+# Keep eth-typing on a pre-4.x release so pytest's web3 plugin can import the
+# legacy ContractName alias when global plugins auto-load. Without this pin,
+# running the suite via the bare ``pytest`` console script can crash before our
+# local shim and sitecustomize helpers are on ``sys.path``.
+eth-typing>=3.3,<4


### PR DESCRIPTION
## Summary
- pin eth-typing to a ContractName-friendly release for the AGI Alpha Node demo
- document why the pin keeps pytest collection stable when global plugins auto-load

## Testing
- pytest tests -q (demo/AGI-Alpha-Node-v0)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69480a84584883338af4b01b274f80fb)