### PR TITLE
Harden demo test runner for constrained Playwright hosts

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -195,9 +195,9 @@ def _run_suite(
             # and otherwise allow the suite to skip e2e checks instead of
             # failing outright on locked-down runners.
             if _can_install_playwright_deps():
-                env.setdefault("PLAYWRIGHT_INSTALL_WITH_DEPS", "1")
+                env["PLAYWRIGHT_INSTALL_WITH_DEPS"] = "1"
             else:
-                env.setdefault("PLAYWRIGHT_INSTALL_WITH_DEPS", "0")
+                env["PLAYWRIGHT_INSTALL_WITH_DEPS"] = "0"
                 env.setdefault("PLAYWRIGHT_OPTIONAL_E2E", "1")
         binary = suite.runner
         cmd = [binary, "test", *_node_runner_args(suite.demo_root)]


### PR DESCRIPTION
## Summary
- detect whether Playwright system dependencies can be installed before forcing Phase-8 e2e setup
- automatically opt into Playwright deps when available and gracefully mark e2e optional when the host cannot install them

## Testing
- python demo/run_demo_tests.py --demo Phase-8-Universal-Value-Dominance


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694840b822008333a6b53480fdbdb6f8)