### PR TITLE
Isolate demo outputs from tracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,5 +85,6 @@ demo/CULTURE-v0/typechain-types/
 demo/CULTURE-v0/hardhat/gasReporterOutput.json
 demo/Phase-8-Universal-Value-Dominance/.cache/
 demo/Phase-8-Universal-Value-Dominance/test-results/
+demo/AGI-Alpha-Node-v0/.runtime/
 __pycache__/
 **/__pycache__/

--- a/demo/AGI-Alpha-Node-v0/alpha_node/cli.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/cli.py
@@ -24,8 +24,10 @@ from .state import StateStore
 def load_environment(config_path: Path) -> dict[str, Any]:
     config = AlphaNodeConfig.load(config_path)
     base_dir = config_path.parent
-    state_store = StateStore(base_dir / "state.json")
-    ledger_path = base_dir / "stake_ledger.csv"
+    runtime_dir = base_dir / ".runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    state_store = StateStore(runtime_dir / "state.json")
+    ledger_path = runtime_dir / "stake_ledger.csv"
     stake_manager = StakeManager(config.stake, state_store, ledger_path)
     ens_registry = base_dir / "ens_registry.csv"
     ens_verifier = ENSVerifier(config.ens, ens_registry)

--- a/demo/AGI-Alpha-Node-v0/alpha_node/node.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/node.py
@@ -26,6 +26,7 @@ class AlphaNode:
         config: AlphaNodeConfig,
         *,
         base_path: Optional[Path] = None,
+        runtime_dir: Optional[Path] = None,
         state_store: Optional[StateStore] = None,
         stake_manager: Optional[StakeManager] = None,
         ens_verifier: Optional[ENSVerifier] = None,
@@ -40,8 +41,10 @@ class AlphaNode:
     ) -> None:
         self.config = config
         self.base_path = base_path or Path(__file__).resolve().parent.parent
-        self.state_store = state_store or StateStore(self.base_path / "state.json")
-        ledger_path = self.base_path / "stake_ledger.csv"
+        self.runtime_dir = runtime_dir or self.base_path / ".runtime"
+        self.runtime_dir.mkdir(parents=True, exist_ok=True)
+        self.state_store = state_store or StateStore(self.runtime_dir / "state.json")
+        ledger_path = self.runtime_dir / "stake_ledger.csv"
         self.stake_manager = stake_manager or StakeManager(config.stake, self.state_store, ledger_path)
         self.ens_verifier = ens_verifier or ENSVerifier(config.ens, self.base_path / "ens_registry.csv")
         self.governance = governance or GovernanceController(config.governance, self.state_store)

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const DEBUG_TOKEN = 'kardashev-demo';
@@ -311,7 +312,7 @@ function parseArgs(argv) {
 function resolveOutputDir(rawOutputDir, { ensure = true } = {}) {
   const dir = rawOutputDir
     ? path.resolve(rawOutputDir)
-    : path.join(__dirname, 'output');
+    : path.join(os.tmpdir(), 'agi-jobs-platform');
   if (ensure) {
     ensureDir(dir);
   }

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
@@ -15,11 +15,13 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Sequence
+import tempfile
 import shutil
 
 
 ROOT = Path(__file__).resolve().parent
 NODE_SCRIPT = ROOT / "run-demo.cjs"
+DEFAULT_OUTPUT_DIR = Path(tempfile.gettempdir()) / "agi-jobs-platform"
 
 
 def _ensure_node_available() -> str:
@@ -49,6 +51,7 @@ def run(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
         help="Directory where generated artefacts should be written.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- write AGI Alpha Node runtime state and stake ledger into a dedicated .runtime directory to avoid mutating tracked fixtures
- switch the Kardashev II demo’s default output directory to the system temp cache and mirror that in the Python wrapper
- ignore the new runtime artefacts to keep the repo clean after running demos locally

## Testing
- pytest demo/AGI-Alpha-Node-v0/grand_demo/tests/test_alpha_node.py demo/AGI-Alpha-Node-v0/grand_demo/tests/test_script_run_demo.py
- pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69488f4e2f908333bb70038f6b291e36)