### PR TITLE
Fix omega-grade demo module entrypoint

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__main__.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__main__.py
@@ -1,11 +1,21 @@
-"""Forward execution to the canonical demo package."""
+"""Module entrypoint for the Omega-grade wrapper package.
 
-from importlib import import_module
+Keeping ``python -m demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega``
+aligned with the ASCII-safe ``run_demo`` helper prevents import errors caused by
+the Unicode-heavy canonical package path. Delegating to the shared launcher
+keeps the invocation consistent with the primary demo wrapper.
+"""
 
-_main_module = import_module(
-    "demo.Kardashev-II Omega-Grade-α-AGI Business-3.kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega.__main__"
-)
-main = _main_module.main
+from __future__ import annotations
 
-if __name__ == "__main__":  # pragma: no cover - script execution entry
+from .run_demo import run
+
+
+def main() -> None:
+    """Invoke the demo CLI via the wrapper launcher."""
+
+    run()
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via subprocess
     main()

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/tests/test_run_demo.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/tests/test_run_demo.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib
+import os
 import runpy
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -44,3 +46,27 @@ def test_run_as_script_imports_canonical_main(monkeypatch):
 
     assert captured["argv"] == []
     assert str(repo_root) in sys.path
+
+
+def test_module_entrypoint_invokable():
+    repo_root = Path(__file__).resolve().parents[3]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        segment for segment in [str(repo_root), env.get("PYTHONPATH", "")] if segment
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "omega-grade" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- route the omega-grade demo wrapper __main__ through the shared run_demo launcher instead of an invalid Unicode module path
- add coverage to ensure `python -m demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega` executes successfully and surfaces help output

## Testing
- python demo/run_demo_tests.py --demo kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948aea952cc8333b6449df66b903b53)