### PR TITLE
Ensure culture graph indexer generates Prisma client

### DIFF
--- a/demo/CULTURE-v0/indexers/culture-graph-indexer/README.md
+++ b/demo/CULTURE-v0/indexers/culture-graph-indexer/README.md
@@ -26,6 +26,7 @@ flowchart LR
 2. Inspect the scripts under `scripts/` or this module's `package.json` entry (where applicable) to discover targeted automation for `demo/CULTURE-v0/indexers/culture-graph-indexer`.
 3. Execute `npm test` and `npm run lint --if-present` before pushing to guarantee a fully green AGI Jobs v0 (v2) CI signal.
 4. Capture mission telemetry with `make operator:green` or the module-specific runbooks documented in [`OperatorRunbook.md`](../../../../OperatorRunbook.md).
+   - Prisma client artefacts are generated automatically by `scripts/ensure-prisma-client.mjs` when you run `npm test`; set `DATABASE_URL` if you need a non-default datasource for generation (defaults to `file:.tmp/dev.db`).
 
 ## Directory Guide
 ### Key Directories

--- a/demo/CULTURE-v0/indexers/culture-graph-indexer/package.json
+++ b/demo/CULTURE-v0/indexers/culture-graph-indexer/package.json
@@ -7,6 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "ts-node --esm src/index.ts",
     "start": "node dist/index.js",
+    "pretest": "node scripts/ensure-prisma-client.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src --ext .ts",

--- a/demo/CULTURE-v0/indexers/culture-graph-indexer/scripts/ensure-prisma-client.mjs
+++ b/demo/CULTURE-v0/indexers/culture-graph-indexer/scripts/ensure-prisma-client.mjs
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const clientIndex = path.join(projectRoot, 'node_modules', '.prisma', 'client', 'index.js');
+const clientPackage = path.join(projectRoot, 'node_modules', '@prisma', 'client', 'index.js');
+const defaultDbPath = path.join(projectRoot, '.tmp', 'dev.db');
+const databaseUrl = process.env.DATABASE_URL ?? `file:${defaultDbPath}`;
+const requireFromProject = createRequire(import.meta.url);
+
+function prismaClientExists() {
+  try {
+    if (fs.existsSync(clientIndex) || fs.existsSync(clientPackage)) {
+      return true;
+    }
+    requireFromProject.resolve('@prisma/client');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureDefaultDbDir() {
+  try {
+    const dir = path.dirname(defaultDbPath);
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    // Best effort; prisma will surface any path errors during generation.
+  }
+}
+
+function generatePrismaClient() {
+  console.log('→ Prisma client artifacts missing; generating with prisma generate...');
+  ensureDefaultDbDir();
+  execSync('npx prisma generate', {
+    cwd: projectRoot,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+      CI: process.env.CI ?? '1',
+    },
+  });
+}
+
+if (!prismaClientExists()) {
+  generatePrismaClient();
+} else if (process.env.DEBUG?.toLowerCase() === 'true') {
+  console.log('→ Prisma client already present; skipping generate.');
+}


### PR DESCRIPTION
## Summary
- add a pretest hook so the culture graph indexer always has Prisma client artifacts before running vitest
- include a helper script that generates the client with a safe default SQLite datasource when DATABASE_URL is absent
- document the automatic Prisma generation flow in the indexer README for local operators

## Testing
- npm test (demo/CULTURE-v0/indexers/culture-graph-indexer)【a82215†L2-L56】

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694953ca37588333b0815214cb91fc95)