### PR TITLE
Handle Foundry installer timeouts in demo runner

### DIFF
--- a/demo/tests/test_run_demo_tests_runner.py
+++ b/demo/tests/test_run_demo_tests_runner.py
@@ -287,6 +287,19 @@ def test_foundry_installation_is_attempted_when_missing(
     run_demo_tests._foundry_install_attempted = False
 
 
+def test_foundry_installation_times_out_cleanly(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _timeout(*args: object, **kwargs: object) -> object:
+        raise subprocess.TimeoutExpired(cmd=args[0] if args else [], timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", _timeout)
+
+    assert run_demo_tests._install_foundry({}) is False
+    captured = capsys.readouterr().out
+    assert "Timed out" in captured
+
+
 def test_foundry_installation_can_be_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add timeouts to the Foundry bootstrap and foundryup steps so the demo runner fails fast without hanging
- surface clear messaging when Foundry installation times out and add coverage for the timeout path

## Testing
- pytest demo/tests/test_run_demo_tests_runner.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69495cf235508333ae664070e8360280)