### PR TITLE
Add thermodynamic resilience metrics to Kardashev demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -54,3 +54,5 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert energy["maintainsBuffer"] is True
     assert energy["freeEnergyMarginGw"] > 0
     assert 0 < energy["freeEnergyMarginPct"] <= 1
+    assert energy["gibbsFreeEnergyGj"] > 0
+    assert 0 <= energy["hamiltonianStability"] <= 1


### PR DESCRIPTION
## Summary
- add thermodynamic reserve outputs (Gibbs free energy and Hamiltonian stability) to the Kardashev II AGI jobs platform report
- expose the new metrics in the Monte Carlo telemetry for downstream consumers
- extend the demo regression tests to verify the added resilience signals

## Testing
- cd demo/AGI-Jobs-Platform-at-Kardashev-II-Scale && pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694986713f64833383c8bb5ea424d7d7)