### PR TITLE
Stabilize Phase-8 demo Playwright server startup

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/playwright.config.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const port = Number(process.env.PORT ?? process.env.PLAYWRIGHT_PORT ?? 4175);
+const baseURL = `http://127.0.0.1:${port}`;
+
 export default defineConfig({
   testDir: './tests',
   globalSetup: './tests/global-setup.ts',
@@ -8,7 +11,7 @@ export default defineConfig({
     timeout: 5_000,
   },
   use: {
-    baseURL: 'http://127.0.0.1:4175',
+    baseURL,
     trace: 'on-first-retry',
   },
   projects: [
@@ -20,8 +23,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'node tests/server.js',
-    port: 4175,
-    reuseExistingServer: !process.env.CI,
+    command: `PORT=${port} node tests/server.js`,
+    port,
+    reuseExistingServer: true,
   },
 });


### PR DESCRIPTION
## Summary
- derive the Playwright base URL and web server command from a configurable port
- allow reusing an existing server instance to avoid port conflicts during repeated runs

## Testing
- python demo/run_demo_tests.py --demo Phase-8-Universal-Value-Dominance

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69499ba6fae88333849730e77d547ca0)