### PR TITLE
Harden Alpha Node demo imports and knowledge compatibility

### DIFF
--- a/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/knowledge/__init__.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/knowledge/__init__.py
@@ -1,4 +1,4 @@
 """Knowledge lake exports."""
-from .lake import KnowledgeItem, KnowledgeLake
+from .lake import KnowledgeEntry, KnowledgeItem, KnowledgeLake
 
-__all__ = ["KnowledgeItem", "KnowledgeLake"]
+__all__ = ["KnowledgeEntry", "KnowledgeItem", "KnowledgeLake"]


### PR DESCRIPTION
## Summary
- add KnowledgeEntry support and add_entry shim to the grand_demo knowledge lake so both Alpha Node variants expose the same API
- export KnowledgeEntry from the grand_demo knowledge package for callers expecting the higher-level dataclass
- sanitize run_alpha_node imports by reordering sys.path and clearing stale alpha_node modules to force the CLI to use the intended package

## Testing
- pytest -q
- pytest -q tests --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c30179e08333ba8b2d544fbc7241)