### PR TITLE
Enhance Kardashev-II demo energy resilience telemetry

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -56,3 +56,5 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert 0 < energy["freeEnergyMarginPct"] <= 1
     assert energy["gibbsFreeEnergyGj"] > 0
     assert 0 <= energy["hamiltonianStability"] <= 1
+    assert energy["entropyMargin"] > 0
+    assert 0 <= energy["gameTheorySlack"] <= 1


### PR DESCRIPTION
## Summary
- add entropy-based headroom and game-theoretic slack metrics to the Kardashev-II energy Monte Carlo
- expose configurable Monte Carlo run counts via environment and surface the richer telemetry in the dossier output
- extend the demo regression test to assert the new stability signals alongside existing free-energy checks

## Testing
- python demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py --check
- python -m pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
- npm run demo:kardashev-ii:ci

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949c6e4b51c8333bc32bb7e85f1c914)