### PR TITLE
Optimize Phase-8 Playwright setup

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
@@ -79,6 +79,7 @@ describe('ensureChromiumAvailable', () => {
       installer,
       prober,
       canInstallDeps,
+      depsProbe: jest.fn().mockReturnValue(true),
     });
 
     expect(ready).toBe(true);
@@ -106,6 +107,7 @@ describe('ensureChromiumAvailable', () => {
       installer,
       prober,
       canInstallDeps,
+      depsProbe: jest.fn().mockReturnValue(true),
     });
 
     expect(ready).toBe(true);
@@ -168,6 +170,33 @@ describe('ensureChromiumAvailable', () => {
     );
     expect(depsProbe).toHaveBeenCalled();
     expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  test('prefers installing with system deps first when the host is missing them', () => {
+    const { ensureChromiumAvailable } = require('../run-tests.js');
+    const installer = jest.fn().mockReturnValue(true);
+    const prober = jest
+      .fn()
+      .mockImplementationOnce(() => false)
+      .mockImplementation(() => true);
+    const depsProbe = jest.fn().mockReturnValue(false);
+
+    const ready = ensureChromiumAvailable({
+      autoInstall: true,
+      installWithDeps: true,
+      browsersPath: '.local-browsers',
+      installer,
+      prober,
+      canInstallDeps,
+      depsProbe,
+    });
+
+    expect(ready).toBe(true);
+    expect(installer).toHaveBeenCalledTimes(1);
+    expect(installer).toHaveBeenCalledWith(
+      expect.objectContaining({ withDeps: true, browsersPath: '.local-browsers' }),
+    );
+    expect(depsProbe).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- adjust the Phase-8 demo Playwright bootstrap to prefer a single with-deps install when system libraries are missing, reducing redundant downloads in CI
- expand the Jest coverage for the installer logic to document the new decision order for dependency installs

## Testing
- npm run test:unit -- scripts/__tests__/run-tests.unit.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949edae973c83338d09bd7c4157f642)