### PR TITLE
Scope Playwright cache to runtime sandbox

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -211,12 +211,14 @@ def _run_suite(
         env.setdefault("npm_config_progress", "false")
         env.setdefault("npm_config_fund", "false")
         # Playwright-heavy demos can attempt to install system dependencies
-        # when they see CI=1. Default to a repo-local browser cache and opt
-        # out of apt-get installs unless callers explicitly request them via
+        # when they see CI=1. Default to a runtime-scoped browser cache (kept
+        # inside the orchestrator sandbox when provided) and opt out of apt-get
+        # installs unless callers explicitly request them via
         # PLAYWRIGHT_INSTALL_WITH_DEPS=1. This keeps the aggregate demo run
         # fast and non-invasive while still allowing suites to download the
         # browser binaries they need.
-        playwright_cache = suite.demo_root / ".cache" / "ms-playwright"
+        runtime_root = Path(env.get("DEMO_RUNTIME_ROOT", Path(__file__).resolve().parent))
+        playwright_cache = runtime_root / ".cache" / "ms-playwright"
         playwright_cache.mkdir(parents=True, exist_ok=True)
         env.setdefault("PLAYWRIGHT_BROWSERS_PATH", str(playwright_cache))
         env.setdefault("PLAYWRIGHT_INSTALL_WITH_DEPS", "0")


### PR DESCRIPTION
## Summary
- point demo Playwright browser caches at the runtime sandbox instead of individual demo directories
- update test coverage to verify Node suites honor the sandboxed cache location

## Testing
- python -m pytest demo/tests/test_run_demo_tests_runner.py::test_node_suites_use_runtime_root_playwright_cache


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a07cffea8833399b4fbbda9ef8dcb)