### PR TITLE
Add static demo fallback for One-Box launcher

### DIFF
--- a/demo/One-Box/lib/launcher.js
+++ b/demo/One-Box/lib/launcher.js
@@ -578,7 +578,11 @@ function startStaticServer(distDir, config) {
     try {
       const base = req.headers.host ? `http://${req.headers.host}` : `${buildOrigin(config.uiHost, config.uiPort)}/`;
       const requestUrl = new URL(req.url || '/', base);
-      if (requestUrl.pathname === '/' && !requestUrl.searchParams.has('orchestrator')) {
+      if (
+        config.publicOrchestratorUrl &&
+        requestUrl.pathname === '/' &&
+        !requestUrl.searchParams.has('orchestrator')
+      ) {
         res.statusCode = 302;
         res.setHeader('Location', `/?${demoQuery}`);
         res.end();


### PR DESCRIPTION
## Summary
- add boolean parsing helpers and propagate allow-partial/demo flags through One-Box launcher config
- allow static-only/demo mode to skip orchestrator start when required env vars are missing while still serving the UI
- make demo URL generation resilient when orchestrator is absent

## Testing
- node --test demo/One-Box/test/launcher.test.cjs

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a13d1fb188333af9698359d3c642b)