### PR TITLE
Add Foundry bootstrap reachability probe

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -764,6 +764,23 @@ def _install_foundry(env: dict[str, str], *, timeout: int = 120) -> bool:
     network access fail fast instead of hanging forever.
     """
 
+    try:
+        probe = urllib.request.Request(
+            "https://foundry.paradigm.xyz", method="HEAD"
+        )
+    except TypeError:
+        probe = urllib.request.Request("https://foundry.paradigm.xyz")
+
+    try:
+        with urllib.request.urlopen(probe, timeout=10):
+            pass
+    except OSError:
+        print(
+            "→ Foundry bootstrap endpoint is unreachable; skipping Foundry suites. "
+            "Set DEMO_INSTALL_FOUNDRY=0 to silence this check explicitly."
+        )
+        return False
+
     bootstrap = ["bash", "-c", "curl -L https://foundry.paradigm.xyz | bash"]
     try:
         result = subprocess.run(


### PR DESCRIPTION
## Summary
- add a reachability probe before attempting automated Foundry installs to avoid hangs on blocked networks
- log a clear skip message when the Foundry bootstrap host is unavailable
- extend the demo test runner coverage to include the new behavior and stub network calls in Foundry installer tests

## Testing
- python -m pytest demo/tests/test_run_demo_tests_runner.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aac88888c8333b1c00b4195ebc7b1)