### PR TITLE
Respect Playwright opt-out for Phase-8 e2e runs

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -222,6 +222,7 @@ def _run_suite(
         runtime_root = Path(env.get("DEMO_RUNTIME_ROOT", Path(__file__).resolve().parent))
         playwright_cache = Path(env.get("DEMO_PLAYWRIGHT_CACHE", Path.home() / ".cache" / "agi-jobs-demo" / "ms-playwright"))
         playwright_cache.mkdir(parents=True, exist_ok=True)
+        user_playwright_pref = env.get("PLAYWRIGHT_INSTALL_WITH_DEPS")
         env.setdefault("PLAYWRIGHT_BROWSERS_PATH", str(playwright_cache))
         env.setdefault("PLAYWRIGHT_INSTALL_WITH_DEPS", "0")
         # Ensure any system package installs triggered by Playwright or other
@@ -234,7 +235,7 @@ def _run_suite(
             # environments. Opt in explicitly when the host can satisfy them,
             # and otherwise allow the suite to skip e2e checks instead of
             # failing outright on locked-down runners.
-            user_pref = env.get("PLAYWRIGHT_INSTALL_WITH_DEPS")
+            user_pref = user_playwright_pref
             if user_pref is None:
                 if _can_install_playwright_deps() and not _playwright_system_deps_ready():
                     env["PLAYWRIGHT_INSTALL_WITH_DEPS"] = "1"

--- a/demo/tests/test_run_demo_tests_runner.py
+++ b/demo/tests/test_run_demo_tests_runner.py
@@ -927,6 +927,37 @@ def test_phase8_honors_user_playwright_dep_preference(
     assert captured_env["PLAYWRIGHT_OPTIONAL_E2E"] == "1"
 
 
+def test_phase8_auto_installs_deps_when_host_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    demo_root = tmp_path / "Phase-8-Universal-Value-Dominance"
+    tests_dir = demo_root / "tests"
+    demo_root.mkdir()
+    tests_dir.mkdir()
+
+    captured_env: dict[str, str] = {}
+
+    class _Result:
+        returncode = 0
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> _Result:
+        captured_env.update(kwargs.get("env", {}))  # type: ignore[arg-type]
+        return _Result()
+
+    suite = run_demo_tests.Suite(demo_root=demo_root, tests_dir=tests_dir, runner="npm")
+
+    monkeypatch.delenv("PLAYWRIGHT_INSTALL_WITH_DEPS", raising=False)
+    monkeypatch.setattr(run_demo_tests, "_can_install_playwright_deps", lambda: True)
+    monkeypatch.setattr(run_demo_tests, "_playwright_system_deps_ready", lambda: False)
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    code, _ = run_demo_tests._run_suite(suite, {}, timeout=1)
+
+    assert code == 0
+    assert captured_env["PLAYWRIGHT_INSTALL_WITH_DEPS"] == "1"
+    assert captured_env["PLAYWRIGHT_OPTIONAL_E2E_ON_FAILURE"] == "1"
+
+
 def test_vitest_suites_use_single_thread_pool(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     demo_root = tmp_path / "demo"
     tests_dir = demo_root / "tests"


### PR DESCRIPTION
## Summary
- honor user-provided PLAYWRIGHT_INSTALL_WITH_DEPS values when running Phase-8 demo suites so callers can skip forced system installs while still enabling optional e2e coverage
- add regression coverage to ensure the runner preserves the user preference and sets optional e2e mode appropriately

## Testing
- python -m pytest demo/tests/test_run_demo_tests_runner.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694adc87d64c83338c46f0b90b83fa59)