### PR TITLE
Gate supreme demo fast defaults behind env flag

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/run_demo.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/run_demo.py
@@ -10,15 +10,16 @@ directory.
 from __future__ import annotations
 
 import importlib
+import os
 import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
-# Keep demos fast and deterministic when no CLI arguments are provided. The
-# canonical orchestrator defaults to an infinite run with long validator delays,
-# which can feel “stuck” in automated smoke tests. These defaults execute a
-# handful of cycles with short validation windows so operators immediately see
-# output and generated artifacts.
+# Keep demos fast and deterministic when no CLI arguments are provided and the
+# fast-defaults opt-in is enabled. The canonical orchestrator defaults to an
+# infinite run with long validator delays, which can feel “stuck” in automated
+# smoke tests. These defaults execute a handful of cycles with short validation
+# windows so operators immediately see output and generated artifacts.
 DEFAULT_DEMO_ARGS = [
     "--cycles",
     "6",
@@ -34,6 +35,7 @@ DEFAULT_DEMO_ARGS = [
     "10",
     "--no-resume",
 ]
+FAST_DEFAULTS_ENV = "AGI_SUPREME_FAST_DEFAULTS"
 
 PACKAGE_NAME = "demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme"
 THIS_DIR = Path(__file__).resolve().parent
@@ -78,7 +80,8 @@ def run(argv: Optional[Iterable[str]] = None, *, main_fn=None) -> None:
     """
 
     argv_list = sys.argv[1:] if argv is None else list(argv)
-    if not argv_list:
+    use_fast_defaults = os.getenv(FAST_DEFAULTS_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+    if not argv_list and use_fast_defaults:
         argv_list = DEFAULT_DEMO_ARGS.copy()
         print(
             "🛰️  Launching Supreme Omega-grade demo with fast defaults "


### PR DESCRIPTION
### Motivation
- The supreme demo script injected a set of fast-default CLI arguments whenever no argv were provided which caused unexpected behavior when run as a script or imported as a package.
- That implicit argument injection broke a unit test which expects an empty `argv` when the script is invoked as `__main__`.
- Make fast defaults explicit and opt-in to avoid surprising callers and to follow best-practice of not mutating global process state silently.

### Description
- Add `FAST_DEFAULTS_ENV = "AGI_SUPREME_FAST_DEFAULTS"` and import `os` to read an opt-in environment flag. 
- Gate application of the `DEFAULT_DEMO_ARGS` so they are only applied when `AGI_SUPREME_FAST_DEFAULTS` is set to a truthy value (`1|true|yes|on`).
- Update the docstring/comment to explain the opt-in behavior and keep the existing default args unchanged otherwise.

### Testing
- Ran `pytest -q "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_supreme_run_demo.py"` and all tests passed (`4 passed`).
- The change addresses the previously failing demo suite invocation that reported an unexpected injected `argv` value during the `__main__` run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af0f0f3d4833390073066894a8329)