### PR TITLE
Add claim arbitration window to omega demo orchestrator

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
@@ -86,6 +86,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=30.0,
         help="Seconds between autonomous integrity verification sweeps",
     )
+    parser.add_argument(
+        "--claim-window",
+        type=float,
+        default=0.4,
+        help="Seconds to collect job claims before arbitration (0 = immediate assignment)",
+    )
     parser.add_argument("--audit-log", type=Path, help="JSONL audit log output path")
     parser.add_argument(
         "--status-output",
@@ -151,6 +157,7 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
     _require_positive(args.heartbeat_timeout, field="heartbeat_timeout_seconds")
     _require_positive(args.health_check_interval, field="health_check_interval_seconds")
     _require_positive(args.integrity_interval, field="integrity_check_interval_seconds")
+    _require_positive(args.claim_window, field="claim_window_seconds", allow_zero=True)
     _require_positive(args.energy_oracle_interval, field="energy_oracle_interval_seconds")
     checkpoint_interval = float(
         overrides.get("checkpoint_interval_seconds", OrchestratorConfig.checkpoint_interval_seconds)
@@ -180,6 +187,7 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
         "heartbeat_timeout_seconds": args.heartbeat_timeout,
         "health_check_interval_seconds": args.health_check_interval,
         "integrity_check_interval_seconds": args.integrity_interval,
+        "claim_window_seconds": args.claim_window,
     }
     params.update(overrides)
     params["checkpoint_interval_seconds"] = checkpoint_interval

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -64,6 +65,7 @@ class OrchestratorConfig:
     heartbeat_timeout_seconds: float = 30.0
     health_check_interval_seconds: float = 5.0
     integrity_check_interval_seconds: float = 30.0
+    claim_window_seconds: float = 0.4
 
 
 class Orchestrator:
@@ -113,12 +115,16 @@ class Orchestrator:
             "job_deadline": self._handle_job_deadline_event,
             "validation_commit_end": self._handle_validation_commit_end_event,
             "validation_finalize": self._handle_validation_finalize_event,
+            "claim_window": self._handle_claim_window_event,
         }
         self._agent_last_seen: Dict[str, datetime] = {}
         self._agent_roles: Dict[str, str] = {}
         self._agent_skills: Dict[str, List[str]] = {}
         self._unresponsive_agents: Set[str] = set()
         self._agent_lock = Lock()
+        self._claim_window_seconds = max(0.0, float(config.claim_window_seconds))
+        self._claim_buffer: Dict[str, List[str]] = {}
+        self._claim_event_ids: Dict[str, str] = {}
 
     def _log(self, level: int, event: str, **fields: object) -> None:
         self.log.log(level, event, extra={"event": event, **fields})
@@ -548,14 +554,7 @@ class Orchestrator:
             while self._running:
                 message = await receiver()
                 if message.topic == "jobs:claim":
-                    try:
-                        await self.assign_job(message.payload["job_id"], message.payload["agent"])
-                    except ValueError:
-                        self._warning(
-                            "job_claim_race",
-                            job_id=message.payload.get("job_id"),
-                            agent=message.payload.get("agent"),
-                        )
+                    await self._register_claim(message.payload)
                 elif message.topic.startswith("results:"):
                     await self._handle_job_result(message.payload)
                 elif message.topic.startswith("validation:commit:"):
@@ -572,6 +571,69 @@ class Orchestrator:
             self._warning("scheduler_unknown_event", event_type=event.event_type, payload=event.payload)
             return
         await handler(event)
+
+    async def _register_claim(self, payload: Dict[str, Any]) -> None:
+        job_id = str(payload.get("job_id"))
+        agent = str(payload.get("agent"))
+        if not job_id or not agent:
+            return
+        job = self.job_registry.get_job(job_id)
+        if job.status != JobStatus.POSTED:
+            return
+        if self._claim_window_seconds <= 0:
+            try:
+                await self.assign_job(job_id, agent)
+            except ValueError:
+                return
+            return
+        claims = self._claim_buffer.setdefault(job_id, [])
+        if agent not in claims:
+            claims.append(agent)
+        if job_id not in self._claim_event_ids:
+            execute_at = datetime.now(timezone.utc) + timedelta(seconds=self._claim_window_seconds)
+            event = await self.scheduler.schedule("claim_window", execute_at, {"job_id": job_id})
+            self._claim_event_ids[job_id] = event.event_id
+
+    async def _handle_claim_window_event(self, event: ScheduledEvent) -> None:
+        job_id = str(event.payload.get("job_id"))
+        if not job_id:
+            return
+        self._claim_event_ids.pop(job_id, None)
+        job = self.job_registry.get_job(job_id)
+        if job.status != JobStatus.POSTED:
+            self._claim_buffer.pop(job_id, None)
+            return
+        claims = self._claim_buffer.pop(job_id, [])
+        if not claims:
+            return
+        winner = self._select_claim_winner(job, claims)
+        try:
+            await self.assign_job(job_id, winner)
+        except ValueError:
+            self._warning("job_claim_expired", job_id=job_id, winner=winner)
+
+    def _select_claim_winner(self, job: JobRecord, claims: List[str]) -> str:
+        scored = [(self._score_claim(job, agent), agent) for agent in claims]
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        return scored[0][1]
+
+    def _score_claim(self, job: JobRecord, agent: str) -> float:
+        required_skills = {skill for skill in job.spec.required_skills if skill}
+        agent_skills = set(self._agent_skills.get(agent, []))
+        skill_overlap = len(required_skills & agent_skills)
+        skill_coverage = skill_overlap / max(1, len(required_skills))
+        active_jobs = sum(
+            1
+            for record in self.job_registry.iter_jobs()
+            if record.assigned_agent == agent and record.status == JobStatus.IN_PROGRESS
+        )
+        load_penalty = 1.0 / (1.0 + active_jobs)
+        energy_cost = job.spec.energy_budget * self.resources.energy_price
+        compute_cost = job.spec.compute_budget * self.resources.compute_price
+        hamiltonian = energy_cost + compute_cost
+        entropy_bonus = math.log1p(skill_overlap)
+        free_energy = job.spec.reward_tokens - hamiltonian
+        return (free_energy * load_penalty) + (10.0 * skill_coverage) + entropy_bonus
 
     async def _control_file_listener(self) -> None:
         try:


### PR DESCRIPTION
### Motivation

- Resolve simultaneous job claim races in the Omega-grade orchestrator by adding a short arbitration window so assignments are fair and stable.
- Encourage assignment selection that accounts for skill-fit, current load, and resource costs using a principled utility-style score.
- Expose the claim arbitration window to operators via the CLI so behaviour is configurable per run.

### Description

- Introduce `claim_window_seconds` in `OrchestratorConfig` and wire a `--claim-window` CLI flag to configure it via `cli.py`.
- Buffer `jobs:claim` messages and schedule a `claim_window` event that triggers arbitration after the configured window in `orchestrator.py`.
- Implement a claim scoring function combining skill-coverage, load penalty, resource-cost (energy/compute → Hamiltonian), entropy bonus, and free-energy style utility to pick a winner.
- Fall back to immediate assignment when `claim_window_seconds` is `0`, preserving existing behaviour.

### Testing

- Ran `pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests" -q` which completed with `14 passed`.
- The repository-wide demo test runner (`demo/run_demo_tests.py`) was executed earlier and ran multiple demo suites, but a full run was interrupted by environment package installation and is not part of this PR verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1361f6048333859c49d4ec627c3b)