### PR TITLE
Enhance Kardashev-II demo simulation thermodynamics

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -389,17 +389,20 @@ class Orchestrator:
             prev_energy_available = self.resources.energy_available
             prev_compute_capacity = self.resources.compute_capacity
             prev_compute_available = self.resources.compute_available
+            free_energy_boost = max(0.0, min(0.5, state.free_energy))
+            energy_scale = self.config.simulation_energy_scale * (1.0 + free_energy_boost * 0.05)
             energy_capacity_target = max(
                 self.resources.energy_capacity,
                 self.config.energy_capacity,
-                state.energy_output_gw * self.config.simulation_energy_scale,
+                state.energy_output_gw * energy_scale,
             )
             prosperity_factor = 1.0 + state.prosperity_index * self.config.simulation_compute_scale
             sustainability_factor = 1.0 + state.sustainability_index * 0.5 * self.config.simulation_compute_scale
+            coordination_factor = 1.0 + state.coordination_index * 0.1
             compute_capacity_target = max(
                 self.resources.compute_capacity,
                 self.config.compute_capacity,
-                self.config.compute_capacity * prosperity_factor * sustainability_factor,
+                self.config.compute_capacity * prosperity_factor * sustainability_factor * coordination_factor,
             )
             energy_usage = max(0.0, prev_energy_capacity - prev_energy_available)
             compute_usage = max(0.0, prev_compute_capacity - prev_compute_available)
@@ -416,6 +419,10 @@ class Orchestrator:
                 energy_output=state.energy_output_gw,
                 prosperity=state.prosperity_index,
                 sustainability=state.sustainability_index,
+                free_energy=state.free_energy,
+                entropy=state.entropy,
+                hamiltonian=state.hamiltonian,
+                coordination_index=state.coordination_index,
                 energy_available=self.resources.energy_available,
                 compute_available=self.resources.compute_available,
                 energy_price=self.resources.energy_price,
@@ -1121,6 +1128,10 @@ class Orchestrator:
                 "energy_output_gw": self._latest_simulation_state.energy_output_gw,
                 "prosperity_index": self._latest_simulation_state.prosperity_index,
                 "sustainability_index": self._latest_simulation_state.sustainability_index,
+                "free_energy": self._latest_simulation_state.free_energy,
+                "entropy": self._latest_simulation_state.entropy,
+                "hamiltonian": self._latest_simulation_state.hamiltonian,
+                "coordination_index": self._latest_simulation_state.coordination_index,
             }
         pending_events = list(self.scheduler.pending_events())
         pending_counts = Counter(event.event_type for event in pending_events)
@@ -1193,6 +1204,10 @@ class Orchestrator:
                 "energy_output_gw": self._latest_simulation_state.energy_output_gw,
                 "prosperity_index": self._latest_simulation_state.prosperity_index,
                 "sustainability_index": self._latest_simulation_state.sustainability_index,
+                "free_energy": self._latest_simulation_state.free_energy,
+                "entropy": self._latest_simulation_state.entropy,
+                "hamiltonian": self._latest_simulation_state.hamiltonian,
+                "coordination_index": self._latest_simulation_state.coordination_index,
             }
         return {
             "mission": self.config.mission_name,

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Dict
 
@@ -11,6 +12,10 @@ class SimulationState:
     energy_output_gw: float
     prosperity_index: float
     sustainability_index: float
+    free_energy: float = 0.0
+    entropy: float = 0.0
+    hamiltonian: float = 0.0
+    coordination_index: float = 0.0
 
 
 class PlanetarySimulation:
@@ -33,14 +38,40 @@ class SyntheticEconomySim(PlanetarySimulation):
         self.prosperity_index = min(1.0, self.prosperity_index + action.get("stimulus", 0.0) * 0.01)
         self.sustainability_index = min(1.0, self.sustainability_index + action.get("green_shift", 0.0) * 0.02)
 
+    def _compute_thermodynamic_metrics(self) -> dict[str, float]:
+        """Compute free-energy inspired metrics for the simulated economy."""
+
+        order_parameter = (self.prosperity_index + self.sustainability_index) / 2.0
+        order_parameter = min(1.0 - 1e-6, max(1e-6, order_parameter))
+        entropy = -(
+            order_parameter * math.log(order_parameter)
+            + (1.0 - order_parameter) * math.log(1.0 - order_parameter)
+        )
+        temperature = 1.0 + (1.0 - self.sustainability_index)
+        internal_energy = self.energy_output_gw / 1_000_000.0
+        free_energy = internal_energy - temperature * entropy
+        hamiltonian = -internal_energy * order_parameter
+        coordination_index = 1.0 - abs(self.prosperity_index - self.sustainability_index)
+        coordination_index = min(1.0, max(0.0, coordination_index))
+        return {
+            "free_energy": free_energy,
+            "entropy": entropy,
+            "hamiltonian": hamiltonian,
+            "coordination_index": coordination_index,
+        }
+
     def tick(self, hours: float) -> SimulationState:
         drift = hours / 24
         self.energy_output_gw *= 1.0 + 0.0001 * drift
         self.prosperity_index = min(1.0, self.prosperity_index + 0.0005 * drift)
         self.sustainability_index = min(1.0, self.sustainability_index + 0.0004 * drift)
+        metrics = self._compute_thermodynamic_metrics()
         return SimulationState(
             energy_output_gw=self.energy_output_gw,
             prosperity_index=self.prosperity_index,
             sustainability_index=self.sustainability_index,
+            free_energy=metrics["free_energy"],
+            entropy=metrics["entropy"],
+            hamiltonian=metrics["hamiltonian"],
+            coordination_index=metrics["coordination_index"],
         )
-

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.simulation import SyntheticEconomySim
+
+
+def test_simulation_thermodynamic_metrics() -> None:
+    sim = SyntheticEconomySim()
+    state = sim.tick(hours=1.0)
+
+    order_parameter = (state.prosperity_index + state.sustainability_index) / 2.0
+    order_parameter = min(1.0 - 1e-6, max(1e-6, order_parameter))
+    entropy = -(
+        order_parameter * math.log(order_parameter)
+        + (1.0 - order_parameter) * math.log(1.0 - order_parameter)
+    )
+    temperature = 1.0 + (1.0 - state.sustainability_index)
+    internal_energy = state.energy_output_gw / 1_000_000.0
+    free_energy = internal_energy - temperature * entropy
+    hamiltonian = -internal_energy * order_parameter
+    coordination_index = 1.0 - abs(state.prosperity_index - state.sustainability_index)
+
+    assert state.entropy == pytest.approx(entropy)
+    assert state.free_energy == pytest.approx(free_energy)
+    assert state.hamiltonian == pytest.approx(hamiltonian)
+    assert state.coordination_index == pytest.approx(coordination_index)
+    assert 0.0 <= state.coordination_index <= 1.0


### PR DESCRIPTION
### Motivation
- Introduce richer, physics-inspired signals to the planetary-scale demo so resource scaling and coordination are grounded in interpretable metrics.
- Provide a minimal but principled free-energy / entropy style model to inform orchestration decisions and telemetry.
- Surface coordination and Hamiltonian-like signals to enable downstream policy or game-theoretic reasoning in the orchestrator.

### Description
- Add thermodynamic/coordination metrics to the simulation by extending `SimulationState` and implementing `_compute_thermodynamic_metrics` in `simulation.py` and populating them in `SyntheticEconomySim.tick`.
- Consume the new metrics in the orchestrator by adapting `Orchestrator._simulation_loop` to bias energy and compute scaling with `free_energy` and `coordination_index`, and include the metrics in simulation telemetry snapshots.
- Add a unit test `tests/test_simulation_metrics.py` that validates the computed `entropy`, `free_energy`, `hamiltonian`, and `coordination_index` against the expected formulas.

### Testing
- Ran `pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests"` which executed the demo suite including the new `test_simulation_metrics.py` and all tests passed (15 passed).
- Verified the demo CLI and orchestrator smoke paths by running the demo entrypoint with a short run (`python -m demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo --cycles 1 --no-sim`) and observed normal shutdown behavior.
- Existing demo test suites for related demos were also run to ensure no regressions, and their tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b287f7bc88333a9e2b824a0a1d443)