### PR TITLE
Fix Kardashev II dashboard telemetry rendering

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -56,6 +56,16 @@
           <p>Status: <span id="energy-monte-carlo-status">…</span></p>
         </article>
         <article class="card">
+          <h2>Thermodynamic reserve</h2>
+          <ul class="thermo-list">
+            <li id="thermo-free-energy">…</li>
+            <li id="thermo-hamiltonian">…</li>
+            <li id="thermo-entropy">…</li>
+            <li id="thermo-game">…</li>
+            <li id="thermo-gibbs">…</li>
+          </ul>
+        </article>
+        <article class="card">
           <h2>Live energy feeds</h2>
           <p id="energy-feed-compliance">…</p>
           <p id="energy-feed-latency">…</p>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
@@ -8,6 +8,10 @@ Generated: 2125-01-01T19:05:39.398Z
 - **Dyson Swarm Progress:** 2669/10000 satellites assembled (26.69% coverage).
 - **Captured Power:** 120,105 MW available for reallocation.
 - **Energy Monte Carlo:** 3.91% breach probability across 256 runs (tolerance 5.00%).
+- **Free Energy Margin:** 13478.69 GW (5.57%) vs 11980.00 GW minimum buffer.
+- **Entropy Buffer:** 2.69σ thermodynamic headroom; game-theoretic slack 75.7%.
+- **Thermodynamic Reserve:** 48,523,291.36 GJ Gibbs free energy; Hamiltonian stability 50.8% across the sampled phase space.
+- **Gibbs Allocation Temperature:** 0.49 (lower favors resilience-heavy shards); Nash welfare 9.99%.
 - **Sentinel Status:** 3 advisories generated; all resolved within guardian SLA.
 
 ## Shard Operations
@@ -17,6 +21,14 @@ Generated: 2125-01-01T19:05:39.398Z
 | earth   | 668,431      | 133               | 6 min          | 0.999      | 99.54%             |
 | mars    | 112,364      | 120               | 17 min         | 0.999      | 98.73%             |
 | orbital | 600,104      | 120               | 6 min          | 0.999      | 99.16%             |
+
+## Thermodynamic Allocation Policy
+
+| Shard   | Boltzmann Weight | Recommended GW | Nash Payoff |
+| ------- | ---------------- | -------------- | ----------- |
+| earth   | 33.4%            | 80,942.25      | 0.1         |
+| mars    | 33.0%            | 79,739.29      | 0.1         |
+| orbital | 33.6%            | 81,318.46      | 0.1         |
 
 ## Sentinel Advisories
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css
@@ -40,6 +40,20 @@ h1 {
   gap: 16px;
 }
 
+.thermo-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.95rem;
+}
+
+.thermo-list li {
+  color: rgba(226, 232, 240, 0.85);
+}
+
 .card {
   background: var(--card-bg);
   border: 1px solid rgba(148, 163, 184, 0.25);


### PR DESCRIPTION
### Motivation
- Make the Kardashev-II dashboard tolerant to partial or variant telemetry payloads so the UI does not break when generated artefacts change shape. 
- Surface key thermodynamic metrics (free energy, Hamiltonian stability, entropy, game-theoretic slack, Gibbs reserve) so operators can see physical / game-theoretic signals at-a-glance. 
- Follow defensive UI best-practices: normalize incoming data, show clear "unavailable" states, and avoid uncaught exceptions during bootstrap. 

### Description
- Normalize telemetry with a new `normalizeTelemetry` helper and small utilities (`isNumber`, `formatOptionalNumber`, `formatOptionalPercent`, `average`) so downstream renderers receive stable shapes. 
- Hardened rendering logic in `ui/dashboard.js` to: use `setStatusUnknown` for missing values, guard DOM selectors, gracefully render empty lists, and compute sensible fallbacks for feeds/bridges. 
- Added a Thermodynamic Reserve card to `index.html` and corresponding styles in `ui/style.css` to display free energy margin, Hamiltonian stability, entropy buffer, game-theoretic slack, and Gibbs reserve. 
- Regenerated the demo artefacts via the orchestrator so outputs and README parity remain consistent (`output/kardashev-report.md` updated). 

### Testing
- Ran the orchestrator to refresh artefacts with `npm run demo:kardashev-ii:orchestrate` and confirmed artefacts were regenerated (succeeded). 
- Validated the demo CI checks with `npm run demo:kardashev-ii:ci` and confirmed the directory validation and README checks passed (succeeded). 
- Performed a local HTTP serve of the demo UI and captured a dashboard screenshot to verify client-side rendering and the new thermodynamic card (manual render verified). 
- Note: an initial `--check` run flagged a telemetry drift until artefacts were regenerated, which was resolved by rerunning the orchestrator prior to final CI validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b4e984800833392bc159b3e5e891b)