### PR TITLE
Enable fast defaults in supreme demo wrapper

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/run_demo.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/run_demo.py
@@ -15,11 +15,12 @@ import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
-# Keep demos fast and deterministic when no CLI arguments are provided and the
-# fast-defaults opt-in is enabled. The canonical orchestrator defaults to an
-# infinite run with long validator delays, which can feel “stuck” in automated
-# smoke tests. These defaults execute a handful of cycles with short validation
-# windows so operators immediately see output and generated artifacts.
+# Keep demos fast and deterministic when no CLI arguments are provided unless
+# fast defaults are explicitly disabled. The canonical orchestrator defaults to
+# an infinite run with long validator delays, which can feel “stuck” in
+# automated smoke tests. These defaults execute a handful of cycles with short
+# validation windows so operators immediately see output and generated
+# artifacts.
 DEFAULT_DEMO_ARGS = [
     "--cycles",
     "6",
@@ -80,8 +81,9 @@ def run(argv: Optional[Iterable[str]] = None, *, main_fn=None) -> None:
     """
 
     argv_list = sys.argv[1:] if argv is None else list(argv)
-    use_fast_defaults = os.getenv(FAST_DEFAULTS_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
-    if not argv_list and use_fast_defaults:
+    raw_fast_defaults = os.getenv(FAST_DEFAULTS_ENV, "").strip().lower()
+    disable_fast_defaults = raw_fast_defaults in {"0", "false", "no", "off"}
+    if not argv_list and not disable_fast_defaults:
         argv_list = DEFAULT_DEMO_ARGS.copy()
         print(
             "🛰️  Launching Supreme Omega-grade demo with fast defaults "


### PR DESCRIPTION
### Motivation
- Ensure the Supreme demo launches with short, deterministic defaults when no CLI arguments are provided so CI/smoke tests do not hang in long or infinite runs.
- Fix a regression where fast-demo defaults required an opt-in and caused wrapper tests to fail.
- Allow operators to explicitly opt-out of the fast defaults via an environment flag while keeping a frictionless developer experience.

### Description
- Updated `demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/run_demo.py` to treat `AGI_SUPREME_FAST_DEFAULTS` as a disable flag so fast defaults are applied by default unless the env is set to `0/false/no/off`.
- Replaced the previous opt-in boolean check with `raw_fast_defaults`/`disable_fast_defaults` logic and apply `DEFAULT_DEMO_ARGS` when no CLI args are provided and fast defaults are not disabled.
- Clarified the inline documentation to reflect the new default-fast behavior.
- Preserved existing CLI delegation and `sys.path` handling so package `run_from_cli` remains unchanged.

### Testing
- Ran `pytest -q demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/tests/test_run_demo_wrapper.py` which completed successfully (`4 passed`).
- Verified the targeted regression is resolved by re-running the failing wrapper test that previously caused the demo test-run to report a failed suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b5a87c180833388dda94657f3ff9e)