### PR TITLE
Add simulation control actions and policy-driven updates to Omega demo

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
+
+
+def test_simulation_action_updates_resources() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
+    assert orchestrator.simulation is not None
+
+    initial_capacity = orchestrator.resources.energy_capacity
+
+    asyncio.run(
+        orchestrator._handle_simulation_action(
+            {
+                "action_payload": {
+                    "build_dyson_nodes": 2,
+                    "stimulus": 3.0,
+                    "green_shift": 1.0,
+                }
+            }
+        )
+    )
+
+    assert orchestrator._latest_simulation_state is not None
+    assert orchestrator.resources.energy_capacity >= initial_capacity
+    assert orchestrator._last_simulation_action is not None
+    assert orchestrator._last_simulation_action["action"]["build_dyson_nodes"] == 2.0
+
+
+def test_simulation_policy_auto_generates_action() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
+    assert orchestrator.simulation is not None
+
+    asyncio.run(orchestrator._handle_simulation_action({"policy": "auto"}))
+
+    assert orchestrator._last_simulation_action is not None
+    assert orchestrator._last_simulation_action["policy"] == "auto"
+    assert "build_dyson_nodes" in orchestrator._last_simulation_action["action"]


### PR DESCRIPTION
### Motivation

- Provide a programmable control surface for the Omega-grade planetary simulation so operators can apply actions or let an auto-policy determine actions. 
- Surface thermodynamic-inspired signals (free energy, Hamiltonian, coordination) into resource/accounting decisions to keep simulation → resource coupling deterministic and testable. 
- Reduce duplication by centralizing simulation-state application and make action effects observable and auditable. 
- Enable automated policies (using simple statistical-physics / game-theoretic heuristics) to produce sensible default actions when operators request `policy` driven behavior.

### Description

- Add an abstract `apply_action` to `PlanetarySimulation` and implement `SyntheticEconomySim.apply_action` to mutate state and return a `SimulationState` snapshot via a new `_snapshot_state` helper. 
- Introduce `_apply_simulation_state` in `Orchestrator` to centralize state->resource updates and logging, and add `_last_simulation_action` to track the most-recent applied simulation action. 
- Implement control handling for simulation updates via `_handle_simulation_action` plus helpers `
`_normalize_simulation_action` and `_build_policy_action` which derive actions using Gibbs/Hamiltonian/temperature-style weighting and coordination damping. 
- Persist and expose the last applied action in status snapshots and add `demo/.../tests/test_simulation_actions.py` with coverage for manual and auto-policy application.

### Testing

- Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests` and all tests passed (10 passed). 
- Existing demo unit tests in the modified demo continue to pass after the changes. 
- Exercised the CLI entrypoint paths during manual runs to ensure compatibility with both `run_demo.py` and `python -m demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b73c443d08333b9edd66b0e160e0f)