### PR TITLE
Make Supreme demo fast-defaults opt-in and non-surprising

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/run_demo.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/run_demo.py
@@ -15,12 +15,11 @@ import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
-# Keep demos fast and deterministic when no CLI arguments are provided unless
-# fast defaults are explicitly disabled. The canonical orchestrator defaults to
-# an infinite run with long validator delays, which can feel “stuck” in
-# automated smoke tests. These defaults execute a handful of cycles with short
-# validation windows so operators immediately see output and generated
-# artifacts.
+# Keep demos fast and deterministic when explicitly requested. The canonical
+# orchestrator defaults to an infinite run with long validator delays, which can
+# feel “stuck” in automated smoke tests. These defaults execute a handful of
+# cycles with short validation windows so operators immediately see output and
+# generated artifacts without surprising CLI callers.
 DEFAULT_DEMO_ARGS = [
     "--cycles",
     "6",
@@ -80,10 +79,15 @@ def run(argv: Optional[Iterable[str]] = None, *, main_fn=None) -> None:
             underlying package state.
     """
 
+    argv_provided = argv is not None
     argv_list = sys.argv[1:] if argv is None else list(argv)
     raw_fast_defaults = os.getenv(FAST_DEFAULTS_ENV, "").strip().lower()
-    disable_fast_defaults = raw_fast_defaults in {"0", "false", "no", "off"}
-    if not argv_list and not disable_fast_defaults:
+    fast_defaults_env = raw_fast_defaults in {"1", "true", "yes", "on"}
+    fast_defaults_flag = "--fast-defaults" in argv_list
+    if fast_defaults_flag:
+        argv_list = [arg for arg in argv_list if arg != "--fast-defaults"]
+
+    if not argv_list and (fast_defaults_env or fast_defaults_flag or argv_provided):
         argv_list = DEFAULT_DEMO_ARGS.copy()
         print(
             "🛰️  Launching Supreme Omega-grade demo with fast defaults "


### PR DESCRIPTION
### Motivation

- Prevent the Supreme demo wrapper from surprising CLI callers by injecting fast defaults only when explicitly requested.
- Preserve convenient short-run behavior for automated tests and programmatic callers while avoiding implicit mutation of user-supplied invocation semantics.
- Provide both environment (`AGI_SUPREME_FAST_DEFAULTS`) and CLI (`--fast-defaults`) opt-in mechanisms for clarity.

### Description

- Updated `demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/run_demo.py` to require explicit opt-in before supplying `DEFAULT_DEMO_ARGS` when no arguments are present. 
- Added parsing for an opt-in `--fast-defaults` flag and tightened environment acceptance to truthy values (`1`, `true`, `yes`, `on`).
- Treats an explicit API call with an empty `argv` (i.e. `run(argv=[])`) as an intentional request to receive fast defaults, while no longer forcing defaults for plain CLI invocations without opt-in.
- Keeps existing behavior for wiring `REPO_ROOT`/`DEMO_ROOT` into `sys.path` and for delegating to the package `main`/`run_from_cli` entrypoints.

### Testing

- Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/tests/test_run_demo_wrapper.py -q` and the suite passed (4 tests).
- Ran `pytest demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/tests/test_supreme_run_demo.py -q` and the suite passed (4 tests).
- Ran the full demo test suite `pytest demo -q` and all tests passed (302 tests).
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bd5d3459c83339751eda2894a9fec)