### PR TITLE
Enhance Kardashev II allocation entropy metrics

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
@@ -37,7 +37,8 @@ def _build_command(args: argparse.Namespace) -> list[str]:
     cmd = [_ensure_node_available(), str(NODE_SCRIPT)]
     if args.output_dir:
         output_dir = Path(args.output_dir).expanduser().resolve()
-        output_dir.mkdir(parents=True, exist_ok=True)
+        if not args.check:
+            output_dir.mkdir(parents=True, exist_ok=True)
         cmd.extend(["--output-dir", str(output_dir)])
     if args.check:
         cmd.append("--check")

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -60,6 +60,11 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert energy["entropyMargin"] > 0
     assert 0 <= energy["gameTheorySlack"] <= 1
 
+    allocation = telemetry_payload["allocationPolicy"]
+    assert allocation["allocationEntropy"] >= 0
+    assert 0 < allocation["fairnessIndex"] <= 1
+    assert allocation["gibbsPotential"] <= 0
+
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
 def test_run_demo_rejects_invalid_energy_feed(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Improve the Kardashev-II allocation policy with information-theoretic and thermodynamic summaries to make allocation decisions more interpretable and robust.
- Avoid unwanted filesystem side-effects when running the demo in validation/check mode so CI and contributors can run checks without creating output directories.
- Surface the new allocation metrics in the generated report and telemetry so downstream dashboards and tests can assert on them.
- Keep the demo's governance artefact references correct and relative to the generated output directory for reproducible operator workflows.

### Description
- Extend `softmaxScores` to return both normalized `weights` and the `partition` constant and update `computeAllocationPolicy` to compute `allocationEntropy`, `fairnessIndex`, and `gibbsPotential` and include them in the returned policy object.
- Add allocation entropy/fairness/Gibbs potential to the dossier `kardashev-report.md` and include a compact `Thermodynamic Allocation Policy` table of computed Boltzmann weights and recommended GW allocations.
- Make the Python wrapper `run_demo.py` refrain from creating the output directory when invoked with `--check` to preserve check-mode side-effect free behavior by only creating the directory when not in check mode.
- Write the Dyson mermaid hierarchy to a deterministic path and reference it via a relative path in the report for correct UI/dashboard ingestion.

### Testing
- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` which executed the demo wrapper and assertions against produced telemetry and the new allocation fields, and all tests passed (3 passed).
- Executed the demo wrapper directly with `python demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py` to validate runtime output and observed successful dossier generation with the new metrics included.
- The change set was sanity-checked against the demo CI runner used earlier in the session where all demo suites had previously passed, and no regressions were introduced for the modified module.
- No automated tests failed during verification of the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bf13d5b288333afd35f75c7a43637)