### PR TITLE
Improve Supreme demo thermodynamic telemetry and default fast-launch behavior

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/orchestrator.py
@@ -415,6 +415,11 @@ class SupremeOrchestrator(SupremeOrchestratorProtocol):
                         "energy_output": state.energy_output,
                         "compute_output": state.compute_output,
                         "stress_index": state.stress_index,
+                        "gibbs_free_energy": state.gibbs_free_energy,
+                        "entropy": state.entropy,
+                        "hamiltonian": state.hamiltonian,
+                        "coordination_index": state.coordination_index,
+                        "temperature": state.temperature,
                         "narrative": state.narrative,
                     },
                 )

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_supreme_run_demo.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_supreme_run_demo.py
@@ -74,16 +74,22 @@ def test_run_as_script_uses_package_main(monkeypatch):
     def fake_main(argv):
         captured["argv"] = argv
 
+    real_import_module = importlib.import_module
+
     def fake_import(name):
-        assert name == "demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme"
-        return SimpleNamespace(main=fake_main)
+        if name == "demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme":
+            return SimpleNamespace(main=fake_main)
+        return real_import_module(name)
 
     monkeypatch.setattr(importlib, "import_module", fake_import)
     monkeypatch.setattr(sys, "argv", [str(script_path)])
 
+    module = importlib.import_module(
+        "demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme.run_demo"
+    )
     runpy.run_path(str(script_path), run_name="__main__")
 
-    assert captured["argv"] == []
+    assert captured["argv"] == module.DEFAULT_DEMO_ARGS
     assert str(repo_root) in sys.path
 
 

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_supreme_simulation_metrics.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_supreme_simulation_metrics.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme.simulation import (
+    SyntheticEconomySim,
+)
+
+
+def test_supreme_simulation_thermodynamics_are_consistent() -> None:
+    sim = SyntheticEconomySim(
+        population=7_500_000_000,
+        energy_output=1_250_000.0,
+        compute_output=4_000_000.0,
+        stress_index=0.2,
+    )
+
+    state = sim.get_state()
+
+    order_parameter = 1.0 - state.stress_index
+    order_parameter = min(1.0 - 1e-6, max(1e-6, order_parameter))
+    entropy = -(
+        order_parameter * math.log(order_parameter)
+        + (1.0 - order_parameter) * math.log(1.0 - order_parameter)
+    )
+    temperature = 1.0 + state.stress_index
+    internal_energy = (state.energy_output / 1_000_000.0) + (state.compute_output / 2_000_000.0)
+    gibbs_free_energy = internal_energy - temperature * entropy
+    hamiltonian = -internal_energy * order_parameter
+    total_output = state.energy_output + state.compute_output
+    balance = state.energy_output / total_output
+    coordination_index = 1.0 - abs(balance - 0.5) * 2.0
+
+    assert state.entropy == pytest.approx(entropy)
+    assert state.temperature == pytest.approx(temperature)
+    assert state.gibbs_free_energy == pytest.approx(gibbs_free_energy)
+    assert state.hamiltonian == pytest.approx(hamiltonian)
+    assert state.coordination_index == pytest.approx(coordination_index)
+    assert 0.0 <= state.coordination_index <= 1.0

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/run_demo.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/run_demo.py
@@ -87,7 +87,17 @@ def run(argv: Optional[Iterable[str]] = None, *, main_fn=None) -> None:
     if fast_defaults_flag:
         argv_list = [arg for arg in argv_list if arg != "--fast-defaults"]
 
-    if not argv_list and (fast_defaults_env or fast_defaults_flag or argv_provided):
+    full_run_flag = "--full-run" in argv_list
+    if full_run_flag:
+        argv_list = [arg for arg in argv_list if arg != "--full-run"]
+
+    use_fast_defaults = False
+    if not argv_list:
+        use_fast_defaults = not full_run_flag
+    if fast_defaults_env or fast_defaults_flag:
+        use_fast_defaults = True
+
+    if use_fast_defaults and not argv_list:
         argv_list = DEFAULT_DEMO_ARGS.copy()
         print(
             "🛰️  Launching Supreme Omega-grade demo with fast defaults "


### PR DESCRIPTION
### Motivation
- Provide richer physical/thermodynamic telemetry for the Supreme demo so operators and tests can reason about Gibbs free energy, entropy and Hamiltonian-inspired diagnostics.
- Make the Supreme demo wrapper more ergonomic for fast smoke runs by defaulting to a short, deterministic configuration unless an explicit `--full-run` is requested. 
- Surface the new metrics in orchestrator logs so downstream observers (dashboards / metrics snapshots) receive consistent signals.
- Add tests to lock in the new metrics and the adjusted launch behaviour.

### Description
- Add `gibbs_free_energy`, `entropy`, `hamiltonian`, `coordination_index`, and `temperature` fields to `PlanetaryState` and compute them in `SyntheticEconomySim._compute_thermodynamic_metrics`.
- Populate those metrics on `apply_action` / `get_state` and persist each state record to the simulation log.
- Emit the new thermodynamic metrics from the Supreme orchestrator simulation loop in `orchestrator._simulation_loop` so they appear in structured telemetry events.
- Change the Supreme demo wrapper (`run_demo.py`) to apply fast defaults by default and only skip them if `--full-run` is explicitly passed, while preserving `--fast-defaults` and the environment toggle.
- Add `test_supreme_simulation_metrics.py` to validate the thermodynamic calculations and update `test_supreme_run_demo.py` to reflect the new default-argument behaviour.

### Testing
- Ran `pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests"` and all tests passed (`16 passed`).
- Ran the demo wrapper smoke run `python demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/run_demo.py --cycles 1` during investigation to verify runtime telemetry (manual run showed expected log entries).
- Existing demo test runner (`demo/tests` and the individual demo suites used earlier during the rollout) remained green for the modified suites that were executed.
- New unit test `test_supreme_simulation_metrics.py` was added and included in the passing test run above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bf95e6b2c83339c10c621d723cf81)