### PR TITLE
Enhance Kardashev-II demo: route to orchestrator, add thermodynamic Monte Carlo metrics, regenerate outputs

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/governance-playbook.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/governance-playbook.md
@@ -1,13 +1,170 @@
-# Kardashev II Governance Playbook
+# Kardashev II Orchestration Runbook
 
-1. **Pause orchestration:** Execute `forwardPauseCall(SystemPause.PAUSE_ALL)` from the multisig, verify sentinels acknowledge, then resume with `forwardPauseCall(SystemPause.UNPAUSE_ALL)` once the guardian quorum signs.
-2. **Retune guardrails:**
-   - Set `guardianReviewWindow` to `900` seconds for interplanetary latency.
-   - Adjust `globalAutonomyFloorBps` to `8500` to unlock orbital autonomy.
-   - Update `energyOracle` to the live telemetry endpoint defined in `config/energy-feeds.json`.
-   - Confirm `knowledgeGraph` pointer matches the knowledge mesh contract.
-3. **Identity operations:** Register new agents via ENS + DID bundles, rotate certificates for Mars sentinels, and revoke stale identities; rerun `npm run demo:kardashev` to ensure reputation dispersion < 0.7 Gini.
-4. **Capital stream oversight:** Call `configureCapitalStream` for each domain to reflect the captured MW; confirm RewardEngineMB temperature cooled by ≥4%.
-5. **Manifest evolution:** Upload the new manifesto to IPFS, call `updateManifesto(uri, hash)`, then append a fresh self-improvement cadence with zk-proof placeholders recorded.
+**Manifest hash**: 0x96c86f0f4ff7f3c7ee017c892efcc7f43774e16019c2356298d0151e24694f1c
+**Dominance score**: 90.0 / 100
 
-All actions are auditable; copy/paste-ready commands are available via `npm run demo:kardashev -- --print-commands`.
+---
+
+## Governance actions
+1. Load `output/kardashev-safe-transaction-batch.json` into Safe (or timelock). 
+2. Verify manager, guardian council, and system pause addresses in review modals.
+3. Stage pause + resume transactions but leave them unsent until incident drills.
+4. Confirm self-improvement plan hash matches guardian-approved digest.
+5. Confirm unstoppable owner score 100.00% (pause true, resume true, secondary corroboration aligned @ 100.00%, tertiary decode aligned @ 100.00% · decode failures 0).
+
+---
+
+## Energy telemetry
+* Captured GW (Dyson baseline): 420,000 GW.
+* Utilisation: 57.62% (margin 0.13%).
+* Regional availability: earth 82000 GW · mars 24000 GW · orbital 136000 GW.
+* Monte Carlo breach probability 0.00% (runs 256, tolerance 1.00%).
+* Free energy margin 167810.86 GW (39.95%) · Gibbs free energy 604119100.38 GJ.
+* Hamiltonian stability 70.0% · entropy buffer 17.73σ · game-theoretic slack 86.5%.
+* Demand percentiles: P95 252,189.139 GW · P99 255,160.811 GW.
+* Live feeds (≤ 5%): earth-grid Δ 0.00% · mars-dome Δ 0.00% · orbital-swarm Δ 0.00%.
+* Feed latency: avg 241467 ms · max 720000 ms (calibrated 2025-02-28T18:00:00Z).
+* Energy window coverage 100.00% (threshold 98%) · reliability 98.56%.
+* Energy window deficits: none — all federations meet coverage targets.
+
+---
+
+## Logistics corridors
+* 3 corridors · avg reliability 98.50% · avg utilisation 82.00% · min buffer 14.00 days.
+* Watcher coverage: 9 unique sentinels; verification ✅.
+* Capacity 2,010,000 tonnes/day · throughput 1,677,600 tonnes/day · energy 363,000 MWh.
+* Logistics advisories: none — buffers and reliability nominal.
+
+---
+
+## Compute & domains
+* Aggregate compute 49.10 EF · 4,480,000,000 agents · deviation 0.45% (≤ 0.75%).
+* **EARTH** – 18.40 EF, 2,800,000,000 agents, resilience 94.50%.
+* **MARS** – 6.10 EF, 720,000,000 agents, resilience 93.50%.
+* **ORBITAL** – 24.60 EF, 960,000,000 agents, resilience 95.90%.
+
+---
+
+## Mission lattice & task hierarchy
+* 3 programmes · 26 tasks · 2,441,200 GW · 261.90 EF.
+* Unstoppable score 94.44% · dependencies resolved true · sentinel coverage true.
+* Lead programme Dyson Swarm Expansion Programme (orbital) — 17 tasks, 2173200 GW, unstoppable 83.33%.
+* ⚠ Mission advisories: dyson-swarm autonomy exceeds max 7800 bps
+
+---
+
+## Identity lattice
+* Root authority 0x4c9fa72be46de83f2d15d6e4e4d3b21f7ac1b0d2 · Merkle root 0x2b3aa7c0c2a715f3a4d19c6b7d8f4e90c214a8c1b3d4e56f7a8b9c0d1e2f3a45.
+* 3/3 federations at quorum 5; revocation 0.35 ppm (≤ 120 ppm).
+* Average attestation latency 55s (window 240s).
+* **Earth Identity Mesh** – DID did:agi:earth · anchors 5 · coverage 97.00%.
+* **Mars Identity Council** – DID did:agi:mars · anchors 5 · coverage 94.50%.
+* **Orbital Identity Halo** – DID did:agi:orbital · anchors 5 · coverage 96.30%.
+
+---
+
+## Compute fabric orchestrators
+* Total plane capacity 82.50 EF · failover 44.50 EF (quorum 42.90 EF).
+* Average availability 98.23% · failover within quorum: true.
+* **Solara Earth Core** (Earth orbit low-latency ring) – scheduler 0x2f4a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f34, capacity 38.00 EF, latency 38 ms, availability 98.60%, failover partner sol-mars.
+* **Ares Horizon Fabric** (Mars synchronous polar array) – scheduler 0x4d6e8f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d61, capacity 18.50 EF, latency 112 ms, availability 97.20%, failover partner sol-orbital.
+* **Helios Orbital Halo** (Dyson swarm maintenance lattice) – scheduler 0x7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e78, capacity 26.00 EF, latency 24 ms, availability 98.90%, failover partner sol-earth.
+* Sharded registry fabric health — domains aligned, sentinels aligned, federations aligned.
+* Fabric latency: avg 240413 ms · max 720000 ms.
+
+---
+
+## Scenario stress sweep
+* **20% demand surge vs Dyson safety margin** — status NOMINAL (confidence 100.0%) · Dyson lattice absorbs surge with 129,600 GW spare.
+  - Simulated demand: 290,400 GW (ok)
+  - Remaining buffer: 129,600 GW (ok)
+  - Thermostat margin: 52,500 GW (ok)
+  - Utilisation: 69.14% (ok)
+  - Recommended: Dispatch pause bundle for non-critical Earth workloads. · Increase stellar thermostat target via setGlobalParameters if surge persists.
+* **Interplanetary bridge outage simulation** — status WARNING (confidence 25.0%) · Failover latency 180s breaches 120s failsafe.
+  - Baseline latency: 90s (ok)
+  - Failover latency: 180s (check)
+  - Failsafe budget: 120s (ok)
+  - Slack: -60s (check)
+  - Recommended: Execute bridge isolation routine from mission directives if slack < 0. · Rebalance capital streams to spin up orbital relays before load crosses failsafe.
+* **Sentinel outage (10 min) coverage test** — status NOMINAL (confidence 100.0%) · Guardian window stays protected under sentinel gap.
+  - Minimum sentinel coverage: 1800s (ok)
+  - Simulated coverage: 1200s (ok)
+  - Guardian window: 900s (ok)
+  - Coverage ratio: 133.33% (ok)
+  - Recommended: Register standby sentinel via Safe batch if ratio < 100%. · Shorten guardian drill cadence until redundancy restored.
+* **Compute drawdown (15%) resilience** — status WARNING (confidence 35.0%) · Deviation 14.62% exceeds tolerance 0.75%.
+  - Projected compute: 48.88 EF (ok)
+  - Stressed compute: 41.73 EF (check)
+  - Deviation: 14.62% (check)
+  - Tolerance: 0.75% (ok)
+  - Recommended: Authorise capital stream expansion for orbital compute nodes. · Notify guardians to ratify temporary autonomy reduction if deviation persists.
+* **Dyson phase slip (30 days)** — status NOMINAL (confidence 95.0%) · Schedule buffer absorbs slip with 490 days remaining.
+  - Total timeline: 900 days (ok)
+  - Slip: 30 days (ok)
+  - Remaining buffer: 490 days (ok)
+  - Slip ratio: 3.33% (ok)
+  - Recommended: Accelerate self-improvement plan execution to reclaim schedule slack. · Reallocate capital from Earth infrastructure to Dyson assembly for this epoch.
+* **Primary energy window offline** — status CRITICAL (confidence 82.2%) · Removing orbital 8h window drops coverage to 80.58%.
+  - Removed window: orbital @ 0h (check)
+  - Remaining coverage: 80.58% (check)
+  - Threshold: 98.00% (ok)
+  - Lost capacity: 1128000.00 GW·h (check)
+  - Recommended: Trigger orbital battery discharge if coverage < threshold. · Re-route Mars workloads to orbital halo until replacement window is provisioned.
+* **Logistics demand spike (+25%)** — status WARNING (confidence 85.7%) · Corridors absorb spike with utilisation 104.33% and buffers 12.00d.
+  - Nominal utilisation: 83.46% (ok)
+  - Stressed utilisation: 104.33% (check)
+  - Spare capacity: 332,400 tonnes/day (ok)
+  - Buffer after spike: 12.00 days (check)
+  - Recommended: Stage failover corridor encoded in manifest.failoverCorridor via Safe batch. · Increase watcher quorum on highest utilisation corridor within 12h.
+* **Settlement backlog (+40% finality)** — status WARNING (confidence 90.8%) · Settlement mesh absorbs backlog within tolerance.
+  - Sol-Earth Safe Settlement: 7.70 min (ok)
+  - Mars Credit Hub: 10.92 min (check)
+  - Orbital Lattice Clearing: 3.36 min (ok)
+  - Recommended: Activate treasury failover to orbital credit rails. · Deploy additional watchers to reduce backlog latency.
+* **Identity infiltration (3% forged daily credentials)** — status NOMINAL (confidence 100.0%) · Revocation network absorbs infiltration within tolerance.
+  - Forged credentials: 103,200 (ok)
+  - Revocation load: 23.39 ppm (ok)
+  - Tolerance: 120 ppm (ok)
+  - Anchors at quorum: 3/3 (ok)
+  - Recommended: Execute fallback ENS registrar policy if forged rate exceeds tolerance. · Rotate identity anchors using Safe batch identity transactions.
+* **Live energy feed drift shock** — status NOMINAL (confidence 100.0%) · Live feeds remain within tolerance bands.
+  - Max drift: 0.00% (ok)
+  - Tolerance: 5% (ok)
+  - Drift alert: 8.5% (ok)
+  - Average latency: 241467 ms (check)
+  - Recommended: Trigger energy oracle recalibration from mission directives. · Rebalance Dyson thermostat inputs toward the affected federation until drift subsides.
+* **Primary compute plane offline** — status NOMINAL (confidence 100.0%) · Failover capacity 44.50 EF covers quorum.
+  - Largest plane: Solara Earth Core (ok)
+  - Failover capacity: 44.50 EF (ok)
+  - Required quorum: 42.90 EF (ok)
+  - Average availability: 98.23% (ok)
+  - Recommended: Trigger failover playbook defined in compute fabrics policy. · Increase energy allocation for reserve plane from Dyson thermostat.
+
+---
+
+## Bridges
+* earthToMars: latency 90s, bandwidth 14.6 Gbps, operator 0xb12d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d.
+* earthToOrbital: latency 2s, bandwidth 240 Gbps, operator 0xd4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3.
+
+---
+
+## Settlement lattice & forex
+* Average finality 5.23 min (max 10.00 min) · coverage 96.70% (threshold 95%).
+* Watchers online 9/9 · slippage threshold 75 bps.
+* Protocols: Sol-Earth Safe Settlement — finality 5.50 min (tol 8.00 min) · coverage 98.40% · Mars Credit Hub — finality 7.80 min (tol 10.00 min) · coverage 96.70% · Orbital Lattice Clearing — finality 2.40 min (tol 4.50 min) · coverage 99.50%.
+
+---
+
+## Dyson programme
+* Seed Swarm: 1,200 satellites, 4,800 GW, 120 days.
+* Helios Halo: 6,800 satellites, 64,000 GW, 260 days.
+* Crown Array: 24,000 satellites, 420,000 GW, 520 days.
+
+---
+
+## Reflection checklist
+- [ ] Guardian coverage ≥ guardian review window.
+- [ ] Energy utilisation within safety margin.
+- [ ] Bridge latency ≤ failsafe latency.
+- [ ] Pause bundle verified on live SystemPause contract.

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-monte-carlo.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-monte-carlo.json
@@ -9,5 +9,15 @@
   "maxGw": 256900.13860232956,
   "averageGw": 236334.58660710318,
   "withinTolerance": true,
-  "tolerance": 0.01
+  "tolerance": 0.01,
+  "capturedGw": 420000,
+  "marginGw": 52500,
+  "freeEnergyMarginGw": 167810.861217711,
+  "freeEnergyMarginPct": 0.3995496695659786,
+  "gibbsFreeEnergyGj": 604119100.3837596,
+  "hamiltonianStability": 0.6997748347829893,
+  "entropyMargin": 17.733813250187428,
+  "gameTheorySlack": 0.8648986756523452,
+  "demandStdDevGw": 9462.762399166317,
+  "maintainsBuffer": true
 }

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
@@ -19,6 +19,8 @@
 * Utilisation: 57.62% (margin 0.13%).
 * Regional availability: earth 82000 GW · mars 24000 GW · orbital 136000 GW.
 * Monte Carlo breach probability 0.00% (runs 256, tolerance 1.00%).
+* Free energy margin 167810.86 GW (39.95%) · Gibbs free energy 604119100.38 GJ.
+* Hamiltonian stability 70.0% · entropy buffer 17.73σ · game-theoretic slack 86.5%.
 * Demand percentiles: P95 252,189.139 GW · P99 255,160.811 GW.
 * Live feeds (≤ 5%): earth-grid Δ 0.00% · mars-dome Δ 0.00% · orbital-swarm Δ 0.00%.
 * Feed latency: avg 241467 ms · max 720000 ms (calibrated 2025-02-28T18:00:00Z).

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
@@ -1,48 +1,57 @@
-# Kardashev II Scale Control Dossier
+# Kardashev II Operator Briefing
 
-Generated: 2125-01-01T19:05:39.398Z
+## Owner powers
+- **Pause & resume entire civilisation mesh** (Safe step #0) — Execute forwardPauseCall(pauseAll/unpauseAll) from the Safe batch to freeze or relaunch all federations. · Playbook: ipfs://QmKardashevPauseProtocol
+- **Upgrade governance parameters** (Safe step #1) — Use setGlobalParameters + setGuardianCouncil transactions to roll new addresses, rate limits, or manifests. · Playbook: ipfs://QmKardashevUpgradeProtocol
+- **Deploy or reconfigure a domain** (Safe step #4) — Register domains, sentinels, and capital streams in one action bundle; review autonomy levels before execution. · Playbook: ipfs://QmKardashevDomainProtocol
 
-## Executive Summary
+## Escalation pathways
+* Guardians: guardian@agi.jobs · Ops: +1-800-AGI-JOBS
+* Status page: https://status.agi.jobs/kardashev
+* Bridge failover: Trigger bridge isolation routine if latency exceeds failsafe for 3 consecutive intervals.
 
-- **Universal Dominance Score:** 99.9/100 (targets met across all shards).
-- **Dyson Swarm Progress:** 2669/10000 satellites assembled (26.69% coverage).
-- **Captured Power:** 120,105 MW available for reallocation.
-- **Energy Monte Carlo:** 3.91% breach probability across 256 runs (tolerance 5.00%).
-- **Sentinel Status:** 3 advisories generated; all resolved within guardian SLA.
+## Drill cadence
+* Pause drill every 6h · Guardian review window 12 minutes.
+* Next scheduled drill: 2025-03-02T12:00:00Z
 
-## Shard Operations
+## Verification status
+* Energy models (regionalSum, dysonProjection, thermostatBudget) aligned: true
+* Monte Carlo breach 0.00% (≤ 1% tolerance): true
+* Energy window coverage 100.00% (threshold 98%) · reliability 98.56%.
+* Compute deviation 0.45% (tolerance 0.75%): true
+* Energy feed drift ≤ 5%: true
+* Bridge latency tolerance (120s): true
+* Settlement finality 5.23 min (max 10.00 min) · slippage threshold 75 bps.
+* Logistics corridors 3 active — avg reliability 98.50% · min buffer 14.00d · watchers 9 (nominal).
+* Mission unstoppable 94.44% across 3 programmes (dependencies resolved true).
+* Mission advisories: dyson-swarm autonomy exceeds max 7800 bps
+* Owner override unstoppable score 100.00% (selectors true, pause true, resume true, secondary aligned @ 100.00%, tertiary aligned @ 100.00% · decode failures 0).
+* Scenario sweep: 6/11 nominal, 4 warning, 1 critical.
+  - Interplanetary bridge outage simulation: Failover latency 180s breaches 120s failsafe.
+  - Compute drawdown (15%) resilience: Deviation 14.62% exceeds tolerance 0.75%.
+  - Primary energy window offline: Removing orbital 8h window drops coverage to 80.58%.
+  - Logistics demand spike (+25%): Corridors absorb spike with utilisation 104.33% and buffers 12.00d.
+  - Settlement backlog (+40% finality): Settlement mesh absorbs backlog within tolerance.
+* Audit checklist: ipfs://QmKardashevAuditChecklist
 
-| Shard   | Monthly Jobs | Active Validators | Settlement Lag | Resilience | Energy Utilisation |
-| ------- | ------------ | ----------------- | -------------- | ---------- | ------------------ |
-| earth   | 668,431      | 133               | 6 min          | 0.999      | 99.54%             |
-| mars    | 112,364      | 120               | 17 min         | 0.999      | 98.73%             |
-| orbital | 600,104      | 120               | 6 min          | 0.999      | 99.16%             |
+## Identity posture
+* 3/3 federations meeting quorum 5.
+* Revocation rate 0.35 ppm (tolerance 120 ppm); latency window 96s / 240s.
+* Identity ledger delta 0 agents vs compute registry.
 
-## Sentinel Advisories
+## Compute fabric posture
+* Failover capacity 44.50 EF vs quorum 42.90 EF; within quorum true.
+* Average plane availability 98.23% (planes 3).
+* Lead plane Solara Earth Core (Earth orbit low-latency ring) capacity 38.00 EF, partner sol-mars.
+* Sharded registry fabric domains OK · sentinels OK · federations OK.
 
-### Advisory 1: earth-energy
-- Severity: moderate
-- Action: SystemPause.PAUSE_DOMAIN
-- Reason: Energy utilisation breached 92% threshold – initiating cooldown window.
-- Mean time to recovery: 14 minutes
-
-### Advisory 2: mars-energy
-- Severity: moderate
-- Action: SystemPause.PAUSE_DOMAIN
-- Reason: Energy utilisation breached 92% threshold – initiating cooldown window.
-- Mean time to recovery: 14 minutes
-
-### Advisory 3: orbital-energy
-- Severity: moderate
-- Action: SystemPause.PAUSE_DOMAIN
-- Reason: Energy utilisation breached 92% threshold – initiating cooldown window.
-- Mean time to recovery: 14 minutes
-
-## Dyson Swarm Analytics
-
-- Remaining build days: 77
-- Assembly rate: 96 satellites/day
-- Energy per satellite: 45 MW
-
-A detailed task hierarchy diagram is available at `output/mermaid/dyson-hierarchy.mmd`.
-
+## Federation snapshot
+* **Earth Sovereign Federation** (chain 1) — Safe 0xaaccfefb5b833b41c1a6ff1d4a20e2f91b9fa5c2, energy 82000 GW, compute 18.4 EF.
+  - Lead domains: Orbital Infrastructure Directorate (512.00B/mo, resilience 94.20%) · Earth Treasury Fusion (428.00B/mo, resilience 94.80%)
+  - Sentinels: Gaia Energy Sentinel
+* **Mars Terraforming Compact** (chain 534352) — Safe 0x7b0f87d532f43c4a0e7816d9d7806f48a9c3f2d1, energy 24000 GW, compute 6.1 EF.
+  - Lead domains: Mars Terraforming Directorate (298.00B/mo, resilience 93.50%)
+  - Sentinels: Ares Habitat Guardian
+* **Orbital Research Halo** (chain 42161) — Safe 0x1b3da8f56e47c29e8ceaff4b2d9c8b5d7ae2c6f4, energy 136000 GW, compute 24.6 EF.
+  - Lead domains: Orbital Defense Shield (618.00B/mo, resilience 95.70%) · Interstellar Research Nexus (452.00B/mo, resilience 96.10%)
+  - Sentinels: Orbital Solar Shield Sentinel

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
@@ -226,7 +226,17 @@
       "maxGw": 256900.13860232956,
       "averageGw": 236334.58660710318,
       "withinTolerance": true,
-      "tolerance": 0.01
+      "tolerance": 0.01,
+      "capturedGw": 420000,
+      "marginGw": 52500,
+      "freeEnergyMarginGw": 167810.861217711,
+      "freeEnergyMarginPct": 0.3995496695659786,
+      "gibbsFreeEnergyGj": 604119100.3837596,
+      "hamiltonianStability": 0.6997748347829893,
+      "entropyMargin": 17.733813250187428,
+      "gameTheorySlack": 0.8648986756523452,
+      "demandStdDevGw": 9462.762399166317,
+      "maintainsBuffer": true
     },
     "liveFeeds": {
       "calibrationISO8601": "2025-02-28T18:00:00Z",

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "demo:aurora:report": "ts-node --transpile-only demo/aurora/bin/aurora-report.ts",
     "demo:aurora:sepolia": "npx hardhat run demo/aurora/aurora.demo.ts --network sepolia",
     "demo:flagship": "demo/cosmic-omni-sovereign-symphony/bin/flagship-demo.sh",
-    "demo:kardashev": "node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs",
+    "demo:kardashev": "npm run demo:kardashev-ii:orchestrate",
     "demo:kardashev-ii-lattice:ci": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/stellar-civilization-lattice/scripts/ci-validate.ts",
     "demo:kardashev-ii-lattice:orchestrate": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/stellar-civilization-lattice/scripts/orchestrate.ts",
     "demo:kardashev-ii-omega-upgrade": "python -m kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo.cli launch --config demo/'Kardashev-II Omega-Grade-α-AGI Business-3'/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo/config/mission.json",


### PR DESCRIPTION
### Motivation
- Prevent the legacy Node wrapper from overwriting orchestrator-produced, dashboard-ready telemetry by routing the `demo:kardashev` shortcut to the orchestrator entrypoint. 
- Surface richer thermodynamic and game-theoretic signals from the Monte Carlo energy simulation to improve operator decision-making (free energy margin, Gibbs free energy, Hamiltonian stability, entropy buffer, slack). 
- Ensure the generated artefacts consumed by the UI and runbook are consistent with the new metrics and remain CI-verifiable. 
- Keep reports and runbooks actionable for operators by embedding the new metrics into orchestration outputs.

### Description
- Updated `package.json` so `npm run demo:kardashev` delegates to the orchestrator via `demo:kardashev-ii:orchestrate` instead of directly invoking the legacy Node script. 
- Extended `runEnergyMonteCarlo` in `scripts/run-kardashev-demo.ts` to compute variance, demand standard deviation, P95 demand, `freeEnergyMarginGw`, `freeEnergyMarginPct`, `gibbsFreeEnergyGj`, `hamiltonianStability`, `entropyMargin`, `gameTheorySlack`, and `maintainsBuffer`, and included them in the returned `MonteCarloSummary`. 
- Injected the new Monte Carlo fields into telemetry and surfaced them in the generated artefacts and human-readable runbook via updated report lines in `run-kardashev-demo.ts`. 
- Adjusted the output mapping so both prefixed telemetry artefacts and a non-prefixed `governance-playbook.md`/`report.md` are written and regenerated the demo `output/` files to keep the UI and CI aligned.

### Testing
- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` which reported `3 passed` and completed successfully. 
- Executed `npm run demo:kardashev` (now routed to the orchestrator) which completed and printed orchestration summary lines. 
- Executed `npm run demo:kardashev-ii:ci` which validated artefact parity and the README and completed with success. 
- Verified regenerated artefacts under `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/` contain the new Monte Carlo fields and updated reports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bf13d5b288333afd35f75c7a43637)