### PR TITLE
Add autonomous policy actions to Kardashev-II omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
@@ -103,6 +103,18 @@ def build_parser() -> argparse.ArgumentParser:
         default=60.0,
         help="Seconds between energy oracle telemetry updates",
     )
+    parser.add_argument(
+        "--auto-policy-actions",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable autonomous policy actions based on simulation metrics",
+    )
+    parser.add_argument(
+        "--policy-action-interval",
+        type=float,
+        default=10.0,
+        help="Seconds between autonomous policy actions",
+    )
     parser.add_argument("--config", type=Path, help="Optional JSON file overriding orchestrator configuration")
     return parser
 
@@ -152,6 +164,7 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
     _require_positive(args.health_check_interval, field="health_check_interval_seconds")
     _require_positive(args.integrity_interval, field="integrity_check_interval_seconds")
     _require_positive(args.energy_oracle_interval, field="energy_oracle_interval_seconds")
+    _require_positive(args.policy_action_interval, field="policy_action_interval_seconds")
     checkpoint_interval = float(
         overrides.get("checkpoint_interval_seconds", OrchestratorConfig.checkpoint_interval_seconds)
     )
@@ -176,6 +189,8 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
         "status_output_path": args.status_output,
         "energy_oracle_path": args.energy_oracle,
         "energy_oracle_interval_seconds": args.energy_oracle_interval,
+        "auto_policy_actions": args.auto_policy_actions,
+        "policy_action_interval_seconds": args.policy_action_interval,
         "heartbeat_interval_seconds": args.heartbeat_interval,
         "heartbeat_timeout_seconds": args.heartbeat_timeout,
         "health_check_interval_seconds": args.health_check_interval,

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
+
+
+def test_autonomous_policy_action_updates_simulation(tmp_path: Path) -> None:
+    async def _run() -> None:
+        config = OrchestratorConfig(
+            max_cycles=None,
+            cycle_sleep_seconds=0.05,
+            checkpoint_interval_seconds=5,
+            enable_simulation=True,
+            simulation_tick_seconds=0.02,
+            simulation_hours_per_tick=0.01,
+            auto_policy_actions=True,
+            policy_action_interval_seconds=0.02,
+            control_channel_file=tmp_path / "control.jsonl",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            status_output_path=None,
+            audit_log_path=None,
+            energy_oracle_path=None,
+        )
+        orchestrator = Orchestrator(config)
+        try:
+            await orchestrator.start()
+
+            async def _wait_for_action() -> None:
+                while orchestrator._last_simulation_action is None:
+                    await asyncio.sleep(0.01)
+
+            await asyncio.wait_for(_wait_for_action(), timeout=2)
+            assert orchestrator._last_simulation_action is not None
+        finally:
+            await orchestrator.shutdown()
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Enable the Omega-grade demo to act autonomously on simulation-derived thermodynamic signals using game-theoretic / statistical-physics informed policies. 
- Provide a low-friction operator surface to enable/disable autonomous policy behavior and tune cadence via CLI/config flags. 
- Ensure simulation state and policy actions are serialised safely to avoid race conditions when the simulation is probed or mutated. 
- Improve observability by recording autonomous policy actions in status snapshots for auditing and integrity checks. 

### Description
- Added CLI flags `--auto-policy-actions` and `--policy-action-interval` and wired them into `build_config` to expose autonomous policy toggles. 
- Extended `OrchestratorConfig` with `auto_policy_actions` and `policy_action_interval_seconds`, and added a `policy_action_loop` that computes and applies `_build_policy_action` actions periodically. 
- Introduced an asyncio `Lock`/`Event` (`_simulation_lock` / `_simulation_ready`) and serialized accesses to `simulation.tick` / `apply_action` and `_apply_simulation_state` to prevent concurrent mutation. 
- Persist `self._last_simulation_action` into status snapshots and added `tests/test_policy_actions.py` to cover autonomous policy execution. 

### Testing
- Ran `pytest demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/tests` which executed the suite including the new `test_policy_actions.py` and reported `16 passed` in this demo suite. 
- The demo-level `run_demo_tests.py` runner was used during development to validate isolation and previously observed suites; the targeted demo tests passed end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1ddc72208333aee431034771468c)