### PR TITLE
Add validator reward pools and distribution to Omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/governance.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/governance.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 class GovernanceParameters:
     worker_stake_ratio: float = 0.15
     validator_stake: float = 100.0
+    validator_reward_ratio: float = 0.05
     validator_commit_window: timedelta = timedelta(minutes=5)
     validator_reveal_window: timedelta = timedelta(minutes=5)
     approvals_required: int = 2
@@ -33,4 +34,3 @@ class GovernanceController:
 
     def slash_amount(self, stake_locked: float) -> float:
         return stake_locked * self.params.slash_ratio
-

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/jobs.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/jobs.py
@@ -136,6 +136,7 @@ class JobRecord:
     energy_used: float = 0.0
     compute_used: float = 0.0
     stake_locked: float = 0.0
+    validator_reward_pool: float = 0.0
     reserved_energy: float = 0.0
     reserved_compute: float = 0.0
     result_summary: Optional[str] = None
@@ -158,6 +159,7 @@ class JobRecord:
             "energy_used": self.energy_used,
             "compute_used": self.compute_used,
             "stake_locked": self.stake_locked,
+            "validator_reward_pool": self.validator_reward_pool,
             "reserved_energy": self.reserved_energy,
             "reserved_compute": self.reserved_compute,
             "result_summary": self.result_summary,

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -538,6 +538,7 @@ class Orchestrator:
                 energy_used=float(payload.get("energy_used", 0.0)),
                 compute_used=float(payload.get("compute_used", 0.0)),
                 stake_locked=float(payload.get("stake_locked", 0.0)),
+                validator_reward_pool=float(payload.get("validator_reward_pool", 0.0)),
                 reserved_energy=reserved_energy,
                 reserved_compute=reserved_compute,
                 result_summary=payload.get("result_summary"),
@@ -882,6 +883,7 @@ class Orchestrator:
         if job.status in {JobStatus.POSTED, JobStatus.IN_PROGRESS}:
             job = self.job_registry.mark_failed(job.job_id, "Deadline reached")
             self._warning("job_deadline_missed", job_id=job.job_id)
+            self._refund_validator_reward_pool(job, reason="deadline_missed")
             if job.assigned_agent:
                 slash_amount = self.governance.slash_amount(job.stake_locked)
                 self.resources.slash(job.assigned_agent, slash_amount)
@@ -926,11 +928,14 @@ class Orchestrator:
         employer = spec.metadata.get("employer", self.config.operator_account)
         employer_account = self.resources.ensure_account(employer, self.config.base_agent_tokens)
         stake_required = spec.reward_tokens * self.governance.params.worker_stake_ratio
-        if employer_account.tokens < spec.reward_tokens + stake_required:
+        validator_reward_pool = self._compute_validator_reward_pool(spec.reward_tokens)
+        total_required = spec.reward_tokens + stake_required + validator_reward_pool
+        if employer_account.tokens < total_required:
             raise ValueError("Employer lacks budget for job")
-        self.resources.debit_tokens(employer, spec.reward_tokens)
+        self.resources.debit_tokens(employer, spec.reward_tokens + validator_reward_pool)
         spec.stake_required = stake_required
         record = self.job_registry.create_job(spec)
+        record.validator_reward_pool = validator_reward_pool
         try:
             self.resources.reserve_budget(
                 record.job_id,
@@ -939,7 +944,7 @@ class Orchestrator:
             )
         except ValueError as exc:
             self.job_registry.delete_job(record.job_id)
-            self.resources.credit_tokens(employer, spec.reward_tokens)
+            self.resources.credit_tokens(employer, spec.reward_tokens + validator_reward_pool)
             raise
         record.reserved_energy = max(0.0, spec.energy_budget)
         record.reserved_compute = max(0.0, spec.compute_budget)
@@ -950,6 +955,7 @@ class Orchestrator:
             reward=spec.reward_tokens,
             energy_budget=spec.energy_budget,
             compute_budget=spec.compute_budget,
+            validator_reward_pool=validator_reward_pool,
         )
         deadline_event = await self.scheduler.schedule(
             "job_deadline",
@@ -1016,9 +1022,11 @@ class Orchestrator:
         if job.status == JobStatus.FINALIZED:
             return
         approvals = sum(1 for v in job.validator_votes.values() if v)
-        if not self.governance.require_quorum(approvals):
+        approved = self.governance.require_quorum(approvals)
+        if not approved:
             self._warning("validation_quorum_not_met", job_id=job.job_id)
             job = self.job_registry.mark_failed(job.job_id, "Validation quorum not met")
+            self._refund_validator_reward_pool(job, reason="validation_quorum_not_met")
             if job.assigned_agent:
                 slash_amount = self.governance.slash_amount(job.stake_locked)
                 self.resources.slash(job.assigned_agent, slash_amount)
@@ -1027,6 +1035,9 @@ class Orchestrator:
             if job.assigned_agent:
                 self.resources.credit_tokens(job.assigned_agent, job.spec.reward_tokens)
                 self.resources.release_stake(job.assigned_agent, job.stake_locked)
+            distributed = self._distribute_validator_rewards(job)
+            if distributed <= 0.0 and job.validator_reward_pool > 0.0:
+                self._refund_validator_reward_pool(job, reason="no_validator_votes")
         released_energy, released_compute = self.resources.release_budget(job.job_id)
         if released_energy or released_compute:
             job.reserved_energy = max(0.0, job.reserved_energy - released_energy)
@@ -1197,7 +1208,8 @@ class Orchestrator:
             self._info("cancel_noop", job_id=job_id)
             return
         employer = str(job.spec.metadata.get("employer", self.config.operator_account))
-        self.resources.credit_tokens(employer, job.spec.reward_tokens)
+        self.resources.credit_tokens(employer, job.spec.reward_tokens + job.validator_reward_pool)
+        job.validator_reward_pool = 0.0
         if job.assigned_agent:
             self.resources.release_stake(job.assigned_agent, job.stake_locked)
         self._release_validator_stake(job)
@@ -1213,6 +1225,45 @@ class Orchestrator:
         )
         self._info("job_cancelled", job_id=job_id, reason=reason)
         await self._persist_status_snapshot()
+
+    def _compute_validator_reward_pool(self, reward_tokens: float) -> float:
+        ratio = max(0.0, float(self.governance.params.validator_reward_ratio))
+        return max(0.0, reward_tokens * ratio)
+
+    def _distribute_validator_rewards(self, job: JobRecord) -> float:
+        pool = max(0.0, job.validator_reward_pool)
+        if pool <= 0:
+            return 0.0
+        eligible = [validator for validator, vote in job.validator_votes.items() if vote]
+        if not eligible:
+            return 0.0
+        share = pool / len(eligible)
+        for validator in eligible:
+            self.resources.credit_tokens(validator, share)
+        job.validator_reward_pool = 0.0
+        self._info(
+            "validator_rewards_distributed",
+            job_id=job.job_id,
+            validators=eligible,
+            amount=pool,
+        )
+        return pool
+
+    def _refund_validator_reward_pool(self, job: JobRecord, *, reason: str) -> float:
+        pool = max(0.0, job.validator_reward_pool)
+        if pool <= 0:
+            return 0.0
+        employer = str(job.spec.metadata.get("employer", self.config.operator_account))
+        self.resources.credit_tokens(employer, pool)
+        job.validator_reward_pool = 0.0
+        self._info(
+            "validator_reward_refunded",
+            job_id=job.job_id,
+            employer=employer,
+            amount=pool,
+            reason=reason,
+        )
+        return pool
 
     def _capture_agent_snapshot(self) -> Dict[str, Any]:
         with self._agent_lock:

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_validator_rewards.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_validator_rewards.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.jobs import (
+    JobRecord,
+    JobSpec,
+    JobStatus,
+)
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
+
+
+def _make_job(reward_pool: float, *, employer: str = "operator") -> JobRecord:
+    now = datetime.now(timezone.utc)
+    spec = JobSpec(
+        title="Test job",
+        description="Validator reward distribution test.",
+        required_skills=["validation"],
+        reward_tokens=100.0,
+        deadline=now + timedelta(hours=1),
+        validation_window=timedelta(minutes=5),
+        metadata={"employer": employer},
+    )
+    return JobRecord(
+        job_id="job-1",
+        spec=spec,
+        status=JobStatus.COMPLETED,
+        created_at=now,
+        validator_reward_pool=reward_pool,
+    )
+
+
+def test_validator_rewards_distributed_to_approvers() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=False))
+    job = _make_job(12.0)
+    job.validator_votes = {
+        "validator-1": True,
+        "validator-2": True,
+        "validator-3": False,
+    }
+    for validator in job.validator_votes:
+        orchestrator.resources.ensure_account(validator)
+
+    distributed = orchestrator._distribute_validator_rewards(job)
+
+    assert distributed == 12.0
+    assert job.validator_reward_pool == 0.0
+    assert orchestrator.resources.get_account("validator-1").tokens == 6.0
+    assert orchestrator.resources.get_account("validator-2").tokens == 6.0
+    assert orchestrator.resources.get_account("validator-3").tokens == 0.0
+
+
+def test_validator_reward_pool_refunded_to_employer() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=False))
+    job = _make_job(7.5, employer="chief-operator")
+    orchestrator.resources.ensure_account("chief-operator")
+
+    refunded = orchestrator._refund_validator_reward_pool(job, reason="unit-test")
+
+    assert refunded == 7.5
+    assert job.validator_reward_pool == 0.0
+    assert orchestrator.resources.get_account("chief-operator").tokens == 7.5


### PR DESCRIPTION
### Motivation
- Provide explicit economic incentives for validators so they are rewarded for honest reveals and participation in the validation protocol.
- Keep job-level accounting balanced and auditable by reserving a small validator reward pool at job posting time.
- Reduce edge-case surprise losses by refunding validator pools when jobs are cancelled, fail validation quorum, or miss deadlines.
- Align incentives and enable later policy experiments (e.g. game-theoretic splits or Gibbs/Hamiltonian-driven allocations) via a configurable ratio.

### Description
- Add a new governance parameter `validator_reward_ratio` to control the fraction of a job reward reserved for validators.
- Extend `JobRecord` with a `validator_reward_pool` field and persist/rehydrate it through the checkpointing and job rehydration code-paths.
- Fund the validator pool when posting jobs (employer debited for reward + pool), distribute the pool to approving validators in `_distribute_validator_rewards`, and refund it to the employer on cancellation, deadline miss, or failed quorum via `_refund_validator_reward_pool`.
- Add unit tests `demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_validator_rewards.py` that validate distribution and refund behaviour.

### Testing
- Ran `pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_validator_rewards.py"` and the two tests passed.
- Executed the demo test runner via `python demo/run_demo_tests.py` which completed successfully (demo suites passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c26a33c348333b81ca62e16dae5b0)