### PR TITLE
Align Kardashev demo with CI orchestrator and isolate legacy outputs

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -450,7 +450,7 @@ function parseArgs(argv) {
 function resolveOutputDir(rawOutputDir, { ensure = true } = {}) {
   const dir = rawOutputDir
     ? path.resolve(rawOutputDir)
-    : path.join(__dirname, 'output');
+    : path.join(__dirname, 'output', 'legacy');
   if (ensure) {
     ensureDir(dir);
   }

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
@@ -1,6 +1,6 @@
 """Python wrapper for the Kardashev II platform demo.
 
-This wrapper delegates to the existing ``run-demo.cjs`` Node script while
+This wrapper delegates to the legacy ``run-demo.cjs`` Node script while
 providing a Python-friendly interface for CI and contributor workflows.
 It mirrors the most important flags (``--output-dir``, ``--check``, and
 ``--print-commands``) and ensures outputs are written to the requested
@@ -20,7 +20,7 @@ import shutil
 
 ROOT = Path(__file__).resolve().parent
 NODE_SCRIPT = ROOT / "run-demo.cjs"
-DEFAULT_OUTPUT_DIR = ROOT / "output"
+DEFAULT_OUTPUT_DIR = ROOT / "output" / "legacy"
 
 
 def _ensure_node_available() -> str:

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "demo:aurora:report": "ts-node --transpile-only demo/aurora/bin/aurora-report.ts",
     "demo:aurora:sepolia": "npx hardhat run demo/aurora/aurora.demo.ts --network sepolia",
     "demo:flagship": "demo/cosmic-omni-sovereign-symphony/bin/flagship-demo.sh",
-    "demo:kardashev": "node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs",
+    "demo:kardashev": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/run-kardashev-demo.ts",
     "demo:kardashev-ii-lattice:ci": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/stellar-civilization-lattice/scripts/ci-validate.ts",
     "demo:kardashev-ii-lattice:orchestrate": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/stellar-civilization-lattice/scripts/orchestrate.ts",
     "demo:kardashev-ii-omega-upgrade": "python -m kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo.cli launch --config demo/'Kardashev-II Omega-Grade-α-AGI Business-3'/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo/config/mission.json",


### PR DESCRIPTION
### Motivation
- Prevent CI drift caused by the legacy Node demo writing differing artefacts into the shared `output/` tree. 
- Ensure the `demo:kardashev` entrypoint is the same orchestrator logic that the CI validator exercises. 
- Isolate legacy behaviour to avoid accidental comparisons against committed telemetry and ledgers.

### Description
- Route the `demo:kardashev` npm script to the orchestrator implementation at `scripts/run-kardashev-demo.ts` instead of the legacy `run-demo.cjs` by updating `package.json`. 
- Move the legacy demo defaults to a dedicated `output/legacy` folder by changing the default output path in `run-demo.cjs` and the Python wrapper `run_demo.py`. 
- Keep the Python wrapper behavior the same while making its `DEFAULT_OUTPUT_DIR` point to `output/legacy` so contributors invoking the legacy script do not collide with CI artefacts. 
- Files changed: `package.json`, `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs`, and `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py`.

### Testing
- Ran `pytest -q demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` and all tests passed (`3 passed`).
- Executed the orchestrator: `npm run demo:kardashev-ii:orchestrate` (via `ts-node`) and it generated artefacts and logged summary metrics successfully.
- Ran the CI validator: `npm run demo:kardashev-ii:ci` and it reported `✔ Kardashev-II artefacts are up-to-date.` and `✔ Kardashev-II README verified.` with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c5110451083339b806b55e2f4fc1b)