### PR TITLE
Add allocation policy telemetry and dashboard

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -118,6 +118,20 @@
 
       <section class="card">
         <div class="section-title">
+          <h2>Allocation policy</h2>
+        </div>
+        <p id="allocation-summary" class="lede">…</p>
+        <div class="allocation-metrics">
+          <p>Gibbs temperature: <span id="allocation-temperature">…</span></p>
+          <p>Nash welfare: <span id="allocation-nash">…</span></p>
+          <p>Fairness index: <span id="allocation-fairness">…</span></p>
+          <p>Gibbs potential: <span id="allocation-gibbs">…</span></p>
+        </div>
+        <ul id="allocation-list" class="allocation-list"></ul>
+      </section>
+
+      <section class="card">
+        <div class="section-title">
           <h2>Mission lattice</h2>
         </div>
         <p id="mission-summary" class="lede">…</p>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
@@ -25,7 +25,10 @@
 * Live feeds (≤ 5%): earth-grid Δ 0.00% · mars-dome Δ 0.00% · orbital-swarm Δ 0.00%.
 * Feed latency: avg 241467 ms · max 720000 ms (calibrated 2025-02-28T18:00:00Z).
 * Energy window coverage 100.00% (threshold 98%) · reliability 98.56%.
+* Allocation policy: Gibbs temp 0.30 · Nash welfare 60.44% · fairness 90.3%.
 * Energy window deficits: none — all federations meet coverage targets.
+* Allocation policy: Gibbs temperature 0.30 · Nash welfare 60.44% · fairness 90.3% · Gibbs potential -0.207.
+* Top allocations: orbital 50.2% · 295219 GW · earth 35.4% · 208107 GW · mars 14.4% · 84485 GW.
 
 ---
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
@@ -576,6 +576,56 @@
       }
     }
   },
+  "allocationPolicy": {
+    "temperature": 0.3002251652170107,
+    "nashProduct": 0.6044212863844729,
+    "allocationEntropy": 0.9923063827819896,
+    "fairnessIndex": 0.9032361944403527,
+    "gibbsPotential": -0.20676099515198731,
+    "availableGw": 587810.861217711,
+    "reserveGw": 167810.861217711,
+    "allocations": [
+      {
+        "federation": "earth",
+        "name": "Earth Sovereign Federation",
+        "weight": 0.35403689197533944,
+        "recommendedGw": 208106.730374866,
+        "payoff": 0.8324032499999999,
+        "resilience": 0.945,
+        "coverageSeconds": 1950,
+        "energyAvailableGw": 82000,
+        "computeExaflops": 18.4,
+        "latencyMs": 85,
+        "renewablePct": 0.87
+      },
+      {
+        "federation": "mars",
+        "name": "Mars Terraforming Compact",
+        "weight": 0.14372774729043328,
+        "recommendedGw": 84484.73091567111,
+        "payoff": 0.28779299999999997,
+        "resilience": 0.935,
+        "coverageSeconds": 2400,
+        "energyAvailableGw": 24000,
+        "computeExaflops": 6.1,
+        "latencyMs": 820,
+        "renewablePct": 0.93
+      },
+      {
+        "federation": "orbital",
+        "name": "Orbital Research Halo",
+        "weight": 0.5022353607342273,
+        "recommendedGw": 295219.39992717386,
+        "payoff": 0.9217332599999999,
+        "resilience": 0.959,
+        "coverageSeconds": 1920,
+        "energyAvailableGw": 136000,
+        "computeExaflops": 24.6,
+        "latencyMs": 42,
+        "renewablePct": 0.99
+      }
+    ]
+  },
   "logistics": {
     "corridors": [
       {

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -310,6 +310,8 @@ function computeAllocationPolicy(shardMetrics, energyMonteCarlo) {
     allocationEntropy,
     fairnessIndex,
     gibbsPotential,
+    availableGw,
+    reserveGw: energyMonteCarlo.reserveGw ?? 0,
     allocations,
   };
 }

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -336,6 +336,7 @@ function renderLegacyMetrics(telemetry) {
     "#fabric-summary",
     "#fabric-federation-summary",
     "#schedule-summary",
+    "#allocation-summary",
     "#mission-summary",
     "#logistics-summary",
     "#settlement-summary",
@@ -347,6 +348,22 @@ function renderLegacyMetrics(telemetry) {
       applyStatus(element, "status-warn");
     }
   });
+
+  ["#allocation-temperature", "#allocation-nash", "#allocation-fairness", "#allocation-gibbs"].forEach((selector) => {
+    const element = document.querySelector(selector);
+    if (element) {
+      element.textContent = "—";
+      applyStatus(element, "status-warn");
+    }
+  });
+  const allocationList = document.querySelector("#allocation-list");
+  if (allocationList) {
+    allocationList.innerHTML = "";
+    const li = document.createElement("li");
+    li.textContent = "Allocation policy unavailable in legacy telemetry.";
+    li.classList.add("status-warn");
+    allocationList.appendChild(li);
+  }
 
   ["#mission-mermaid", "#mermaid-container", "#dyson-container"].forEach((selector) => {
     const element = document.querySelector(selector);
@@ -580,6 +597,56 @@ function renderEnergySchedule(schedule, verification) {
     deficits.classList.add("status-fail");
     deficits.classList.remove("status-ok");
   }
+}
+
+function renderAllocationPolicy(policy) {
+  const summary = document.querySelector("#allocation-summary");
+  const temperatureEl = document.querySelector("#allocation-temperature");
+  const nashEl = document.querySelector("#allocation-nash");
+  const fairnessEl = document.querySelector("#allocation-fairness");
+  const gibbsEl = document.querySelector("#allocation-gibbs");
+  const list = document.querySelector("#allocation-list");
+
+  if (!summary || !temperatureEl || !nashEl || !fairnessEl || !gibbsEl || !list) return;
+
+  if (!policy) {
+    summary.textContent = "Allocation policy unavailable. Regenerate telemetry to restore Game Theory routing.";
+    applyStatus(summary, "status-warn");
+    temperatureEl.textContent = "—";
+    nashEl.textContent = "—";
+    fairnessEl.textContent = "—";
+    gibbsEl.textContent = "—";
+    list.innerHTML = "";
+    return;
+  }
+
+  const reserveGw = Number.isFinite(policy.reserveGw) ? policy.reserveGw : 0;
+  summary.textContent = `Gibbs temperature ${policy.temperature.toFixed(2)} · Nash welfare ${(policy.nashProduct * 100).toFixed(
+    2
+  )}% · fairness ${(policy.fairnessIndex * 100).toFixed(1)}% · reserve ${formatNumber(reserveGw)} GW`;
+  applyStatus(
+    summary,
+    policy.fairnessIndex >= 0.8 ? "status-ok" : policy.fairnessIndex >= 0.7 ? "status-warn" : "status-fail"
+  );
+
+  temperatureEl.textContent = policy.temperature.toFixed(2);
+  nashEl.textContent = `${(policy.nashProduct * 100).toFixed(2)}%`;
+  fairnessEl.textContent = `${(policy.fairnessIndex * 100).toFixed(1)}%`;
+  gibbsEl.textContent = policy.gibbsPotential.toFixed(3);
+
+  list.innerHTML = "";
+  [...policy.allocations]
+    .sort((a, b) => b.weight - a.weight)
+    .forEach((allocation) => {
+      const li = document.createElement("li");
+      li.innerHTML = `<strong>${allocation.name}</strong> · ${(allocation.weight * 100).toFixed(1)}% share · ${formatNumber(
+        allocation.recommendedGw
+      )} GW · payoff ${allocation.payoff.toFixed(3)} · latency ${allocation.latencyMs} ms`;
+      li.classList.add(
+        allocation.weight >= 0.34 ? "status-ok" : allocation.weight >= 0.2 ? "status-warn" : "status-fail"
+      );
+      list.appendChild(li);
+    });
 }
 
 function renderMissionLattice(mission) {
@@ -1059,6 +1126,7 @@ async function bootstrap() {
   renderComputeFabric(telemetry.computeFabric);
   renderOrchestrationFabric(telemetry.orchestrationFabric);
   renderEnergySchedule(telemetry.energy.schedule, telemetry.verification.energySchedule);
+  renderAllocationPolicy(telemetry.allocationPolicy);
   renderMissionLattice(telemetry.missionLattice);
   renderLogistics(telemetry.logistics, telemetry.verification.logistics);
   renderSettlement(telemetry.settlement, telemetry.verification.settlement);

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css
@@ -215,7 +215,8 @@ button:hover {
 
 .identity-list,
 .fabric-list,
-.feed-list {
+.feed-list,
+.allocation-list {
   list-style: none;
   padding: 0;
   margin: 12px 0 0 0;
@@ -226,12 +227,26 @@ button:hover {
 
 .identity-list li,
 .fabric-list li,
-.feed-list li {
+.feed-list li,
+.allocation-list li {
   background: rgba(15, 23, 42, 0.5);
   border: 1px solid rgba(99, 102, 241, 0.25);
   border-radius: 14px;
   padding: 12px 16px;
   line-height: 1.5;
+}
+
+.allocation-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px 16px;
+  margin-top: 12px;
+}
+
+.allocation-metrics p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
 }
 
 .feed-list li {


### PR DESCRIPTION
### Motivation
- Surface a game-theoretic Gibbs/Nash allocation policy so the Kardashev-II orchestrator can recommend energy reallocation across federations using thermodynamic and game‑theory signals.
- Provide operators with immediate visibility of allocation tradeoffs (temperature, Nash welfare, fairness) alongside existing energy Monte Carlo telemetry.
- Keep operator artefacts and runbook synchronized by including allocation data in generated telemetry and reports.
- Improve UI feedback for legacy vs full orchestrator outputs so dashboards remain informative when full telemetry is missing.

### Description
- Added `softmaxScores` and `computeAllocationPolicy` to `scripts/run-kardashev-demo.ts` to compute Gibbs temperature, allocation weights, payoff, Nash product, allocation entropy, fairness index and Gibbs potential from manifest + Monte Carlo results.
- Propagated `allocationPolicy` into generated telemetry and runbook by injecting it into the telemetry object and runbook text in `scripts/run-kardashev-demo.ts` and mirrored the shape in the Node runner `run-demo.cjs`.
- Extended the dashboard with a new "Allocation policy" card and a `renderAllocationPolicy` function in `ui/dashboard.js`, added UI placeholders in `index.html`, and styles in `ui/style.css` including legacy fallbacks for when full telemetry is not present.
- Regenerated artefacts (`output/kardashev-telemetry.json` and `kardashev-orchestration-report.md`) and updated the Node script to expose `availableGw`/`reserveGw` for accurate reserve reporting.

### Testing
- Ran `npm run demo:kardashev-ii:orchestrate` to regenerate artefacts and it completed successfully with the allocation policy included.
- Ran `npm run demo:kardashev-ii:ci` which reported artefacts up-to-date and README verification succeeded.
- Executed the demo tests with `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` and all tests passed (3 passed).
- Performed a headless dashboard render / screenshot against the served demo (`python -m http.server`) to validate the new UI section was populated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c5110451083339b806b55e2f4fc1b)