### PR TITLE
Add thermodynamic guardrails to Day-One Utility Benchmark demo

### DIFF
--- a/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
@@ -51,6 +51,12 @@ def test_simulate_e2e_outputs():
     assert payload["metrics"]["candidate"]["platform_fee"] > 0
     assert payload["metrics"]["candidate"]["treasury_bonus"] >= 0
     assert payload["metrics"]["latency_p95"] > 0
+    thermo = payload["thermodynamics"]
+    assert thermo["free_energy_margin"] > 0
+    assert thermo["gibbs_free_energy"] > 0
+    assert 0 <= thermo["hamiltonian_stability"] <= 1
+    assert thermo["entropy_margin_sigma"] >= 0
+    assert 0 <= thermo["game_theory_slack"] <= 1
 
 
 def test_pause_blocks_simulation():


### PR DESCRIPTION
### Motivation

- Surface physics-inspired stability signals (entropy, Gibbs free energy, Hamiltonian) to reason about strategy robustness and resource margins.  
- Provide a compact game-theoretic slack metric to help owners and CI detect instability or guardrail breaches early.  
- Improve human operator transparency by exposing thermodynamic metrics in the CLI human summary and dashboard for easier review.

### Description

- Added `_shannon_entropy` and `_compute_thermodynamics` helpers to compute entropy, free energy margin, Gibbs free energy, Hamiltonian stability, temperature, and game-theory slack.  
- Injected a new `thermodynamics` block into the simulation `report` JSON and surfaced those values in the human summary via `run_cli`/`_build_human_summary`.  
- Rendered a new "Thermodynamic Guardrails" section in the HTML dashboard via `_render_dashboard`.  
- Updated unit tests in `demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py` to assert the new thermodynamics outputs and adjusted orchestration code in `demo/AGIJobs-Day-One-Utility-Benchmark/demo_runner.py`.

### Testing

- Ran `pytest -q demo/AGIJobs-Day-One-Utility-Benchmark/tests` and all tests passed (`17 passed`).  
- Executed `python demo/AGIJobs-Day-One-Utility-Benchmark/run_demo.py simulate --format json` and verified the produced JSON includes a `thermodynamics` block with expected numeric ranges.  
- Generated the dashboard HTML and verified the new Thermodynamic Guardrails section was written to `out/dashboard_e2e.html`.  
- Created a visual snapshot of the dashboard (Playwright-driven screenshot) to confirm rendering of the new metrics section.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c5110451083339b806b55e2f4fc1b)