### PR TITLE
Add local dashboard server and file:// fetch warning for Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/README.md
@@ -16,7 +16,8 @@ This dossier is the living operator manual for `demo/AGI-Jobs-Platform-at-Kardas
 2. Run `npm run demo:kardashev-ii:ci` to validate artefacts, README integrity, and orchestrator invariants.
 3. Launch a deterministic dry-run with `npm run demo:kardashev-ii:orchestrate -- --check` to produce ledgers without writing new outputs.
 4. Generate full artefacts with `npm run demo:kardashev` (writes to `output/` and refreshes dashboards in `ui/`).
-5. Escalate anomalies using the guardian contacts embedded in [`OperatorRunbook.md`](../../OperatorRunbook.md) and `config/kardashev-ii.manifest.json`.
+5. Serve the dashboard locally with `npm run demo:kardashev-ii:serve` and open the provided `http://localhost` URL.
+6. Escalate anomalies using the guardian contacts embedded in [`OperatorRunbook.md`](../../OperatorRunbook.md) and `config/kardashev-ii.manifest.json`.
 
 ## 🧱 Architecture overview
 ```mermaid

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
@@ -8,6 +8,11 @@ Generated: 2125-01-01T19:05:39.398Z
 - **Dyson Swarm Progress:** 2669/10000 satellites assembled (26.69% coverage).
 - **Captured Power:** 120,105 MW available for reallocation.
 - **Energy Monte Carlo:** 3.91% breach probability across 256 runs (tolerance 5.00%).
+- **Free Energy Margin:** 13478.69 GW (5.57%) vs 11980.00 GW minimum buffer.
+- **Entropy Buffer:** 2.69σ thermodynamic headroom; game-theoretic slack 75.7%.
+- **Thermodynamic Reserve:** 48,523,291.36 GJ Gibbs free energy; Hamiltonian stability 50.8% across the sampled phase space.
+- **Gibbs Allocation Temperature:** 0.49 (lower favors resilience-heavy shards); Nash welfare 9.99%.
+- **Allocation Entropy:** 1.099 (fairness 100.0%); Gibbs potential -0.536.
 - **Sentinel Status:** 3 advisories generated; all resolved within guardian SLA.
 
 ## Shard Operations
@@ -17,6 +22,14 @@ Generated: 2125-01-01T19:05:39.398Z
 | earth   | 668,431      | 133               | 6 min          | 0.999      | 99.54%             |
 | mars    | 112,364      | 120               | 17 min         | 0.999      | 98.73%             |
 | orbital | 600,104      | 120               | 6 min          | 0.999      | 99.16%             |
+
+## Thermodynamic Allocation Policy
+
+| Shard   | Boltzmann Weight | Recommended GW | Nash Payoff |
+| ------- | ---------------- | -------------- | ----------- |
+| earth   | 33.4%            | 80,942.25      | 0.1         |
+| mars    | 33.0%            | 79,739.29      | 0.1         |
+| orbital | 33.6%            | 81,318.46      | 0.1         |
 
 ## Sentinel Advisories
 
@@ -44,5 +57,5 @@ Generated: 2125-01-01T19:05:39.398Z
 - Assembly rate: 96 satellites/day
 - Energy per satellite: 45 MW
 
-A detailed task hierarchy diagram is available at `output/mermaid/dyson-hierarchy.mmd`.
+A detailed task hierarchy diagram is available at `mermaid/dyson-hierarchy.mmd`.
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/serve-dashboard.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/serve-dashboard.cjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+const http = require('http');
+const fs = require('fs/promises');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const DEMO_ROOT = path.resolve(__dirname, '..');
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.mmd': 'text/plain; charset=utf-8',
+  '.md': 'text/plain; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+};
+
+function parseArgs(argv) {
+  const portIndex = argv.findIndex((value) => value === '--port');
+  const portValue = portIndex >= 0 ? argv[portIndex + 1] : undefined;
+  const port = Number(portValue || process.env.PORT || 4175);
+  return {
+    port: Number.isFinite(port) && port > 0 ? port : 4175,
+  };
+}
+
+function resolvePath(requestUrl) {
+  try {
+    const parsed = new URL(requestUrl, 'http://localhost');
+    const decoded = decodeURIComponent(parsed.pathname);
+    const safePath = path.normalize(decoded).replace(/^\.\.(\/|\\)/, '');
+    const resolved = path.join(DEMO_ROOT, safePath);
+    if (!resolved.startsWith(DEMO_ROOT)) {
+      return null;
+    }
+    return resolved;
+  } catch (error) {
+    return null;
+  }
+}
+
+async function readFileOr404(targetPath, res) {
+  try {
+    const stats = await fs.stat(targetPath);
+    if (stats.isDirectory()) {
+      const indexPath = path.join(targetPath, 'index.html');
+      return readFileOr404(indexPath, res);
+    }
+    const ext = path.extname(targetPath).toLowerCase();
+    const mime = MIME_TYPES[ext] || 'application/octet-stream';
+    const buffer = await fs.readFile(targetPath);
+    res.writeHead(200, { 'Content-Type': mime });
+    res.end(buffer);
+  } catch (error) {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Not found');
+  }
+}
+
+async function startServer() {
+  const { port } = parseArgs(process.argv.slice(2));
+
+  const server = http.createServer(async (req, res) => {
+    if (!req.url) {
+      res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Missing request URL');
+      return;
+    }
+
+    const targetPath = resolvePath(req.url);
+    if (!targetPath) {
+      res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Invalid path');
+      return;
+    }
+
+    await readFileOr404(targetPath, res);
+  });
+
+  server.listen(port, () => {
+    const url = `http://localhost:${port}/index.html`;
+    console.log(`🚀 Kardashev II dashboard ready at ${url}`);
+    console.log('   Serve this URL in a browser to load telemetry without CORS errors.');
+    console.log(`   Demo root: ${pathToFileURL(DEMO_ROOT).toString()}`);
+  });
+}
+
+startServer().catch((error) => {
+  console.error('Failed to start dashboard server:', error);
+  process.exit(1);
+});

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -71,6 +71,17 @@ function renderGlobalFailure(message) {
   main.prepend(alert);
 }
 
+function renderLocalFileWarning() {
+  renderGlobalFailure(
+    "This dashboard is running from a local file URL. Modern browsers block fetch() for local files, so telemetry cannot be loaded."
+  );
+  const hint = document.createElement("p");
+  hint.classList.add("lede");
+  hint.innerHTML =
+    "Start the local dashboard server with <code>npm run demo:kardashev-ii:serve</code> and open the provided <code>http://localhost</code> URL.";
+  document.querySelector("main")?.querySelector("section")?.appendChild(hint);
+}
+
 function isLegacyTelemetry(telemetry) {
   return telemetry && telemetry.dominance === undefined && typeof telemetry.dominanceScore === "number";
 }
@@ -1023,6 +1034,10 @@ function renderOwnerProof(ownerProof, telemetry) {
 }
 
 async function bootstrap() {
+  if (window.location.protocol === "file:") {
+    renderLocalFileWarning();
+    return;
+  }
   const [telemetryResult, ledgerResult, ownerProofResult] = await Promise.allSettled([
     fetchJson("./output/kardashev-telemetry.json"),
     fetchJson("./output/kardashev-stability-ledger.json"),

--- a/package.json
+++ b/package.json
@@ -223,6 +223,7 @@
     "demo:aurora:sepolia": "npx hardhat run demo/aurora/aurora.demo.ts --network sepolia",
     "demo:flagship": "demo/cosmic-omni-sovereign-symphony/bin/flagship-demo.sh",
     "demo:kardashev": "node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs",
+    "demo:kardashev-ii:serve": "node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/serve-dashboard.cjs",
     "demo:kardashev-ii-lattice:ci": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/stellar-civilization-lattice/scripts/ci-validate.ts",
     "demo:kardashev-ii-lattice:orchestrate": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/stellar-civilization-lattice/scripts/orchestrate.ts",
     "demo:kardashev-ii-omega-upgrade": "python -m kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo.cli launch --config demo/'Kardashev-II Omega-Grade-α-AGI Business-3'/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo/config/mission.json",


### PR DESCRIPTION
### Motivation
- The Kardashev II dashboard fails to load telemetry when opened as a local file because modern browsers block `fetch()` on `file://` URLs, producing a confusing blank UI.  
- Operators need a lightweight way to serve the demo artifacts locally without adding heavy dependencies or extra configuration.  
- The README quickstart did not document serving the dashboard, increasing the chance contributors open `index.html` directly and encounter CORS/fetch errors.  
- Regenerating the report artefacts keeps the demo outputs consistent with the orchestration logic and CI expectations.  

### Description
- Add a small static server `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/serve-dashboard.cjs` that serves the demo tree over HTTP and logs the `http://localhost:<port>/index.html` URL.  
- Add a new npm script `demo:kardashev-ii:serve` that runs the new server via `node`.  
- Update `ui/dashboard.js` to detect `window.location.protocol === 'file:'` and surface a clear, actionable warning explaining why telemetry cannot be loaded and instructing users to run `npm run demo:kardashev-ii:serve`.  
- Update the demo `README.md` quickstart and refresh `output/kardashev-report.md` to reflect regenerated artefacts from `npm run demo:kardashev`.  

### Testing
- Ran `npm run demo:kardashev` to regenerate artefacts and the command completed successfully producing updated files in `demo/.../output/`.  
- Executed `npm run demo:kardashev-ii:ci` which initially flagged drift until outputs were regenerated, and after regenerating artefacts the CI validation passed.  
- Ran the demo test runner `python demo/run_demo_tests.py --demo AGI-Jobs-Platform-at-Kardashev-II-Scale --fail-fast` and the suite passed (`3 passed`).  
- Started the local server and captured a browser screenshot via Playwright to verify the dashboard loads over `http://localhost:4175/index.html` (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c369a734c8333ba6cc13c6c23a28c)