### PR TITLE
Allow Kardashev II demo to default energy tolerance

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -334,9 +334,11 @@ function validateEnergyFeeds(energy) {
     }
   });
 
-  const tolerancePct = energy?.tolerancePct ?? 0;
-  if (!Number.isFinite(tolerancePct) || tolerancePct <= 0 || tolerancePct > 50) {
-    throw new Error('Energy tolerancePct must be between 0 and 50.');
+  const tolerancePct = energy?.tolerancePct;
+  if (tolerancePct !== undefined) {
+    if (!Number.isFinite(tolerancePct) || tolerancePct <= 0 || tolerancePct > 50) {
+      throw new Error('Energy tolerancePct must be between 0 and 50.');
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation

- The Kardashev II demo rejected configurations that omitted `tolerancePct` even though sensible defaults exist, causing unnecessary failures for CI and contributors.
- The intent is to make the demo more robust to partial configs while surfacing real data errors for malformed feeds.

### Description

- Relax `validateEnergyFeeds` in `run-demo.cjs` to accept a missing `tolerancePct` (only validate it if present) instead of forcing a default zero-check that failed validation.
- Add a new test `test_run_demo_allows_default_tolerance` to `tests/test_run_demo.py` to ensure missing tolerance fields do not cause validation failures and the demo runs in check mode.
- Kept existing strict validation for per-feed fields (`nominalMw`, `bufferMw`, `latencyMs`) to ensure malformed feed entries still fail fast.

### Testing

- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` and observed `4 passed` for the modified demo tests.
- The change was exercised by running the demo in check mode and confirming the output indicates validation succeeded with defaulted tolerance behavior.
- Existing validation tests (invalid feed with negative `nominalMw`) continue to fail as expected, ensuring coverage for error paths.
- No other automated tests in the modified area were broken by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c70b418c88333913c62da2cdb5f92)