### PR TITLE
Add allocation stability metrics to Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -64,6 +64,9 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert allocation["allocationEntropy"] >= 0
     assert 0 < allocation["fairnessIndex"] <= 1
     assert allocation["gibbsPotential"] <= 0
+    assert 0 <= allocation["strategyStability"] <= 1
+    assert 0 <= allocation["deviationIncentive"] <= 1
+    assert 0 <= allocation["jainIndex"] <= 1
 
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")


### PR DESCRIPTION
### Motivation
- Improve the allocation policy's observability by quantifying stability and fairness of recommended shard allocations using simple game-theoretic and statistical measures.
- Surface metrics that help operators reason about incentives and deviation risk when applying Gibbs/Nash-inspired allocation decisions.
- Provide machine-checkable invariants so CI and operator tooling can detect pathological allocation outcomes early.

### Description
- Added `computeJainIndex` and computed `deviationIncentive`, `strategyStability`, and `jainIndex` inside `computeAllocationPolicy` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` and returned them as part of the allocation policy object.
- Rendered the new stability metrics into the generated report by appending a `Strategy Stability` line to the executive summary in the same Node script.
- Extended `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` to assert the presence and valid ranges (`0..1`) of `strategyStability`, `deviationIncentive`, and `jainIndex`.

### Testing
- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and the suite passed (`4 passed`).
- The modified `computeAllocationPolicy` is exercised by the demo's existing CI checks and the specific demo test which validated the new fields. 
- No regressions observed in the targeted demo tests after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c7a28418c8333855292676b68ac81)