### PR TITLE
Add thermodynamic allocation policy to Kardashev‑II demo and dashboard

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -118,6 +118,15 @@
 
       <section class="card">
         <div class="section-title">
+          <h2>Thermodynamic allocation policy</h2>
+        </div>
+        <p id="allocation-summary" class="lede">…</p>
+        <p id="allocation-stability" class="lede">…</p>
+        <ul id="allocation-list" class="fabric-list"></ul>
+      </section>
+
+      <section class="card">
+        <div class="section-title">
           <h2>Mission lattice</h2>
         </div>
         <p id="mission-summary" class="lede">…</p>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
@@ -21,6 +21,8 @@
 * Monte Carlo breach probability 0.00% (runs 256, tolerance 1.00%).
 * Free energy margin 167810.86 GW (39.95%) · Gibbs free energy 604,119,100.384 GJ.
 * Hamiltonian stability 70.0% · entropy margin 17.73σ · game-theory slack 86.5% · buffer stable.
+* Allocation policy: Gibbs temperature 0.23 · Nash welfare 85.60% · fairness 93.6% · Gibbs potential -0.157.
+* Allocation deltas: Earth Sovereign Federation -17187.62 GW · Mars Terraforming Compact +29171.09 GW · Orbital Research Halo -11983.47 GW.
 * Demand percentiles: P95 252,189.139 GW · P99 255,160.811 GW.
 * Live feeds (≤ 5%): earth-grid Δ 0.00% · mars-dome Δ 0.00% · orbital-swarm Δ 0.00%.
 * Feed latency: avg 241467 ms · max 720000 ms (calibrated 2025-02-28T18:00:00Z).

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
@@ -237,6 +237,57 @@
       "withinTolerance": true,
       "tolerance": 0.01
     },
+    "allocationPolicy": {
+      "temperature": 0.23417562886926835,
+      "nashProduct": 0.8559979953942851,
+      "strategyStability": 0.8789210176765097,
+      "deviationIncentive": 0.12107898232349039,
+      "jainIndex": 0.9900236513129889,
+      "allocationEntropy": 1.0283928406037925,
+      "fairnessIndex": 0.9360835038997727,
+      "gibbsPotential": -0.1565517654231928,
+      "allocations": [
+        {
+          "federation": "earth",
+          "name": "Earth Sovereign Federation",
+          "weight": 0.26781974907193434,
+          "recommendedGw": 64812.38,
+          "payoff": 0.8265,
+          "currentGw": 82000,
+          "deltaGw": -17187.62,
+          "resilience": 0.945,
+          "renewablePct": 0.87,
+          "latencyMs": 85,
+          "storageGwh": 54000
+        },
+        {
+          "federation": "mars",
+          "name": "Mars Terraforming Compact",
+          "weight": 0.21971525874123823,
+          "recommendedGw": 53171.09,
+          "payoff": 0.7754,
+          "currentGw": 24000,
+          "deltaGw": 29171.09,
+          "resilience": 0.935,
+          "renewablePct": 0.93,
+          "latencyMs": 820,
+          "storageGwh": 18000
+        },
+        {
+          "federation": "orbital",
+          "name": "Orbital Research Halo",
+          "weight": 0.5124649921868274,
+          "recommendedGw": 124016.53,
+          "payoff": 0.9787,
+          "currentGw": 136000,
+          "deltaGw": -11983.47,
+          "resilience": 0.959,
+          "renewablePct": 0.99,
+          "latencyMs": 42,
+          "storageGwh": 128000
+        }
+      ]
+    },
     "liveFeeds": {
       "calibrationISO8601": "2025-02-28T18:00:00Z",
       "tolerancePct": 5,


### PR DESCRIPTION
### Motivation

- Surface a thermodynamic / game-theory informed energy allocation recommendation so operators can reallocate Dyson/region power using a principled Gibbs/Nash model.  
- Improve observability by exposing allocation stability, fairness and deltas alongside Monte Carlo energy telemetry.  
- Provide an automated, deterministic policy that complements existing Monte Carlo, Hamiltonian and Gibbs diagnostics for mission orchestration.  

### Description

- Add TypeScript types and helpers (`AllocationPolicy`, `AllocationRecommendation`, `softmaxScores`, `computeJainIndex`) and implement `buildEnergyAllocationPolicy` to compute Boltzmann-style weights and Nash/Gibbs-derived metrics.  
- Integrate the allocation policy into orchestration telemetry as `energy.allocationPolicy` and include the policy summary in the runbook text produced by `scripts/run-kardashev-demo.ts`.  
- Add UI support by inserting a new "Thermodynamic allocation policy" card in `index.html` and a renderer `renderAllocationPolicy` in `ui/dashboard.js` to present temperature, Nash welfare, fairness, deltas and per-federation recommendations.  
- Regenerate demo outputs (telemetry and orchestration report) to include allocationPolicy and update the dashboard wiring to call `renderAllocationPolicy` during bootstrap.  

### Testing

- Ran `npm run demo:kardashev-ii:orchestrate` to regenerate artefacts and verify telemetry generation, which completed successfully.  
- Ran `npm run demo:kardashev-ii:ci` which reported the artefacts are up-to-date and README checks passed.  
- Served the dashboard with `npm run demo:kardashev-ii:serve` and captured a browser screenshot of the new allocation card to validate rendering.  
- Executed the project test wrapper `python demo/run_demo_tests.py`; many demo suites completed successfully but Playwright browser download was interrupted (Playwright-based suites were halted mid-run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c94592f288333a2339b8e1c86c9d4)