### PR TITLE
Expand Kardashev II demo diagram outputs

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -422,6 +422,28 @@ flowchart TB
 `;
 }
 
+function buildDysonThermoDiagram(dyson, energyMonteCarlo) {
+  return `---
+title Dyson Swarm Thermodynamic Stability
+---
+flowchart LR
+    capture[Captured Power\\n${formatNumber(dyson.capturedMw)} MW] --> reserve[Reserve Buffer\\n${formatNumber(
+      round(energyMonteCarlo.marginGw, 2)
+    )} GW]
+    reserve --> freeEnergy[Free Energy Margin\\n${formatNumber(round(energyMonteCarlo.freeEnergyMarginGw, 2))} GW]
+    freeEnergy --> gibbs[Gibbs Free Energy\\n${formatNumber(round(energyMonteCarlo.gibbsFreeEnergyGj, 2))} GJ]
+    freeEnergy --> entropy[Entropy Buffer\\n${round(energyMonteCarlo.entropyMargin || 0, 2)}σ]
+    gibbs --> hamiltonian[Hamiltonian Stability\\n${round(energyMonteCarlo.hamiltonianStability * 100, 1)}%]
+    hamiltonian --> gameTheory[Game-Theory Slack\\n${round(energyMonteCarlo.gameTheorySlack * 100, 1)}%]
+
+    style capture fill:#111827,stroke:#22d3ee,stroke-width:2px
+    style freeEnergy fill:#1f2937,stroke:#38bdf8,stroke-width:2px
+    style gibbs fill:#1f2937,stroke:#a855f7
+    style hamiltonian fill:#1f2937,stroke:#f97316
+    style gameTheory fill:#111827,stroke:#22c55e,stroke-width:2px
+`;
+}
+
 function buildSequenceDiagram() {
   return `---
 title Interplanetary Settlement
@@ -521,8 +543,11 @@ function main() {
   const outputDir = resolveOutputDir(cliOutputDir, { ensure: !check });
   const mermaidDir = path.join(outputDir, 'mermaid');
   const dysonHierarchyPath = path.join(mermaidDir, 'dyson-hierarchy.mmd');
+  const taskHierarchyPath = path.join(outputDir, 'kardashev-task-hierarchy.mmd');
+  const mermaidMapPath = path.join(outputDir, 'kardashev-mermaid.mmd');
+  const dysonDiagramPath = path.join(outputDir, 'kardashev-dyson.mmd');
   const dysonHierarchyReference =
-    path.relative(outputDir, dysonHierarchyPath) || 'mermaid/dyson-hierarchy.mmd';
+    path.relative(outputDir, taskHierarchyPath) || 'kardashev-task-hierarchy.mmd';
 
   if (!check) {
     ensureDir(outputDir);
@@ -665,8 +690,20 @@ function main() {
       `${buildMermaidTaskHierarchy(dyson)}\n`
     );
     fs.writeFileSync(
+      taskHierarchyPath,
+      `${buildMermaidTaskHierarchy(dyson)}\n`
+    );
+    fs.writeFileSync(
       path.join(mermaidDir, 'interplanetary-settlement.mmd'),
       `${crossChainDiagram}\n`
+    );
+    fs.writeFileSync(
+      mermaidMapPath,
+      `${crossChainDiagram}\n`
+    );
+    fs.writeFileSync(
+      dysonDiagramPath,
+      `${buildDysonThermoDiagram(dyson, energyMonteCarlo)}\n`
     );
     fs.writeFileSync(
       path.join(outputDir, 'kardashev-report.md'),

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -43,8 +43,11 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     report = tmp_path / "kardashev-report.md"
     governance = tmp_path / "governance-playbook.md"
     telemetry = tmp_path / "kardashev-telemetry.json"
+    task_hierarchy = tmp_path / "kardashev-task-hierarchy.mmd"
+    mermaid_map = tmp_path / "kardashev-mermaid.mmd"
+    dyson_diagram = tmp_path / "kardashev-dyson.mmd"
 
-    for path in (report, governance, telemetry):
+    for path in (report, governance, telemetry, task_hierarchy, mermaid_map, dyson_diagram):
         assert path.exists(), f"expected artefact missing: {path}"
 
     telemetry_payload = json.loads(telemetry.read_text())


### PR DESCRIPTION
### Motivation

- Provide richer dashboard visuals for the Kardashev II demo by emitting diagram artefacts alongside telemetry so the UI can render mission and thermodynamic views.  
- Allow the lightweight (legacy) Node demo output to still populate diagrams where available instead of showing placeholders.  
- Surface thermodynamic telemetry (free energy, Gibbs, Hamiltonian, game-theoretic slack) as a purpose-built Mermaid diagram to aid operator comprehension.  
- Make CI assert the new artefacts to prevent regressions in demo outputs.

### Description

- Added `buildDysonThermoDiagram` to `run-demo.cjs` and emit three new artefacts: `kardashev-task-hierarchy.mmd`, `kardashev-mermaid.mmd`, and `kardashev-dyson.mmd` into the demo `output` directory.  
- Updated output path handling in `run-demo.cjs` to write the task hierarchy, mermaid map, and thermodynamic diagram when not running in `--check` mode.  
- Updated `ui/dashboard.js` to attempt rendering available diagrams in legacy telemetry mode, to clear placeholder status classes when diagrams load, and to show per-diagram failure information if rendering fails.  
- Extended the Python demo test `tests/test_run_demo.py` to assert presence of the new `.mmd` artefacts.

### Testing

- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` which succeeded (4 passed).  
- Executed the full demo test runner `python demo/run_demo_tests.py` which completed successfully (all demo suites passed).  
- Generated demo outputs with `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` and confirmed the new `.mmd` artefacts were produced.  
- Started the local dashboard server and captured a browser screenshot to validate diagrams render in the UI during automated verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca2d4728083339fddc9e2051e151a)