### PR TITLE
Add relay‑boost mitigation to bridge‑failover scenario in Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
@@ -27,7 +27,7 @@
 * Mission advisories: dyson-swarm autonomy exceeds max 7800 bps
 * Owner override unstoppable score 100.00% (selectors true, pause true, resume true, secondary aligned @ 100.00%, tertiary aligned @ 100.00% · decode failures 0).
 * Scenario sweep: 6/11 nominal, 4 warning, 1 critical.
-  - Interplanetary bridge outage simulation: Failover latency 180s breaches 120s failsafe.
+  - Interplanetary bridge outage simulation: Failover latency 117s leaves 3s slack within 120s failsafe. Relay boost 35.0% applied from Gibbs reserve.
   - Compute drawdown (15%) resilience: Deviation 14.62% exceeds tolerance 0.75%.
   - Primary energy window offline: Removing orbital 8h window drops coverage to 80.58%.
   - Logistics demand spike (+25%): Corridors absorb spike with utilisation 104.33% and buffers 12.00d.

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-orchestration-report.md
@@ -83,12 +83,14 @@
   - Thermostat margin: 52,500 GW (ok)
   - Utilisation: 69.14% (ok)
   - Recommended: Dispatch pause bundle for non-critical Earth workloads. · Increase stellar thermostat target via setGlobalParameters if surge persists.
-* **Interplanetary bridge outage simulation** — status WARNING (confidence 25.0%) · Failover latency 180s breaches 120s failsafe.
+* **Interplanetary bridge outage simulation** — status WARNING (confidence 51.2%) · Failover latency 117s leaves 3s slack within 120s failsafe. Relay boost 35.0% applied from Gibbs reserve.
   - Baseline latency: 90s (ok)
   - Failover latency: 180s (check)
+  - Relay boost allocation: 35.0% (147000 GW) (ok)
+  - Mitigated latency: 117s (ok)
   - Failsafe budget: 120s (ok)
-  - Slack: -60s (check)
-  - Recommended: Execute bridge isolation routine from mission directives if slack < 0. · Rebalance capital streams to spin up orbital relays before load crosses failsafe.
+  - Slack: 3s (ok)
+  - Recommended: Allocate relay boost to stabilise bridge latency using Gibbs reserve. · Keep isolation routine on standby while relays rebalance. · Rebalance capital streams to spin up orbital relays before load crosses failsafe.
 * **Sentinel outage (10 min) coverage test** — status NOMINAL (confidence 100.0%) · Guardian window stays protected under sentinel gap.
   - Minimum sentinel coverage: 1800s (ok)
   - Simulated coverage: 1200s (ok)

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
@@ -13,6 +13,7 @@ Generated: 2125-01-01T19:05:39.398Z
 - **Thermodynamic Reserve:** 48,523,291.36 GJ Gibbs free energy; Hamiltonian stability 50.8% across the sampled phase space.
 - **Gibbs Allocation Temperature:** 0.49 (lower favors resilience-heavy shards); Nash welfare 9.99%.
 - **Allocation Entropy:** 1.099 (fairness 100.0%); Gibbs potential -0.536.
+- **Strategy Stability:** 100.0% (deviation incentive 0.0%; Jain fairness 100.0%).
 - **Sentinel Status:** 3 advisories generated; all resolved within guardian SLA.
 
 ## Shard Operations
@@ -57,5 +58,5 @@ Generated: 2125-01-01T19:05:39.398Z
 - Assembly rate: 96 satellites/day
 - Energy per satellite: 45 MW
 
-A detailed task hierarchy diagram is available at `mermaid/dyson-hierarchy.mmd`.
+A detailed task hierarchy diagram is available at `kardashev-task-hierarchy.mmd`.
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-scenario-sweep.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-scenario-sweep.json
@@ -37,8 +37,8 @@
     "id": "bridge-failover",
     "title": "Interplanetary bridge outage simulation",
     "status": "warning",
-    "summary": "Failover latency 180s breaches 120s failsafe.",
-    "confidence": 0.25,
+    "summary": "Failover latency 117s leaves 3s slack within 120s failsafe. Relay boost 35.0% applied from Gibbs reserve.",
+    "confidence": 0.5125,
     "impact": "Bridge sentries maintain cadence under reroute load.",
     "metrics": [
       {
@@ -52,18 +52,29 @@
         "ok": false
       },
       {
+        "label": "Relay boost allocation",
+        "value": "35.0% (147000 GW)",
+        "ok": true
+      },
+      {
+        "label": "Mitigated latency",
+        "value": "117s",
+        "ok": true
+      },
+      {
         "label": "Failsafe budget",
         "value": "120s",
         "ok": true
       },
       {
         "label": "Slack",
-        "value": "-60s",
-        "ok": false
+        "value": "3s",
+        "ok": true
       }
     ],
     "recommendedActions": [
-      "Execute bridge isolation routine from mission directives if slack < 0.",
+      "Allocate relay boost to stabilise bridge latency using Gibbs reserve.",
+      "Keep isolation routine on standby while relays rebalance.",
       "Rebalance capital streams to spin up orbital relays before load crosses failsafe."
     ]
   },

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-stability-ledger.json
@@ -39,7 +39,7 @@
       },
       {
         "method": "scenario-sweep",
-        "score": 0.8306620510044156,
+        "score": 0.8545256873680519,
         "explanation": "Average confidence across Kardashev-II surge, bridge, sentinel, compute, identity, and schedule stressors."
       },
       {
@@ -314,7 +314,7 @@
     "nominal": 6,
     "warning": 4,
     "critical": 1,
-    "averageConfidence": 0.8306620510044156,
+    "averageConfidence": 0.8545256873680519,
     "entries": [
       {
         "id": "energy-demand-surge",
@@ -327,8 +327,8 @@
         "id": "bridge-failover",
         "title": "Interplanetary bridge outage simulation",
         "status": "warning",
-        "confidence": 0.25,
-        "summary": "Failover latency 180s breaches 120s failsafe."
+        "confidence": 0.5125,
+        "summary": "Failover latency 117s leaves 3s slack within 120s failsafe. Relay boost 35.0% applied from Gibbs reserve."
       },
       {
         "id": "sentinel-gap",

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-telemetry.json
@@ -1814,8 +1814,8 @@
       "id": "bridge-failover",
       "title": "Interplanetary bridge outage simulation",
       "status": "warning",
-      "summary": "Failover latency 180s breaches 120s failsafe.",
-      "confidence": 0.25,
+      "summary": "Failover latency 117s leaves 3s slack within 120s failsafe. Relay boost 35.0% applied from Gibbs reserve.",
+      "confidence": 0.5125,
       "impact": "Bridge sentries maintain cadence under reroute load.",
       "metrics": [
         {
@@ -1829,18 +1829,29 @@
           "ok": false
         },
         {
+          "label": "Relay boost allocation",
+          "value": "35.0% (147000 GW)",
+          "ok": true
+        },
+        {
+          "label": "Mitigated latency",
+          "value": "117s",
+          "ok": true
+        },
+        {
           "label": "Failsafe budget",
           "value": "120s",
           "ok": true
         },
         {
           "label": "Slack",
-          "value": "-60s",
-          "ok": false
+          "value": "3s",
+          "ok": true
         }
       ],
       "recommendedActions": [
-        "Execute bridge isolation routine from mission directives if slack < 0.",
+        "Allocate relay boost to stabilise bridge latency using Gibbs reserve.",
+        "Keep isolation routine on standby while relays rebalance.",
         "Rebalance capital streams to spin up orbital relays before load crosses failsafe."
       ]
     },


### PR DESCRIPTION
### Motivation
- Improve resilience of the Kardashev‑II demo by automatically modelling an energy‑based relay boost to mitigate interplanetary bridge failovers using thermodynamic/allocation signals. 
- Surface measurable mitigation metrics and recommended actions so operator runbooks and dashboards can show when Gibbs reserves are being used to stabilise latency.

### Description
- Compute a `relayBoostPct` derived from Monte Carlo Gibbs free energy margin and allocation `strategyStability`, and apply it to mitigate `failoverLatency` in the `bridge-failover` scenario inside `scripts/run-kardashev-demo.ts`.
- Add derived metrics (`relayBoostAllocation`, `mitigatedLatency`, `effectiveSlack`) and a contextual `mitigationNote` to the scenario summary, metrics and recommended actions so reports can advise either applying the boost or restoring the Gibbs reserve.
- Regenerate and update demo artefacts under `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/` so dashboards and reports include the new mitigation information (e.g. `kardashev-scenario-sweep.json`, `kardashev-telemetry.json`, `kardashev-report.md`).

### Testing
- Ran `npm run demo:kardashev-ii:orchestrate` which completed successfully and produced orchestration output including the updated bridge mitigation entries. (Succeeded)
- Ran `npm run demo:kardashev-ii:ci` (the TypeScript CI validate wrapper) which verified artefacts and README headings and returned a successful check. (Succeeded)
- Confirmed the scenario sweep JSON now contains the `bridge-failover` entry with `Relay boost` allocation and updated confidence/metrics. (Observed)
- Executed the Node wrapper `node run-demo.cjs` to regenerate outputs and verified the executive summary and telemetry include `Gibbs`/`strategyStability` signals used by the mitigation. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d55f2a164833393531548016359d1)