### PR TITLE
Add ledger and owner proof outputs to Kardashev demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -43,11 +43,22 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     report = tmp_path / "kardashev-report.md"
     governance = tmp_path / "governance-playbook.md"
     telemetry = tmp_path / "kardashev-telemetry.json"
+    stability_ledger = tmp_path / "kardashev-stability-ledger.json"
+    owner_proof = tmp_path / "kardashev-owner-proof.json"
     task_hierarchy = tmp_path / "kardashev-task-hierarchy.mmd"
     mermaid_map = tmp_path / "kardashev-mermaid.mmd"
     dyson_diagram = tmp_path / "kardashev-dyson.mmd"
 
-    for path in (report, governance, telemetry, task_hierarchy, mermaid_map, dyson_diagram):
+    for path in (
+        report,
+        governance,
+        telemetry,
+        stability_ledger,
+        owner_proof,
+        task_hierarchy,
+        mermaid_map,
+        dyson_diagram,
+    ):
         assert path.exists(), f"expected artefact missing: {path}"
 
     telemetry_payload = json.loads(telemetry.read_text())
@@ -70,6 +81,16 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert 0 <= allocation["strategyStability"] <= 1
     assert 0 <= allocation["deviationIncentive"] <= 1
     assert 0 <= allocation["jainIndex"] <= 1
+
+    ledger_payload = json.loads(stability_ledger.read_text())
+    assert ledger_payload["confidence"]["compositeScore"] >= 0
+    assert isinstance(ledger_payload["checks"], list)
+    assert "summary" in ledger_payload["confidence"]
+
+    owner_payload = json.loads(owner_proof.read_text())
+    assert owner_payload["verification"]["unstoppableScore"] >= 0
+    assert owner_payload["secondaryVerification"]["matchesPrimaryScore"] is True
+    assert owner_payload["hashes"]["transactionSet"].startswith("sha256:")
 
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")


### PR DESCRIPTION
### Motivation

- The Kardashev II demo dashboard expected stability ledger and owner-proof artefacts which were not produced by the lightweight Node demo output, causing parts of the UI to be disabled.
- Generate verifiable ledger and owner-proof payloads so the dashboard can render full telemetry, evidence and owner control checks without requiring the full orchestrator.
- Provide compact, testable provenance (sha256) for owner transaction/selector sets to improve auditability.

### Description

- Add `crypto` utilities and helpers (`clamp01`, `hashString`) and implement `buildStabilityLedger` and `buildOwnerProof` in `run-demo.cjs` to synthesize ledger and owner-proof payloads.
- Emit new artefacts as JSON and inline JS: `kardashev-stability-ledger.json`, `kardashev-stability-ledger.inline.js`, `kardashev-owner-proof.json`, and `kardashev-owner-proof.inline.js` alongside existing telemetry outputs.
- Populate ledger with composite confidence, checks and alerts computed from `energyMonteCarlo`, shard metrics, allocation policy and sentinel findings, and populate owner proof with verification summaries and hashed selector/transaction sets.
- Extend the demo tests in `tests/test_run_demo.py` to assert the presence and basic validity of the new artefacts and their fields.

### Testing

- Ran the demo test suite with `pytest -q` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale` and all tests passed (`4 passed in ~1.7s`).
- Updated unit assertions validate the generated `stability-ledger` and `owner-proof` payloads contain expected fields and hash prefixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d76d1872c8333b0934ac60a4c523f)