### PR TITLE
Enrich Kardashev II demo telemetry and mission synthesis

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -64,6 +64,9 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     telemetry_payload = json.loads(telemetry.read_text())
     assert telemetry_payload.get("energyMonteCarlo", {}).get("withinTolerance") is True
     assert telemetry_payload.get("dominanceScore")
+    assert telemetry_payload.get("dominance", {}).get("score") == telemetry_payload["dominanceScore"]
+    assert telemetry_payload.get("dominance", {}).get("monthlyValueUSD") > 0
+    assert 0 <= telemetry_payload.get("dominance", {}).get("averageResilience") <= 1
 
     energy = telemetry_payload["energyMonteCarlo"]
     assert energy["maintainsBuffer"] is True
@@ -91,6 +94,14 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert owner_payload["verification"]["unstoppableScore"] >= 0
     assert owner_payload["secondaryVerification"]["matchesPrimaryScore"] is True
     assert owner_payload["hashes"]["transactionSet"].startswith("sha256:")
+
+    telemetry_energy = telemetry_payload["energy"]
+    assert telemetry_energy["utilisationPct"] > 0
+    assert telemetry_energy["models"]["regionalSumGw"] > 0
+    assert telemetry_energy["monteCarlo"]["withinTolerance"] is True
+    assert telemetry_energy["liveFeeds"]["feeds"]
+    assert telemetry_payload["missionDirectives"]["ownerPowers"]
+    assert telemetry_payload["missionLattice"]["programmes"]
 
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")


### PR DESCRIPTION
### Motivation

- Populate the Kardashev II dashboard with richer telemetry so the UI can render energy, governance, mission, logistics, and settlement views. 
- Surface game-theoretic and thermodynamic signals (Gibbs potential, Hamiltonian stability, free energy margin, Nash-like payoffs) to aid operator decision-making. 
- Harden validation by failing fast on malformed configs (fabric, energy feeds, manifest, task lattice) to improve contributor feedback. 
- Make mission/task lattice data actionable for scenario sweeps and owner-proof synthesis to improve auditability.

### Description

- Added numeric helpers and synthesis functions to `run-demo.cjs` including `average`, `sum`, `clampRatio`, energy-model builders, live feed simulation, and enrichment of allocation policy. 
- Implemented mission and task-lattice processing (`buildMissionLattice`, critical path, task collectors) plus identity, compute fabric, orchestration fabric, logistics, settlement, energy schedule, and scenario-sweep synthesizers. 
- Integrated manifest and task-lattice inputs into telemetry, expanded the telemetry payload (energy, governance, verification, bridges, missionLattice, logistics, settlement, scenarioSweep) and preserved existing owner-proof and ledger outputs. 
- Added `validateManifest` and `validateTaskLattice` validators and updated `tests/test_run_demo.py` to assert the new telemetry fields and behaviours. 

### Testing

- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` which exercised the wrapper and artefact generation, and all tests passed (4 passed). 
- Verified the wrapper `run_demo.py --check` path completes successfully and reports validation in check mode. 
- Existing demo test suites were observed previously to be green in the environment prior to the change and the focused demo tests remain green after the update. 
- The updated test assertions were executed and validated the new telemetry structure and expected numeric ranges.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d9c3f45d0833398838c5925dd4d34)