### PR TITLE
Enhance Kardashev II welfare telemetry with coalition & dispersion metrics

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -94,9 +94,12 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert sentient["freeEnergyPerAgentGj"] >= 0
     assert 0 <= sentient["cooperationIndex"] <= 1
     assert 0 <= sentient["inequalityIndex"] <= 1
+    assert sentient["payoffCoefficient"] >= 0
+    assert 0 <= sentient["coalitionStability"] <= 1
     assert 0 <= sentient["paretoSlack"] <= 1
     assert 0 <= sentient["equilibriumScore"] <= 1
     assert 0 <= sentient["welfarePotential"] <= 1
+    assert 0 <= sentient["collectiveActionPotential"] <= 1
 
     ledger_payload = json.loads(stability_ledger.read_text())
     assert ledger_payload["confidence"]["compositeScore"] >= 0

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -263,8 +263,14 @@ function renderSentientWelfare(welfare) {
   const potentialText = Number.isFinite(welfare.welfarePotential)
     ? `${(welfare.welfarePotential * 100).toFixed(1)}%`
     : "n/a";
+  const coalitionText = Number.isFinite(welfare.coalitionStability)
+    ? `${(welfare.coalitionStability * 100).toFixed(1)}%`
+    : "n/a";
+  const actionText = Number.isFinite(welfare.collectiveActionPotential)
+    ? `${(welfare.collectiveActionPotential * 100).toFixed(1)}%`
+    : "n/a";
 
-  details.textContent = `Cooperation ${cooperationText} · inequality ${inequalityText} · Pareto slack ${paretoText} · welfare potential ${potentialText}`;
+  details.textContent = `Cooperation ${cooperationText} · inequality ${inequalityText} · Pareto slack ${paretoText} · welfare potential ${potentialText} · coalition stability ${coalitionText} · collective action ${actionText}`;
 
   if (Number.isFinite(welfare.equilibriumScore)) {
     const score = welfare.equilibriumScore;


### PR DESCRIPTION
### Motivation
- Improve sentient welfare observability by adding measures that capture payoff dispersion and coalition readiness, complementing existing Gibbs/Hamiltonian and game-theory signals. 
- Provide actionable, game-theory-informed indicators (coalition stability, payoff coefficient, collective-action potential) for mission owners and orchestrator decision layers.
- Surface these metrics in human-facing outputs so dashboards and reports present richer, aligned signals for supervision and verification.

### Description
- Added `computeCoefficientOfVariation` and integrated it into `buildSentientWelfare` to compute `payoffCoefficient`, `coalitionStability`, and `collectiveActionPotential` in `run-demo.cjs`.
- Emitted the new welfare fields into the report summary so the Markdown operator briefing includes coalition stability, collective action potential, and payoff dispersion.
- Updated the dashboard renderer `ui/dashboard.js` to display the new welfare metrics inline in the Sentient Welfare details line.
- Extended the demo test `tests/test_run_demo.py` to validate the presence and range of the new telemetry fields.

### Testing
- Ran `npm run demo:kardashev-ii:ci` to validate demo artefacts and README, which completed successfully. 
- Executed `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` which passed all checks (4 tests passed). 
- Launched the local dashboard server with the bundled `serve-dashboard.cjs` and captured a Playwright screenshot to verify UI rendering of the new fields (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dfb700ab8833380f345be1497f81b)