### PR TITLE
Add equilibrium action path to Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -139,6 +139,8 @@
         <ul id="equilibrium-components" class="ledger-list"></ul>
         <h3>Pathways</h3>
         <ul id="equilibrium-pathways" class="ledger-list"></ul>
+        <h3>Action path</h3>
+        <ul id="equilibrium-action-path" class="ledger-list"></ul>
         <h3>Recommendations</h3>
         <ul id="equilibrium-recommendations" class="ledger-list"></ul>
       </section>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -121,6 +121,9 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert equilibrium_payload["components"]["compute"]["averageAvailabilityPct"] >= 0
     assert equilibrium_payload["pathways"]
     assert equilibrium_payload["pathways"][0]["title"]
+    assert equilibrium_payload["actionPath"]
+    assert equilibrium_payload["actionPath"][0]["title"]
+    assert equilibrium_payload["actionPath"][0]["target"]
 
     telemetry_energy = telemetry_payload["energy"]
     assert telemetry_energy["utilisationPct"] > 0

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -1293,8 +1293,9 @@ function renderEquilibriumLedger(ledger) {
   const summary = document.querySelector("#equilibrium-summary");
   const componentsList = document.querySelector("#equilibrium-components");
   const pathwaysList = document.querySelector("#equilibrium-pathways");
+  const actionPathList = document.querySelector("#equilibrium-action-path");
   const recommendationsList = document.querySelector("#equilibrium-recommendations");
-  if (!summary || !componentsList || !pathwaysList || !recommendationsList) return;
+  if (!summary || !componentsList || !pathwaysList || !actionPathList || !recommendationsList) return;
 
   if (!ledger) {
     renderEquilibriumUnavailable("Missing ledger payload.");
@@ -1352,6 +1353,22 @@ function renderEquilibriumLedger(ledger) {
       li.innerHTML = `<strong>${pathway.title}</strong> — ${pathway.rationale}<br /><span>${pathway.action}</span>`;
       li.classList.add(status);
       pathwaysList.appendChild(li);
+    });
+  }
+
+  actionPathList.innerHTML = "";
+  if (!ledger.actionPath || ledger.actionPath.length === 0) {
+    const li = document.createElement("li");
+    li.textContent = "No action path available.";
+    li.classList.add("status-warn");
+    actionPathList.appendChild(li);
+  } else {
+    ledger.actionPath.forEach((step) => {
+      const li = document.createElement("li");
+      const status = step.status === "needs-action" ? "status-warn" : "status-ok";
+      li.innerHTML = `<strong>${step.rank}. ${step.title}</strong> — ${step.rationale}<br /><span>${step.action}</span><br /><span>Target: ${step.target}</span>`;
+      li.classList.add(status);
+      actionPathList.appendChild(li);
     });
   }
 


### PR DESCRIPTION
### Motivation

- Provide a concise, actionable recovery sequence when the equilibrium ledger indicates thermodynamic or game-theoretic risk. 
- Surface the recovery path in the dashboard so operators can see ranked interventions at-a-glance. 
- Make the action path part of the generated ledger so downstream tooling and CI can consume it. 
- Validate the new payload in automated demo tests to prevent regressions.

### Description

- Add `buildEquilibriumActionPath(...)` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` which synthesises ranked remediation steps (energy, Nash deviation, welfare, logistics, compute). 
- Include the produced `actionPath` in the equilibrium ledger payload emitted by the demo (`actionPath` alongside `pathways` and `recommendations`). 
- Add a UI region to `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html` (`#equilibrium-action-path`) and render logic in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js` to present ranked steps and targets. 
- Extend `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` to assert the presence and basic structure of `actionPath` in the equilibrium ledger.

### Testing

- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests -q` and the suite covering the demo passed: `4 passed`.
- Executed the Node demo `run-demo.cjs` to confirm artefacts are generated and `actionPath` is present in the produced equilibrium ledger (smoke validation).
- UI rendering changes were exercised via a static serve of the demo and inspected; Playwright screenshot capture was attempted but the headless browser crashed in this environment (SIGSEGV), so a programmatic screenshot was not produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea2bdbe148333acbbd5e03ffe636c)