### PR TITLE
Respect operator simulation actions in omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -717,7 +717,8 @@ class Orchestrator:
             return
         policy = payload.get("policy")
         action_payload = payload.get("action_payload")
-        if isinstance(policy, str):
+        auto_policy = isinstance(policy, str) and policy.lower() in {"auto", "autonomous"}
+        if auto_policy and action_payload is None:
             async with self._simulation_lock:
                 if self._latest_simulation_state is None:
                     state = self.simulation.tick(hours=0.0)

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
@@ -44,6 +44,28 @@ def test_simulation_policy_auto_generates_action() -> None:
     assert "build_dyson_nodes" in orchestrator._last_simulation_action["action"]
 
 
+def test_simulation_operator_action_respects_payload() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
+    assert orchestrator.simulation is not None
+
+    asyncio.run(
+        orchestrator._handle_simulation_action(
+            {
+                "policy": "operator",
+                "action_payload": {
+                    "build_dyson_nodes": 4.0,
+                    "stimulus": 1.0,
+                    "green_shift": 2.0,
+                },
+            }
+        )
+    )
+
+    assert orchestrator._last_simulation_action is not None
+    assert orchestrator._last_simulation_action["policy"] == "operator"
+    assert orchestrator._last_simulation_action["action"]["build_dyson_nodes"] == 4.0
+
+
 def test_policy_action_accounts_for_compute_scarcity() -> None:
     orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
     low_coordination_state = SimulationState(


### PR DESCRIPTION
### Motivation

- Prevent automatic policy generation from overriding explicit operator-provided simulation actions.
- Make the orchestrator behavior predictable when an operator supplies an `action_payload` versus requesting autonomous policy generation.
- Improve test coverage for operator-driven simulation actions to avoid regressions.

### Description

- Modify `Orchestrator._handle_simulation_action` to detect an `auto`/`autonomous` policy (case-insensitive) and only generate a policy action when `action_payload` is not provided, preserving explicit operator payloads.
- Normalize auto-policy detection via `auto_policy = isinstance(policy, str) and policy.lower() in {"auto", "autonomous"}` and conditionally call `_build_policy_action` only when appropriate.
- Add `test_simulation_operator_action_respects_payload` to `demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py` which verifies operator-supplied payloads are applied unchanged.

### Testing

- Ran the targeted tests with `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py` and all tests passed (`4 passed`).
- The change is narrowly scoped and unit-tested to prevent auto-generation from overriding explicit operator actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ecac125608333bb3cb94a81fa34a9)