### PR TITLE
Add policy rationale telemetry for omega demo actions

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
@@ -31,6 +31,7 @@ def test_simulation_action_updates_resources() -> None:
     assert orchestrator.resources.energy_capacity >= initial_capacity
     assert orchestrator._last_simulation_action is not None
     assert orchestrator._last_simulation_action["action"]["build_dyson_nodes"] == 2.0
+    assert orchestrator._last_simulation_action["rationale"]["policy_source"] == "operator"
 
 
 def test_simulation_policy_auto_generates_action() -> None:
@@ -42,6 +43,7 @@ def test_simulation_policy_auto_generates_action() -> None:
     assert orchestrator._last_simulation_action is not None
     assert orchestrator._last_simulation_action["policy"] == "auto"
     assert "build_dyson_nodes" in orchestrator._last_simulation_action["action"]
+    assert orchestrator._last_simulation_action["rationale"]["policy_source"] == "autonomous"
 
 
 def test_simulation_operator_action_respects_payload() -> None:
@@ -64,6 +66,7 @@ def test_simulation_operator_action_respects_payload() -> None:
     assert orchestrator._last_simulation_action is not None
     assert orchestrator._last_simulation_action["policy"] == "operator"
     assert orchestrator._last_simulation_action["action"]["build_dyson_nodes"] == 4.0
+    assert orchestrator._last_simulation_action["rationale"]["policy_source"] == "operator"
 
 
 def test_policy_action_accounts_for_compute_scarcity() -> None:


### PR DESCRIPTION
### Motivation
- Improve observability of autonomous and operator-driven simulation decisions by capturing the underlying policy signals and rationale. 
- Surface thermodynamic and game-theoretic signals (Gibbs free energy, Hamiltonian, coordination indices, price pressures) to make policy behaviour interpretable. 
- Provide structured telemetry for downstream analysis, replay and safer debugging of Kardashev-II demo policy actions.

### Description
- Add ` _compute_policy_signals`, `_build_policy_rationale`, and `_build_policy_decision` helpers to compute physics- and game-theory-inspired signals and structured rationales. 
- Emit policy `rationale` alongside the applied `action` in `self._last_simulation_action` and expose the latest action under the `policy` key in status snapshots. 
- Wire autonomous policy loop and operator-triggered simulation actions to produce and persist decision rationales, and keep the original `_build_policy_action` API by delegating to the new decision path. 
- Extend tests in `test_simulation_actions.py` to assert the presence and provenance (`policy_source`) of rationale metadata.

### Testing
- Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/tests/test_policy_actions.py`, which completed with all tests passing. 
- The change is limited to the omega demo code paths and corresponding unit tests were updated and validated successfully. 
- Existing demo test harness was run during investigation and earlier runs showed the broader demo suites passing prior to this targeted change. 
- No automated tests failed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ef3856c908333abe3069600092c2e)