### PR TITLE
Add stability index to Omega demo policy signals and actions

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -15,6 +15,7 @@ class SimulationState:
     free_energy: float = 0.0
     entropy: float = 0.0
     hamiltonian: float = 0.0
+    stability_index: float = 0.0
     coordination_index: float = 0.0
     game_theory_slack: float = 0.0
 
@@ -61,6 +62,9 @@ class SyntheticEconomySim(PlanetarySimulation):
         hamiltonian = -internal_energy * order_parameter
         coordination_index = 1.0 - abs(self.prosperity_index - self.sustainability_index)
         coordination_index = min(1.0, max(0.0, coordination_index))
+        stability_index = math.exp(-entropy) * (1.0 / (1.0 + abs(hamiltonian)))
+        stability_index *= 0.5 + 0.5 * coordination_index
+        stability_index = min(1.0, max(0.0, stability_index))
         nash_welfare = math.sqrt(
             max(1e-6, self.prosperity_index) * max(1e-6, self.sustainability_index)
         )
@@ -69,6 +73,7 @@ class SyntheticEconomySim(PlanetarySimulation):
             "free_energy": free_energy,
             "entropy": entropy,
             "hamiltonian": hamiltonian,
+            "stability_index": stability_index,
             "coordination_index": coordination_index,
             "game_theory_slack": game_theory_slack,
         }
@@ -89,6 +94,7 @@ class SyntheticEconomySim(PlanetarySimulation):
             free_energy=metrics["free_energy"],
             entropy=metrics["entropy"],
             hamiltonian=metrics["hamiltonian"],
+            stability_index=metrics["stability_index"],
             coordination_index=metrics["coordination_index"],
             game_theory_slack=metrics["game_theory_slack"],
         )

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
@@ -22,6 +22,9 @@ def test_simulation_thermodynamic_metrics() -> None:
     free_energy = internal_energy - temperature * entropy
     hamiltonian = -internal_energy * order_parameter
     coordination_index = 1.0 - abs(state.prosperity_index - state.sustainability_index)
+    stability_index = math.exp(-entropy) * (1.0 / (1.0 + abs(hamiltonian)))
+    stability_index *= 0.5 + 0.5 * coordination_index
+    stability_index = min(1.0, max(0.0, stability_index))
     nash_welfare = math.sqrt(
         max(1e-6, state.prosperity_index) * max(1e-6, state.sustainability_index)
     )
@@ -30,7 +33,9 @@ def test_simulation_thermodynamic_metrics() -> None:
     assert state.entropy == pytest.approx(entropy)
     assert state.free_energy == pytest.approx(free_energy)
     assert state.hamiltonian == pytest.approx(hamiltonian)
+    assert state.stability_index == pytest.approx(stability_index)
     assert state.coordination_index == pytest.approx(coordination_index)
     assert state.game_theory_slack == pytest.approx(game_theory_slack)
     assert 0.0 <= state.coordination_index <= 1.0
+    assert 0.0 <= state.stability_index <= 1.0
     assert 0.0 <= state.game_theory_slack <= 1.0


### PR DESCRIPTION
### Motivation
- Provide a concise, thermodynamically-informed stability metric to augment existing free-energy / Hamiltonian signals used by autonomous policies.
- Let policy decisions account for a stability signal so energy expansion and fiscal stimulus scale more robustly under entropy/hamiltonian-driven volatility.
- Surface the metric in runtime snapshots so operators and oracles can observe the stability signal alongside other simulation telemetry.
- Keep unit coverage aligned by validating the new metric in the existing simulation metrics test.

### Description
- Add `stability_index` to `SimulationState` and compute it in `SyntheticEconomySim._compute_thermodynamic_metrics` as a clamped function of entropy and the Hamiltonian combined with coordination.
- Feed `stability_index` into `Orchestrator._compute_policy_signals` and derive a `stability_factor` used to damp/boost decision weighting, and a `stability_modifier` used to scale `build_dyson_nodes`, `stimulus`, and `green_shift` in `_build_policy_decision`.
- Expose `stability_index` in the orchestrator status and energy snapshots so it is emitted to status output and the energy oracle.
- Update `test_simulation_thermodynamic_metrics` to assert the computed `stability_index` and its bounds.

### Testing
- Ran `pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests"` and the suite completed successfully with `16 passed`.
- The modified simulation metric test `test_simulation_thermodynamic_metrics` asserts the new `stability_index` value and bounds and passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f2d06320483339e8bd7c511e49d58)