### PR TITLE
Fix omega demo main entrypoint resolution

### DIFF
--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__init__.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__init__.py
@@ -38,6 +38,11 @@ __all__ = getattr(_module, "__all__", [])
 _main_attr = getattr(_module, "main", None)
 if _main_attr is None:
     _main_attr = importlib.import_module(f"{__name__}.cli").main
+
+# ``sys.modules`` already points at the nested module, so ensure the fallback
+# ``main`` attribute is attached to that object rather than the transient
+# wrapper module instance.
+setattr(_module, "main", _main_attr)
 main = _main_attr
 
 


### PR DESCRIPTION
### Motivation

- The ASCII-safe wrapper for the Omega-grade demo failed to expose a `main` entrypoint because the nested (Unicode-path) package was loaded into `sys.modules` but the fallback `main` was only attached to the transient wrapper module.
- This caused `run_demo`-style launchers to raise `AttributeError` when operators invoked the ASCII wrapper instead of the canonical package.
- The intent is to keep the wrapper ergonomic while preserving the canonical package API surface for CLI invocations.

### Description

- Update `demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/__init__.py` to attach the resolved fallback `main` callable directly to the loaded nested module via `setattr(_module, "main", _main_attr)`.
- Preserve the existing behavior of importing the nested package and re-exporting its public API while ensuring the `main` attribute is available on the actual module instance stored in `sys.modules`.
- Keep `main = _main_attr` so the wrapper continues to expose the `main` symbol from its own namespace.

### Testing

- Ran the ASCII launcher help to validate CLI wiring with `python demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/run_demo.py --help` and it completed successfully.
- Validated config-only path with `python demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/run_demo.py --no-run` which returned `Configuration validated. No run performed.`.
- Executed the package test suite with `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_omega/tests -q` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f3b29daf08333b6ab3fc6794a457c)