### PR TITLE
Add Nash welfare metric to simulation and use it in policy signals

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -423,6 +423,7 @@ class Orchestrator:
             energy_output=state.energy_output_gw,
             prosperity=state.prosperity_index,
             sustainability=state.sustainability_index,
+            nash_welfare=state.nash_welfare,
             free_energy=state.free_energy,
             entropy=state.entropy,
             hamiltonian=state.hamiltonian,
@@ -671,6 +672,7 @@ class Orchestrator:
         sustainability_gap = max(0.0, 1.0 - state.sustainability_index)
         coordination_gap = max(0.0, 1.0 - state.coordination_index)
         game_theory_slack = max(0.0, min(1.0, state.game_theory_slack))
+        nash_welfare = max(0.0, min(1.0, state.nash_welfare))
         stability_index = max(0.0, min(1.0, state.stability_index))
         energy_price_pressure = max(0.0, self.resources.energy_price - 1.0)
         compute_price_pressure = max(0.0, self.resources.compute_price - 1.0)
@@ -690,6 +692,7 @@ class Orchestrator:
         stability_factor = (
             (0.6 + 0.4 * stability_index)
             * (0.7 + 0.3 * game_theory_slack)
+            * (0.8 + 0.2 * nash_welfare)
             * max(0.4, 1.0 - 0.2 * compute_price_pressure)
         )
         coordination_damping = max(0.2, 1.0 - 0.3 * coordination_gap) * stability_factor
@@ -699,6 +702,7 @@ class Orchestrator:
             "sustainability_gap": sustainability_gap,
             "coordination_gap": coordination_gap,
             "game_theory_slack": game_theory_slack,
+            "nash_welfare": nash_welfare,
             "stability_index": stability_index,
             "energy_price_pressure": energy_price_pressure,
             "compute_price_pressure": compute_price_pressure,
@@ -1370,10 +1374,11 @@ class Orchestrator:
         if self._latest_simulation_state is not None:
             simulation_state = {
                 "energy_output_gw": self._latest_simulation_state.energy_output_gw,
-                "prosperity_index": self._latest_simulation_state.prosperity_index,
-                "sustainability_index": self._latest_simulation_state.sustainability_index,
-                "free_energy": self._latest_simulation_state.free_energy,
-                "entropy": self._latest_simulation_state.entropy,
+            "prosperity_index": self._latest_simulation_state.prosperity_index,
+            "sustainability_index": self._latest_simulation_state.sustainability_index,
+            "nash_welfare": self._latest_simulation_state.nash_welfare,
+            "free_energy": self._latest_simulation_state.free_energy,
+            "entropy": self._latest_simulation_state.entropy,
                 "hamiltonian": self._latest_simulation_state.hamiltonian,
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,
@@ -1453,10 +1458,11 @@ class Orchestrator:
         if self._latest_simulation_state is not None:
             simulation_state = {
                 "energy_output_gw": self._latest_simulation_state.energy_output_gw,
-                "prosperity_index": self._latest_simulation_state.prosperity_index,
-                "sustainability_index": self._latest_simulation_state.sustainability_index,
-                "free_energy": self._latest_simulation_state.free_energy,
-                "entropy": self._latest_simulation_state.entropy,
+            "prosperity_index": self._latest_simulation_state.prosperity_index,
+            "sustainability_index": self._latest_simulation_state.sustainability_index,
+            "nash_welfare": self._latest_simulation_state.nash_welfare,
+            "free_energy": self._latest_simulation_state.free_energy,
+            "entropy": self._latest_simulation_state.entropy,
                 "hamiltonian": self._latest_simulation_state.hamiltonian,
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -12,6 +12,7 @@ class SimulationState:
     energy_output_gw: float
     prosperity_index: float
     sustainability_index: float
+    nash_welfare: float = 0.0
     free_energy: float = 0.0
     entropy: float = 0.0
     hamiltonian: float = 0.0
@@ -70,6 +71,7 @@ class SyntheticEconomySim(PlanetarySimulation):
         )
         game_theory_slack = min(1.0, nash_welfare * (0.5 + 0.5 * coordination_index))
         return {
+            "nash_welfare": nash_welfare,
             "free_energy": free_energy,
             "entropy": entropy,
             "hamiltonian": hamiltonian,
@@ -91,6 +93,7 @@ class SyntheticEconomySim(PlanetarySimulation):
             energy_output_gw=self.energy_output_gw,
             prosperity_index=self.prosperity_index,
             sustainability_index=self.sustainability_index,
+            nash_welfare=metrics["nash_welfare"],
             free_energy=metrics["free_energy"],
             entropy=metrics["entropy"],
             hamiltonian=metrics["hamiltonian"],

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
@@ -31,6 +31,7 @@ def test_simulation_thermodynamic_metrics() -> None:
     game_theory_slack = min(1.0, nash_welfare * (0.5 + 0.5 * coordination_index))
 
     assert state.entropy == pytest.approx(entropy)
+    assert state.nash_welfare == pytest.approx(nash_welfare)
     assert state.free_energy == pytest.approx(free_energy)
     assert state.hamiltonian == pytest.approx(hamiltonian)
     assert state.stability_index == pytest.approx(stability_index)
@@ -39,3 +40,4 @@ def test_simulation_thermodynamic_metrics() -> None:
     assert 0.0 <= state.coordination_index <= 1.0
     assert 0.0 <= state.stability_index <= 1.0
     assert 0.0 <= state.game_theory_slack <= 1.0
+    assert 0.0 <= state.nash_welfare <= 1.0


### PR DESCRIPTION
### Motivation

- Surface a Nash welfare metric from the planetary simulation so policy decisions can use a direct game-theoretic signal.  
- Ground autonomous policy actions in an explicit cooperative welfare measure to improve coordination vs. pure thermodynamic signals.  
- Expose the metric in telemetry and logs so dashboards and audits can reason about multi-agent outcomes.  

### Description

- Add `nash_welfare` to `SimulationState` and compute it in `SyntheticEconomySim._compute_thermodynamic_metrics`.  
- Include `nash_welfare` in `_snapshot_state()` so simulation ticks and applied actions populate the field.  
- Use `state.nash_welfare` in `Orchestrator._compute_policy_signals` to influence `stability_factor`, and surface `nash_welfare` in orchestrator logs and status/energy snapshots.  
- Extend `test_simulation_metrics.py` to assert the `nash_welfare` value and its valid range.  

### Testing

- Ran `pytest demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/tests -q` and observed `16 passed` for the modified demo tests.  
- Existing demo integration smoke (invoking CLI wrapper and a single-cycle run) was exercised during the rollout and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f44e561108333ad796d08546f7878)