### PR TITLE
Add mission thermodynamics and action-queue to Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -104,6 +104,12 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert 0 <= sentient["welfarePotential"] <= 1
     assert 0 <= sentient["collectiveActionPotential"] <= 1
 
+    mission_thermo = telemetry_payload["missionThermodynamics"]
+    assert 0 <= mission_thermo["hamiltonianLoad"] <= 1
+    assert 0 <= mission_thermo["hamiltonianStability"] <= 1
+    assert 0 <= mission_thermo["freeEnergyHeadroomPct"] <= 1
+    assert mission_thermo["actionQueue"]
+
     ledger_payload = json.loads(stability_ledger.read_text())
     assert ledger_payload["confidence"]["compositeScore"] >= 0
     assert isinstance(ledger_payload["checks"], list)


### PR DESCRIPTION
### Motivation
- Quantify mission-level thermodynamic pressure so the Kardashev II demo can reason about free-energy headroom and Hamiltonian stability across programmes. 
- Surface mission-specific risk and schedule pressure to drive prioritized remediation actions in the equilibrium action path. 
- Integrate physics- and game-theory-inspired signals (free energy, Hamiltonian load, risk index) to improve governance recommendations and operator visibility.

### Description
- Added `computeRiskIndex` and `buildMissionThermodynamics` to `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` to compute programme-level energy/compute shares, a Hamiltonian-like load, and a prioritized action queue. 
- Integrated `missionThermodynamics` into telemetry output, the equilibrium ledger `actionPath`, and the generated `kardashev-report.md` to expose headroom, stability, and recommended interventions. 
- Introduced lightweight heuristics combining energy share, compute share, schedule slack, and risk distribution to produce `hamiltonianLoad`, `hamiltonianStability`, `freeEnergyHeadroomPct`, and a top-3 `actionQueue`. 
- Extended `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` to assert presence and sanity bounds for the new `missionThermodynamics` fields.

### Testing
- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and it passed (`5 passed`).
- The change was exercised as part of the demo orchestration run which previously reports all demo test suites passing; the targeted unit test added for mission thermodynamics succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f6299e0f083339b0a59ac58022d42)