### PR TITLE
Enhance equilibrium ledger UI with thermodynamics and game-theory summaries

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -137,6 +137,10 @@
         </div>
         <p id="equilibrium-summary" class="lede">…</p>
         <ul id="equilibrium-components" class="ledger-list"></ul>
+        <h3>Thermodynamics</h3>
+        <ul id="equilibrium-thermo" class="ledger-list"></ul>
+        <h3>Game-theory posture</h3>
+        <ul id="equilibrium-game-theory" class="ledger-list"></ul>
         <h3>Pathways</h3>
         <ul id="equilibrium-pathways" class="ledger-list"></ul>
         <h3>Action path</h3>


### PR DESCRIPTION
### Motivation
- The Equilibrium ledger UI lacked dedicated thermodynamics and game-theory summaries, reducing operator visibility into key metrics like free energy and Nash stability.
- Some ledger fields were rendered naively and could cause missing-field crashes or display inconsistently when telemetry is partial.
- Improve presentation and formatting so mission owners can quickly grasp equilibrium posture (Hamiltonians, Gibbs free energy, Nash metrics).
- Provide defensive defaults and small helpers to keep the dashboard robust when telemetry is absent or incomplete.

### Description
- Added two new subsections to the Kardashev II dashboard HTML: `#equilibrium-thermo` and `#equilibrium-game-theory` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html`.
- Extended `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js` with `formatPercent` and `formatFixed` helpers and defensive rendering to avoid crashes when ledger fields are missing.
- Render thermodynamic items (free energy margin, Gibbs free energy, entropy buffer, Hamiltonian stability) and game-theory items (Nash product, coalition stability, logistics Nash welfare) from `ledger.thermodynamics` and `ledger.gameTheory`, with status coloring based on sensible thresholds.
- Hardened equilibrium component formatting to use helpers and fallbacks so legacy or partial telemetry does not break the dashboard.

### Testing
- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests -q` and observed `5 passed in 2.78s`.
- Served the demo with `python -m http.server 8000` and exercised the dashboard with a headless browser script which loaded `index.html` and produced a screenshot at `artifacts/kardashev-dashboard.png` to verify the new sections render without errors.
- Verified the updated `renderEquilibriumLedger` function gracefully handles missing `thermodynamics` and `gameTheory` payloads by showing warning items instead of throwing.
- No regressions observed in the demo suite during local runs of the modified demo tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f728837bc83338d4d2cf9dde2e1c1)