### PR TITLE
Fix energy feed matching for allocation enrichment (prefer federationSlug)

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -504,16 +504,12 @@ function buildLiveEnergyFeeds(energyConfig, rng) {
 }
 
 function enrichAllocationPolicy(allocationPolicy, shardMetrics, energyConfig) {
-  const feedByShard = new Map(
-    energyConfig.feeds.map((feed) => {
-      const shardId = feed.region.split('-')[0];
-      return [shardId, feed];
-    })
-  );
-
   const allocations = allocationPolicy.allocations.map((allocation) => {
     const metric = shardMetrics.find((entry) => entry.shardId === allocation.shardId);
-    const feed = feedByShard.get(allocation.shardId);
+    const feed = resolveEnergyFeedForShard(
+      { id: allocation.shardId },
+      energyConfig.feeds
+    );
     const nominalGw = feed ? feed.nominalMw / 1000 : 0;
     const deltaGw = allocation.recommendedGw - nominalGw;
     return {


### PR DESCRIPTION
### Motivation

- Allocation enrichment previously matched energy feeds by a brittle `region.split('-')[0]` heuristic which failed when region names drifted.
- The intent is to consistently resolve an energy feed for a shard using the same logic used elsewhere in the demo (federation slug or region matching).
- This ensures allocation metrics (e.g. `deltaGw`, `renewablePct`) are populated reliably for downstream telemetry and governance outputs.
- Add explicit coverage to prevent regressions when region identifiers change but `federationSlug` remains accurate.

### Description

- Replaced the ad-hoc `feedByShard` lookup in `enrichAllocationPolicy` with a call to the canonical `resolveEnergyFeedForShard` resolver so feeds are matched by `federationSlug` or region prefixes.
- Removed the previous `region.split('-')[0]` mapping and now pass a `{ id: allocation.shardId }` stub into `resolveEnergyFeedForShard` to locate the correct feed.
- Added `test_run_demo_energy_feed_resolution_prefers_federation_slug` to `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` to exercise resolution when a feed's `region` drifts but `federationSlug` is intact.
- No other behavior changes; allocations still compute `deltaGw`, `renewablePct`, and `latencyMs` when a feed is found.

### Testing

- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests -q` and the suite passed: `6 passed`.
- The new test executes the demo CLI and asserts telemetry contains allocation entries with `renewablePct` and `deltaGw` for the `earth` shard when `region` is modified.
- Existing demo smoke and unit tests for this demo were also exercised during development to validate no regressions in outputs.
- The `run-demo` check mode remains compatible and continues to produce the expected validation messages when invoked with `--check`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fafdda2b08333ba5db60b794c08b7)