### PR TITLE
Add check mode to Day-One Utility Benchmark demo runner

### DIFF
--- a/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py
@@ -190,6 +190,34 @@ def test_scoreboard_generates_dashboard():
     )
 
 
+def test_check_mode_skips_artifacts(monkeypatch):
+    base_path = Path(__file__).resolve().parents[1]
+    monkeypatch.chdir(base_path)
+
+    output_dir = base_path / "out"
+    report_path = output_dir / "report_e2e.json"
+    dashboard_path = output_dir / "dashboard_e2e.html"
+    snapshot_path = output_dir / "snapshot_e2e.png"
+    scoreboard_path = output_dir / "scoreboard.json"
+
+    for path in (report_path, dashboard_path, snapshot_path, scoreboard_path):
+        if path.exists():
+            path.unlink()
+
+    payload, fmt = run_cli(["simulate", "--strategy", "e2e", "--check"])
+    assert fmt == "json"
+    assert payload["outputs"]["dashboard"] is None
+    assert payload["outputs"]["chart"] is None
+    assert not report_path.exists()
+    assert not dashboard_path.exists()
+    assert not snapshot_path.exists()
+
+    scoreboard_payload, fmt = run_cli(["scoreboard", "--check", "--strategies", "e2e"])
+    assert fmt == "json"
+    assert scoreboard_payload["outputs"]["dashboard"] is None
+    assert not scoreboard_path.exists()
+
+
 def test_scoreboard_human_summary(monkeypatch):
     base_path = Path(__file__).resolve().parents[1]
     monkeypatch.chdir(base_path)


### PR DESCRIPTION
### Motivation
- Provide a non-destructive "check" mode so the Day-One Utility Benchmark can validate computations without writing dashboards or JSON artefacts to disk.
- Make CI and quick validations faster and less noisy by avoiding heavy artifact generation when not needed.
- Ensure human-readable summaries still make sense when artifacts are omitted by surfacing a clear `N/A (check mode)` indicator.
- Allow callers and the existing `run_cli` wrapper to pass `--check` flexibly (flags or subcommands) for backward-compatible UX.

### Description
- Added a `--check` CLI option via `build_parser` and normalized handling in `run_cli` so `--check` can appear in varied positions and is honored for subcommands.
- Extended `DayOneUtilityOrchestrator.simulate` with a `write_artifacts` parameter and guarded artifact creation so charts, dashboards, and JSON files are skipped when `write_artifacts=False`.
- Propagated the artifact-skipping behaviour into `scoreboard` by adding a `write_artifacts` parameter and avoiding HTML/JSON writes when disabled.
- Updated human summary helpers (`_build_human_summary` and `_build_scoreboard_human_summary`) to show `N/A (check mode)` for dashboard/chart outputs, and added `test_check_mode_skips_artifacts` to cover the new flow.

### Testing
- Ran the demo test suite with `pytest demo/AGIJobs-Day-One-Utility-Benchmark/tests`, which passed: `18 passed in 3.66s`.
- Verified `run_cli` invocations: `run_cli(["simulate","--strategy","e2e","--check"])` and `run_cli(["scoreboard","--check","--strategies","e2e"])` produce JSON payloads with `outputs` pointing to `None` and do not create artifact files (asserted in the new test).
- Existing demo integration tests for the modified demo were run as part of the suite and remained green.
- No regressions observed in the tested demo during local runs; artifact generation still works when `--check` is not provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fe8b5b68083338637604d3215bf48)