### PR TITLE
Make AGI Alpha Node demo resilient to missing optional dependencies

### DIFF
--- a/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/metrics/exporter.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/metrics/exporter.py
@@ -1,14 +1,29 @@
 """Prometheus metrics exporter."""
 from __future__ import annotations
 
+import importlib.util
 import logging
 import threading
 from contextlib import suppress
 from typing import Dict
 
-from prometheus_client import Gauge, start_http_server
-
 logger = logging.getLogger(__name__)
+
+_PROMETHEUS_AVAILABLE = importlib.util.find_spec("prometheus_client") is not None
+
+if _PROMETHEUS_AVAILABLE:
+    from prometheus_client import Gauge, start_http_server
+else:
+
+    class Gauge:  # type: ignore[override]
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def set(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    def start_http_server(*_args: object, **_kwargs: object) -> None:
+        logger.warning("Prometheus metrics disabled; prometheus_client is not installed.")
 
 
 class MetricsExporter:
@@ -17,8 +32,12 @@ class MetricsExporter:
         self.port = port
         self._server_thread: threading.Thread | None = None
         self._gauges: Dict[str, Gauge] = {}
+        self._enabled = _PROMETHEUS_AVAILABLE
 
     def start(self) -> None:
+        if not self._enabled:
+            logger.warning("Prometheus metrics disabled; prometheus_client is not installed.")
+            return
         if self._server_thread and self._server_thread.is_alive():
             return
 
@@ -30,6 +49,8 @@ class MetricsExporter:
         self._server_thread.start()
 
     def update(self, metric: str, value: float, description: str = "") -> None:
+        if not self._enabled:
+            return
         gauge = self._gauges.get(metric)
         if gauge is None:
             gauge = Gauge(metric, description or metric)

--- a/demo/AGI-Alpha-Node-v0/grand_demo/scripts/run_demo.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/scripts/run_demo.py
@@ -9,11 +9,12 @@ network sockets.
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import inspect
 import logging
 import sys
 from pathlib import Path
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Optional, TYPE_CHECKING
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = SCRIPT_DIR.parent
@@ -34,16 +35,17 @@ def _bootstrap_sys_path() -> None:
 
 _bootstrap_sys_path()
 
-import uvicorn  # noqa: E402  (import after path bootstrap)
+if TYPE_CHECKING:
+    import uvicorn
 for _name in list(sys.modules):
     if _name.startswith("alpha_node"):
         sys.modules.pop(_name, None)
 
-from alpha_node.console.cli import demo_job  # noqa: E402
-from alpha_node.web.app import app  # noqa: E402
 
 
-def _build_server(app_obj: object, *, host: str, port: int) -> uvicorn.Server:
+def _build_server(app_obj: object, *, host: str, port: int) -> "uvicorn.Server":
+    import uvicorn
+
     return uvicorn.Server(
         uvicorn.Config(app_obj, host=host, port=port, loop="asyncio", lifespan="off")
     )
@@ -90,13 +92,48 @@ async def main(
     host: str = "0.0.0.0",
     port: int = 8080,
     run_server: bool = True,
-    demo_job_fn: Callable[..., Awaitable[None] | None] = demo_job,
-    app_obj: object = app,
+    demo_job_fn: Callable[..., Awaitable[None] | None] | None = None,
+    app_obj: object | None = None,
     config_path: Optional[Path] = None,
 ) -> None:
     """Launch the demo job and, optionally, the local Uvicorn service."""
 
     logging.basicConfig(level=logging.INFO)
+
+    if demo_job_fn is None:
+        from alpha_node.console.cli import demo_job as default_demo_job
+
+        demo_job_fn = default_demo_job
+
+    if run_server and app_obj is None:
+        if importlib.util.find_spec("fastapi") is not None:
+            from alpha_node.web.app import app as default_app
+
+            app_obj = default_app
+        else:
+            logging.warning(
+                "FastAPI is not installed; running a minimal fallback app. "
+                "Install the demo dependencies to enable the full dashboard."
+            )
+
+            async def fallback_app(scope, receive, send):  # type: ignore[no-untyped-def]
+                if scope.get("type") != "http":
+                    return
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 503,
+                        "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+                    }
+                )
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": b"FastAPI is not installed. Install demo dependencies.",
+                    }
+                )
+
+            app_obj = fallback_app
 
     server = _build_server(app_obj, host=host, port=port) if run_server else None
     server_task = asyncio.create_task(server.serve()) if server else None


### PR DESCRIPTION
### Motivation

- Allow the AGI Alpha Node demo entrypoint to be imported and executed in minimal environments without installing optional server and monitoring dependencies.
- Prevent import-time failures during tests by deferring heavy/optional imports until runtime.
- Keep the deterministic demo job runnable in CI/test environments without starting network servers. 

### Description

- Defer `uvicorn` import into `_build_server` and use `TYPE_CHECKING` for static typing so imports don't fail at module import time. 
- Make `main`'s `demo_job_fn` and `app_obj` optional and lazily import `alpha_node.console.cli.demo_job` and `alpha_node.web.app` only when needed. 
- Provide a minimal ASGI `fallback_app` when `FastAPI` is not installed so the demo can still start a lightweight server placeholder. 
- Make Prometheus optional by detecting `prometheus_client` with `importlib.util.find_spec`, adding no-op `Gauge`/`start_http_server` shims, and disabling `MetricsExporter` behavior when the package is absent. 

### Testing

- Ran `python demo/run_demo_tests.py --demo AGI-Alpha-Node-v0 --fail-fast` and the demo test suites for `AGI-Alpha-Node-v0` passed. 
- The demo's JavaScript unit tests under `demo/AGI-Alpha-Node-v0` were exercised via the runner (the project's `npm test` was invoked as part of the suite) and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950104358ec8333b617130c90e62a4c)