### PR TITLE
Fix status snapshot account shape in omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -1380,17 +1380,17 @@ class Orchestrator:
         ]
         root_jobs = [job.job_id for job in jobs if job.spec.parent_id is None]
         resource_state = self.resources.snapshot()
-        accounts = self.resources.to_serializable()
+        accounts = self.resources.accounts_snapshot()
         governance = self.governance.params
         simulation_state: Optional[Dict[str, float]] = None
         if self._latest_simulation_state is not None:
             simulation_state = {
                 "energy_output_gw": self._latest_simulation_state.energy_output_gw,
-            "prosperity_index": self._latest_simulation_state.prosperity_index,
-            "sustainability_index": self._latest_simulation_state.sustainability_index,
-            "nash_welfare": self._latest_simulation_state.nash_welfare,
-            "free_energy": self._latest_simulation_state.free_energy,
-            "entropy": self._latest_simulation_state.entropy,
+                "prosperity_index": self._latest_simulation_state.prosperity_index,
+                "sustainability_index": self._latest_simulation_state.sustainability_index,
+                "nash_welfare": self._latest_simulation_state.nash_welfare,
+                "free_energy": self._latest_simulation_state.free_energy,
+                "entropy": self._latest_simulation_state.entropy,
                 "hamiltonian": self._latest_simulation_state.hamiltonian,
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,
@@ -1470,11 +1470,11 @@ class Orchestrator:
         if self._latest_simulation_state is not None:
             simulation_state = {
                 "energy_output_gw": self._latest_simulation_state.energy_output_gw,
-            "prosperity_index": self._latest_simulation_state.prosperity_index,
-            "sustainability_index": self._latest_simulation_state.sustainability_index,
-            "nash_welfare": self._latest_simulation_state.nash_welfare,
-            "free_energy": self._latest_simulation_state.free_energy,
-            "entropy": self._latest_simulation_state.entropy,
+                "prosperity_index": self._latest_simulation_state.prosperity_index,
+                "sustainability_index": self._latest_simulation_state.sustainability_index,
+                "nash_welfare": self._latest_simulation_state.nash_welfare,
+                "free_energy": self._latest_simulation_state.free_energy,
+                "entropy": self._latest_simulation_state.entropy,
                 "hamiltonian": self._latest_simulation_state.hamiltonian,
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/resources.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/resources.py
@@ -268,6 +268,19 @@ class ResourceManager:
             compute_capacity=self.compute_capacity,
         )
 
+    def accounts_snapshot(self) -> Dict[str, Dict[str, float]]:
+        """Return a JSON-serialisable view of account balances."""
+
+        return {
+            name: {
+                "tokens": account.tokens,
+                "locked": account.locked,
+                "energy_quota": account.energy_quota,
+                "compute_quota": account.compute_quota,
+            }
+            for name, account in self._accounts.items()
+        }
+
     def to_serializable(self) -> Dict[str, object]:
         return {
             "state": {
@@ -279,15 +292,7 @@ class ResourceManager:
                 "energy_price": self.energy_price,
                 "compute_price": self.compute_price,
             },
-            "accounts": {
-                name: {
-                    "tokens": account.tokens,
-                    "locked": account.locked,
-                    "energy_quota": account.energy_quota,
-                    "compute_quota": account.compute_quota,
-                }
-                for name, account in self._accounts.items()
-            },
+            "accounts": self.accounts_snapshot(),
             "reservations": {
                 key: {"energy": values[0], "compute": values[1]}
                 for key, values in self._reservations.items()

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_status_snapshot.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_status_snapshot.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
+
+
+def test_status_snapshot_accounts_are_flat() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=False))
+    orchestrator.resources.ensure_account("operator", 125.0)
+
+    snapshot = orchestrator._collect_status_snapshot()
+
+    accounts = snapshot["resources"]["accounts"]
+    assert "state" not in accounts
+    assert "reservations" not in accounts
+    assert accounts["operator"]["tokens"] == 125.0


### PR DESCRIPTION
### Motivation
- The orchestrator status snapshot exposed nested resource state blocks inside the `accounts` payload which made downstream consumers and telemetry harder to parse.
- The `ResourceManager` needs a stable, flat view of per-account balances for status/export endpoints while retaining the richer `to_serializable()` payload for checkpointing.
- Add a small targeted change to ensure status output is compact and unambiguous for monitoring and integrations.

### Description
- Add `accounts_snapshot` to `ResourceManager` to return a flat mapping of account balances and use it in `_collect_status_snapshot` via `accounts = self.resources.accounts_snapshot()`.
- Delegate `to_serializable()` `accounts` field to the new `accounts_snapshot()` to keep the full checkpoint API unchanged.
- Tidy simulation-state formatting in the orchestrator and add `demo/.../tests/test_status_snapshot.py` which asserts the `accounts` shape remains flat.

### Testing
- Ran `pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests"` and the suite passed (17 passed).
- Added and ran `test_status_snapshot.py`, which verifies the flat `accounts` structure and passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69501a1f8d888333afff70349b98a0d4)