### PR TITLE
Add concise Kardashev II action-path briefing artifact

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -1663,6 +1663,55 @@ function buildEquilibriumLedger({
   };
 }
 
+function formatPercentValue(value, digits = 1) {
+  if (!Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return `${(value * 100).toFixed(digits)}%`;
+}
+
+function buildActionPathBriefing(equilibriumLedger) {
+  const thermodynamics = equilibriumLedger?.thermodynamics ?? {};
+  const gameTheory = equilibriumLedger?.gameTheory ?? {};
+  const actionPath = Array.isArray(equilibriumLedger?.actionPath)
+    ? equilibriumLedger.actionPath
+    : [];
+  const lines = [];
+  lines.push('# Kardashev II Action Path');
+  lines.push('');
+  lines.push(`Generated: ${equilibriumLedger?.generatedAt ?? new Date().toISOString()}`);
+  lines.push('');
+  lines.push('## Core equilibrium signals');
+  lines.push(
+    `- Free energy margin: ${formatPercentValue(thermodynamics.freeEnergyMarginPct, 2)}`
+  );
+  lines.push(
+    `- Gibbs free energy: ${formatNumber(thermodynamics.gibbsFreeEnergyGj ?? 0)} GJ`
+  );
+  lines.push(
+    `- Hamiltonian stability: ${formatPercentValue(thermodynamics.hamiltonianStability)}`
+  );
+  lines.push(`- Nash product: ${formatPercentValue(gameTheory.nashProduct)}`);
+  lines.push(
+    `- Coalition stability: ${formatPercentValue(gameTheory.coalitionStability)}`
+  );
+  lines.push('');
+  lines.push('## Action path');
+  if (actionPath.length === 0) {
+    lines.push('No corrective steps required. Maintain current equilibrium and monitor drift.');
+  } else {
+    actionPath.forEach((step) => {
+      lines.push(`### Step ${step.rank}: ${step.title}`);
+      lines.push(`- Status: ${step.status}`);
+      lines.push(`- Target: ${step.target}`);
+      lines.push(`- Rationale: ${step.rationale}`);
+      lines.push(`- Action: ${step.action}`);
+      lines.push('');
+    });
+  }
+  return lines.join('\n');
+}
+
 function buildEquilibriumActionPath({
   energyMonteCarlo,
   allocationPolicy,
@@ -2398,6 +2447,10 @@ function main() {
     fs.writeFileSync(
       path.join(outputDir, 'governance-playbook.md'),
       `${governanceLines.join('\n')}\n`
+    );
+    fs.writeFileSync(
+      path.join(outputDir, 'kardashev-action-path.md'),
+      `${buildActionPathBriefing(equilibriumLedger)}\n`
     );
 
     const telemetryPath = path.join(outputDir, 'kardashev-telemetry.json');

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -51,6 +51,7 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     mermaid_map = tmp_path / "kardashev-mermaid.mmd"
     dyson_diagram = tmp_path / "kardashev-dyson.mmd"
     diagrams_inline = tmp_path / "kardashev-diagrams.inline.js"
+    action_path = tmp_path / "kardashev-action-path.md"
 
     for path in (
         report,
@@ -63,8 +64,13 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
         mermaid_map,
         dyson_diagram,
         diagrams_inline,
+        action_path,
     ):
         assert path.exists(), f"expected artefact missing: {path}"
+
+    action_path_contents = action_path.read_text()
+    assert "Kardashev II Action Path" in action_path_contents
+    assert "Action path" in action_path_contents
 
     telemetry_payload = json.loads(telemetry.read_text())
     assert telemetry_payload.get("energyMonteCarlo", {}).get("withinTolerance") is True


### PR DESCRIPTION
### Motivation
- Provide a compact, operator-friendly briefing summarising equilibrium signals and corrective steps derived from the equilibrium ledger. 
- Make actionable guidance easily discoverable by emitting a standalone file alongside existing reports. 
- Reduce cognitive load for stewards by translating thermodynamic and game-theoretic signals into a clear action path. 

### Description
- Added `formatPercentValue` and `buildActionPathBriefing` helpers to `run-demo.cjs` to format core equilibrium signals and render an action-path markdown briefing. 
- Emit a new artifact `kardashev-action-path.md` into the demo output directory when the orchestrator runs (non-`--check` mode). 
- Updated `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` to assert the presence and basic contents of `kardashev-action-path.md`. 

### Testing
- Ran `pytest -q demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` which completed successfully with `8 passed`.
- Existing demo checks were exercised during the rollout and no regressions were observed in the targeted demo test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950284709608333b1c80e57919314ec)