### PR TITLE
Add offline Kardashev II dashboard bundle

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -273,6 +273,7 @@
         <code>npm run demo:kardashev-ii:ci</code>
       </footer>
     </main>
+    <script>window.__KARDASHEV_ASSET_BASE__ = "./output";</script>
     <script src="./output/kardashev-telemetry.inline.js"></script>
     <script src="./output/kardashev-stability-ledger.inline.js"></script>
     <script src="./output/kardashev-equilibrium-ledger.inline.js"></script>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -1966,6 +1966,23 @@ function ensureDir(dirPath) {
   }
 }
 
+function writeOfflineDashboard(outputDir) {
+  const uiSourceDir = path.join(__dirname, 'ui');
+  const uiTargetDir = path.join(outputDir, 'ui');
+  ensureDir(uiTargetDir);
+  for (const filename of ['style.css', 'dashboard.js']) {
+    fs.copyFileSync(path.join(uiSourceDir, filename), path.join(uiTargetDir, filename));
+  }
+
+  const indexTemplate = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+  const assetBaseMarker = 'window.__KARDASHEV_ASSET_BASE__ = "./output";';
+  const offlineIndex = indexTemplate
+    .replace(assetBaseMarker, 'window.__KARDASHEV_ASSET_BASE__ = ".";')
+    .replace(/src="\.\/output\//g, 'src="./');
+
+  fs.writeFileSync(path.join(outputDir, 'index.html'), offlineIndex);
+}
+
 function parseArgs(argv) {
   const args = {
     outputDir: process.env.OUTPUT_DIR,
@@ -2491,6 +2508,8 @@ function main() {
         dysonThermo: dysonThermoDiagram,
       })};\n`
     );
+
+    writeOfflineDashboard(outputDir);
 
     const legacyTelemetryPath = path.join(outputDir, 'telemetry.json');
     if (fs.existsSync(legacyTelemetryPath)) {

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -52,6 +52,10 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     dyson_diagram = tmp_path / "kardashev-dyson.mmd"
     diagrams_inline = tmp_path / "kardashev-diagrams.inline.js"
     action_path = tmp_path / "kardashev-action-path.md"
+    offline_index = tmp_path / "index.html"
+    offline_ui = tmp_path / "ui"
+    offline_css = offline_ui / "style.css"
+    offline_dashboard = offline_ui / "dashboard.js"
 
     for path in (
         report,
@@ -65,8 +69,15 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
         dyson_diagram,
         diagrams_inline,
         action_path,
+        offline_index,
+        offline_css,
+        offline_dashboard,
     ):
         assert path.exists(), f"expected artefact missing: {path}"
+
+    offline_index_contents = offline_index.read_text()
+    assert 'window.__KARDASHEV_ASSET_BASE__ = ".";' in offline_index_contents
+    assert 'src="./kardashev-telemetry.inline.js"' in offline_index_contents
 
     action_path_contents = action_path.read_text()
     assert "Kardashev II Action Path" in action_path_contents

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -1,5 +1,32 @@
 let mermaidModule;
 
+const DEFAULT_ASSET_BASE = "./output";
+
+function resolveAssetBase() {
+  const explicitBase = window.__KARDASHEV_ASSET_BASE__;
+  if (typeof explicitBase === "string" && explicitBase.length > 0) {
+    return explicitBase.replace(/\/$/, "");
+  }
+
+  const datasetBase = document.documentElement?.dataset?.assetBase;
+  if (typeof datasetBase === "string" && datasetBase.length > 0) {
+    return datasetBase.replace(/\/$/, "");
+  }
+
+  return DEFAULT_ASSET_BASE;
+}
+
+const ASSET_BASE = resolveAssetBase();
+
+function assetPath(filename) {
+  if (!filename) {
+    return ASSET_BASE;
+  }
+  const trimmed = ASSET_BASE.endsWith("/") ? ASSET_BASE.slice(0, -1) : ASSET_BASE;
+  const base = trimmed === "." ? "." : trimmed || ".";
+  return `${base}/${filename}`;
+}
+
 async function loadMermaid() {
   if (mermaidModule !== undefined) {
     return mermaidModule;
@@ -1774,12 +1801,12 @@ async function bootstrap() {
   }
 
   const [telemetryResult, ledgerResult, equilibriumResult, ownerProofResult] = await Promise.allSettled([
-    inlineTelemetry ? Promise.resolve(inlineTelemetry) : fetchJson("./output/kardashev-telemetry.json"),
-    inlineLedger ? Promise.resolve(inlineLedger) : fetchJson("./output/kardashev-stability-ledger.json"),
+    inlineTelemetry ? Promise.resolve(inlineTelemetry) : fetchJson(assetPath("kardashev-telemetry.json")),
+    inlineLedger ? Promise.resolve(inlineLedger) : fetchJson(assetPath("kardashev-stability-ledger.json")),
     inlineEquilibrium
       ? Promise.resolve(inlineEquilibrium)
-      : fetchJson("./output/kardashev-equilibrium-ledger.json"),
-    inlineOwnerProof ? Promise.resolve(inlineOwnerProof) : fetchJson("./output/kardashev-owner-proof.json"),
+      : fetchJson(assetPath("kardashev-equilibrium-ledger.json")),
+    inlineOwnerProof ? Promise.resolve(inlineOwnerProof) : fetchJson(assetPath("kardashev-owner-proof.json")),
   ]);
 
   if (telemetryResult.status !== "fulfilled") {
@@ -1814,19 +1841,19 @@ async function bootstrap() {
 
     const diagrams = await Promise.allSettled([
       renderMermaidDiagram(
-        "./output/kardashev-task-hierarchy.mmd",
+        assetPath("kardashev-task-hierarchy.mmd"),
         "mission-mermaid",
         "mission-hierarchy-diagram",
         inlineDiagrams?.missionHierarchy
       ),
       renderMermaidDiagram(
-        "./output/kardashev-mermaid.mmd",
+        assetPath("kardashev-mermaid.mmd"),
         "mermaid-container",
         "kardashev-diagram",
         inlineDiagrams?.interstellarMap
       ),
       renderMermaidDiagram(
-        "./output/kardashev-dyson.mmd",
+        assetPath("kardashev-dyson.mmd"),
         "dyson-container",
         "dyson-diagram",
         inlineDiagrams?.dysonThermo
@@ -1883,19 +1910,19 @@ async function bootstrap() {
 
   const diagrams = await Promise.allSettled([
     renderMermaidDiagram(
-      "./output/kardashev-task-hierarchy.mmd",
+      assetPath("kardashev-task-hierarchy.mmd"),
       "mission-mermaid",
       "mission-hierarchy-diagram",
       inlineDiagrams?.missionHierarchy
     ),
     renderMermaidDiagram(
-      "./output/kardashev-mermaid.mmd",
+      assetPath("kardashev-mermaid.mmd"),
       "mermaid-container",
       "kardashev-diagram",
       inlineDiagrams?.interstellarMap
     ),
     renderMermaidDiagram(
-      "./output/kardashev-dyson.mmd",
+      assetPath("kardashev-dyson.mmd"),
       "dyson-container",
       "dyson-diagram",
       inlineDiagrams?.dysonThermo


### PR DESCRIPTION
### Motivation
- Enable the Kardashev II demo dashboard to load telemetry and diagrams from configurable output locations so the UI can be served either from the repo or from the generated `output/` folder.
- Provide a self-contained offline dashboard bundle in the demo `output/` directory so the demo can be opened locally (file protocol) without a web server.
- Improve robustness when users move or package the demo artefacts for distribution or CI.

### Description
- Add an `assetPath` resolver and `__KARDASHEV_ASSET_BASE__` override to `ui/dashboard.js` so all `fetch()` and diagram loads use a configurable base instead of hard-coded `./output` paths.
- Replace hard-coded `./output/...` references in the dashboard with `assetPath(...)` calls to support alternate asset bases and local/offline hosting.
- Emit a self-contained offline dashboard from `run-demo.cjs` by copying `ui/style.css` and `ui/dashboard.js` into `output/ui/` and generating an `output/index.html` that rewrites asset base to refer to local files.
- Add/extend tests in `tests/test_run_demo.py` to validate offline artefacts (`index.html`, `ui/style.css`, `ui/dashboard.js`) and assert the offline index points to the local inline telemetry script.

### Testing
- Ran the demo unit/integration tests for the Kardashev II demo with `python -m pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and all tests passed (`8 passed`).
- Verified `run_demo.py` produces `kardashev-telemetry.json`, inline JS artefacts and the generated offline `index.html` and `ui/` assets in the requested output directory.
- Manually exercised the Node `run-demo.cjs` path used by the wrapper to confirm `output/index.html` is rewritten to load local assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695039e38fa88333841af70028108ac9)