### PR TITLE
Add equilibrium action path to Kardashev II operator briefing

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-operator-briefing.md
@@ -35,6 +35,16 @@
   - Settlement backlog (+40% finality): Settlement mesh absorbs backlog within tolerance.
 * Audit checklist: ipfs://QmKardashevAuditChecklist
 
+## Equilibrium action path
+* Gibbs free energy 3,227,074,308.57 GJ · entropy 99.23σ · Hamiltonian 89.0%
+* Nash 85.6% · coalition 90.0% · logistics welfare 98.5%
+* 1. Stabilize mission Hamiltonian (needs-action) — Rebalance mission timelines and energy buffers to regain Hamiltonian stability. · target Mission Hamiltonian stability ≥ 90% and headroom ≥ 5%.
+* 2. Stabilize free energy buffer (on-track) — Hold reserve cadence and keep Monte Carlo breach probability below tolerance. · target Free energy margin ≥ 70% and Hamiltonian stability ≥ 90%.
+* 3. Reinforce sentient welfare balance (on-track) — Continue cooperative reward rotations to sustain coalition stability. · target Coalition stability ≥ 85% and inequality ≤ 30%.
+* 4. Tighten Nash allocation (on-track) — Keep incentive gradients aligned with Nash stability targets. · target Deviation incentive ≤ 20% and strategy stability ≥ 85%.
+* 5. Restore logistics game-theory slack (on-track) — Maintain corridor utilisation within the equilibrium band. · target Game-theory slack ≥ 85% and entropy ratio ≥ 0.9.
+* 6. Secure compute quorum failover (on-track) — Sustain quorum failover coverage and monitor deviation drift. · target Failover within quorum and availability ≥ 95%.
+
 ## Identity posture
 * 3/3 federations meeting quorum 5.
 * Revocation rate 0.35 ppm (tolerance 120 ppm); latency window 96s / 240s.

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/run-kardashev-demo.ts
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/run-kardashev-demo.ts
@@ -3153,7 +3153,29 @@ function buildRunbook(
   return lines.join("\n");
 }
 
-function buildOperatorBriefing(manifest: Manifest, telemetry: any): string {
+function buildOperatorBriefing(
+  manifest: Manifest,
+  telemetry: any,
+  equilibriumLedger?: {
+    thermodynamics?: {
+      gibbsFreeEnergyGj?: number;
+      entropyMargin?: number;
+      hamiltonianStability?: number;
+    };
+    gameTheory?: {
+      nashProduct?: number;
+      coalitionStability?: number;
+      logisticsNashWelfare?: number;
+    };
+    actionPath?: Array<{
+      rank: number;
+      title: string;
+      status?: string;
+      action: string;
+      target?: string;
+    }>;
+  }
+): string {
   const lines: string[] = [];
   lines.push("# Kardashev II Operator Briefing");
   lines.push("");
@@ -3261,6 +3283,39 @@ function buildOperatorBriefing(manifest: Manifest, telemetry: any): string {
       });
   }
   lines.push(`* Audit checklist: ${telemetry.verification.auditChecklistURI}`);
+  if (equilibriumLedger) {
+    const thermodynamics = equilibriumLedger.thermodynamics ?? {};
+    const gameTheory = equilibriumLedger.gameTheory ?? {};
+    const actionPath = equilibriumLedger.actionPath ?? [];
+    lines.push("");
+    lines.push("## Equilibrium action path");
+    if (Number.isFinite(thermodynamics.gibbsFreeEnergyGj)) {
+      const gibbsEnergy = thermodynamics.gibbsFreeEnergyGj ?? 0;
+      const entropyText = Number.isFinite(thermodynamics.entropyMargin)
+        ? thermodynamics.entropyMargin?.toFixed(2)
+        : "n/a";
+      const hamiltonianPct = Number.isFinite(thermodynamics.hamiltonianStability)
+        ? ((thermodynamics.hamiltonianStability ?? 0) * 100).toFixed(1)
+        : "n/a";
+      lines.push(
+        `* Gibbs free energy ${gibbsEnergy.toLocaleString()} GJ · entropy ${entropyText}σ · Hamiltonian ${hamiltonianPct}%`
+      );
+    }
+    lines.push(
+      `* Nash ${((gameTheory.nashProduct ?? 0) * 100).toFixed(1)}% · coalition ${(
+        (gameTheory.coalitionStability ?? 0) * 100
+      ).toFixed(1)}% · logistics welfare ${((gameTheory.logisticsNashWelfare ?? 0) * 100).toFixed(1)}%`
+    );
+    if (actionPath.length === 0) {
+      lines.push("* No immediate corrective steps required. Maintain equilibrium cadence.");
+    } else {
+      actionPath.forEach((step) => {
+        const status = step.status ? ` (${step.status})` : "";
+        const target = step.target ? ` · target ${step.target}` : "";
+        lines.push(`* ${step.rank}. ${step.title}${status} — ${step.action}${target}`);
+      });
+    }
+  }
   lines.push("");
   lines.push("## Identity posture");
   lines.push(
@@ -5199,7 +5254,7 @@ function run() {
   const mermaid = buildMermaid(manifest, dominanceScore);
   const dysonTimeline = buildDysonTimeline(manifest);
   const runbook = buildRunbook(manifest, telemetryWithScenarios, dominanceScore, scenarioSweep);
-  const operatorBriefing = buildOperatorBriefing(manifest, telemetryWithScenarios);
+  const operatorBriefing = buildOperatorBriefing(manifest, telemetryWithScenarios, equilibriumLedger);
 
   const telemetryJson = `${JSON.stringify(telemetryWithScenarios, null, 2)}\n`;
   const safeJson = `${JSON.stringify(safeBatch, null, 2)}\n`;


### PR DESCRIPTION
### Motivation

- Surface high-level equilibrium signals (thermodynamics, Gibbs free energy, Hamiltonian stability, and game-theory metrics) in the operator briefing so mission owners receive actionable guidance.
- Provide an explicit ranked action path derived from the equilibrium ledger to make corrective steps clear and audit-friendly.
- Thread equilibrium telemetry into the briefing generator to ensure the operator artefact reflects the full orchestrator output.

### Description

- Extended `buildOperatorBriefing` to accept an optional `equilibriumLedger` parameter and render thermodynamic and game-theory summaries.
- Rendered an "Equilibrium action path" block listing Gibbs free energy, entropy, Hamiltonian %, Nash/coalition/logistics metrics, and ranked corrective steps with targets.
- Wired the `equilibriumLedger` into the main run flow by passing it to `buildOperatorBriefing` and regenerated the `output/kardashev-operator-briefing.md` artefact.
- Added defensive formatting for missing/NaN equilibrium fields (shows `n/a` when telemetry is absent).

### Testing

- Ran `npm run demo:kardashev-ii:orchestrate` to regenerate artefacts and confirm the new briefing was produced (success).
- Ran `npm run demo:kardashev-ii:ci` to validate artefacts and README parity (success).
- Executed the repository demo test runner with `python demo/run_demo_tests.py`, which ran many demo suites and unit tests (numerous suites passed; the full run was interrupted during long meta suites but core Kardashev-II suites and CI validation succeeded).
- Verified the generated `output/kardashev-operator-briefing.md` contains the new "Equilibrium action path" section with populated values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69506827ef7883339422bc8203ac9c64)