### PR TITLE
Improve dashboard fallback for offline diagrams

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -734,6 +734,22 @@ function normalizeLegacyAllocationPolicy(telemetry) {
 
 let mermaidInitialised = false;
 
+function renderDiagramFallback(container, source, message) {
+  if (!container) {
+    return;
+  }
+  container.innerHTML = "";
+  const notice = document.createElement("p");
+  notice.textContent = message;
+  notice.classList.add("status-warn");
+
+  const pre = document.createElement("pre");
+  pre.classList.add("diagram-source");
+  pre.textContent = source;
+
+  container.append(notice, pre);
+}
+
 async function renderMermaidDiagram(path, containerId, renderId, inlineSource) {
   const container = document.querySelector(`#${containerId}`);
   if (!container) {
@@ -756,9 +772,11 @@ async function renderMermaidDiagram(path, containerId, renderId, inlineSource) {
   }
   const mermaid = await loadMermaid();
   if (!mermaid) {
-    container.textContent =
-      "Diagram renderer unavailable — check connectivity to the Mermaid CDN and retry.";
-    container.classList.add("status-warn");
+    renderDiagramFallback(
+      container,
+      source,
+      "Diagram renderer unavailable — rendering source for offline inspection."
+    );
     return;
   }
 
@@ -767,9 +785,14 @@ async function renderMermaidDiagram(path, containerId, renderId, inlineSource) {
     mermaidInitialised = true;
   }
 
-  const { svg } = await mermaid.render(renderId, source);
-  container.classList.remove("status-warn", "status-fail");
-  container.innerHTML = svg;
+  try {
+    const { svg } = await mermaid.render(renderId, source);
+    container.classList.remove("status-warn", "status-fail");
+    container.innerHTML = svg;
+  } catch (error) {
+    console.warn(`Mermaid render failed for ${path}`, error);
+    renderDiagramFallback(container, source, "Diagram render failed — showing source instead.");
+  }
 }
 
 function attachReflectionButton(telemetry) {

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css
@@ -177,6 +177,19 @@ button:hover {
   overflow-x: auto;
 }
 
+.diagram-source {
+  margin: 12px 0 0;
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.9);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .footer-note {
   font-size: 0.85rem;
   color: rgba(148, 163, 184, 0.8);


### PR DESCRIPTION
### Motivation
- The Kardashev II dashboard can be opened from a local file or in restricted CI environments where the Mermaid CDN or runtime may be unavailable. 
- When the diagram renderer or CDN is unreachable the dashboard previously showed a terse warning or empty container instead of useful information. 
- Expose the original Mermaid source to allow offline inspection and easier debugging of diagram artefacts. 
- Keep the dashboard readable and informative in low-connectivity or offline scenarios.

### Description
- Added `renderDiagramFallback` helper in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js` to display a user-facing notice plus the raw Mermaid source when rendering is impossible. 
- Wrapped the Mermaid render call in a `try`/`catch` and call the fallback on render failure or when the Mermaid module cannot be loaded. 
- Added CSS rules for `.diagram-source` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/style.css` to style the displayed source for readability. 
- Files changed: `ui/dashboard.js`, `ui/style.css`.

### Testing
- Ran the demo test suite with `pytest -q demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` and observed all tests pass (`8 passed`).
- Executed the demo wrapper with `python demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py` to validate artefact generation and manual inspection of the dashboard in an HTTP-served output directory (generation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695070ab94008333bc1265bfcd26f231)