### PR TITLE
Buffer and score job claims to avoid race conditions in Omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -63,6 +63,7 @@ class OrchestratorConfig:
     energy_oracle_interval_seconds: float = 60.0
     auto_policy_actions: bool = True
     policy_action_interval_seconds: float = 10.0
+    job_claim_window_seconds: float = 0.5
     heartbeat_interval_seconds: float = 5.0
     heartbeat_timeout_seconds: float = 30.0
     health_check_interval_seconds: float = 5.0
@@ -125,6 +126,9 @@ class Orchestrator:
         self._agent_skills: Dict[str, List[str]] = {}
         self._unresponsive_agents: Set[str] = set()
         self._agent_lock = Lock()
+        self._claim_buffer: Dict[str, Dict[str, datetime]] = {}
+        self._claim_tasks: Dict[str, asyncio.Task[None]] = {}
+        self._claim_lock = asyncio.Lock()
 
     def _log(self, level: int, event: str, **fields: object) -> None:
         self.log.log(level, event, extra={"event": event, **fields})
@@ -570,14 +574,7 @@ class Orchestrator:
             while self._running:
                 message = await receiver()
                 if message.topic == "jobs:claim":
-                    try:
-                        await self.assign_job(message.payload["job_id"], message.payload["agent"])
-                    except ValueError:
-                        self._warning(
-                            "job_claim_race",
-                            job_id=message.payload.get("job_id"),
-                            agent=message.payload.get("agent"),
-                        )
+                    await self._handle_job_claim(message.payload)
                 elif message.topic.startswith("results:"):
                     await self._handle_job_result(message.payload)
                 elif message.topic.startswith("validation:commit:"):
@@ -724,6 +721,118 @@ class Orchestrator:
             "compute_boost": compute_boost,
             "entropy_damping": entropy_damping,
         }
+
+    def _score_claimant(self, job: JobRecord, agent: str) -> Tuple[float, float, int, str]:
+        required_skills = {skill for skill in job.spec.required_skills if skill}
+        agent_skills = set(self._agent_skills.get(agent, []))
+        if required_skills:
+            skill_match = len(required_skills & agent_skills) / len(required_skills)
+        else:
+            skill_match = 1.0
+        active_jobs = [
+            record
+            for record in self.job_registry.iter_jobs()
+            if record.status == JobStatus.IN_PROGRESS and record.assigned_agent
+        ]
+        load_map = Counter(record.assigned_agent for record in active_jobs)
+        load_count = load_map.get(agent, 0)
+        total_active = max(1, sum(load_map.values()))
+        load_penalty = load_count / total_active
+        responsiveness = 0.0 if agent in self._unresponsive_agents else 1.0
+        score = (0.6 + 0.4 * responsiveness) * (0.7 + 0.3 * skill_match) * (1.0 - 0.5 * load_penalty)
+        return (score, skill_match, -load_count, agent)
+
+    def _select_best_claimant(self, job: JobRecord, claimants: Iterable[str]) -> Optional[str]:
+        unique_claimants = {agent for agent in claimants if agent}
+        if not unique_claimants:
+            return None
+        ordered = sorted(unique_claimants)
+        return max(ordered, key=lambda agent: self._score_claimant(job, agent))
+
+    async def _handle_job_claim(self, payload: Dict[str, Any]) -> None:
+        job_id = payload.get("job_id")
+        agent = payload.get("agent")
+        if not isinstance(job_id, str) or not job_id or not isinstance(agent, str) or not agent:
+            self._warning("job_claim_invalid", job_id=job_id, agent=agent)
+            return
+        try:
+            job = self.job_registry.get_job(job_id)
+        except KeyError:
+            self._warning("job_claim_unknown", job_id=job_id, agent=agent)
+            return
+        if job.status != JobStatus.POSTED:
+            await self.bus.publish(
+                f"jobs:claim:declined:{job_id}",
+                {"job_id": job_id, "agent": agent, "reason": "job_unavailable"},
+                "orchestrator",
+            )
+            return
+        async with self._claim_lock:
+            self._claim_buffer.setdefault(job_id, {})[agent] = datetime.now(timezone.utc)
+            if job_id not in self._claim_tasks:
+                self._claim_tasks[job_id] = asyncio.create_task(
+                    self._resolve_job_claim(job_id),
+                    name=f"claim-resolve:{job_id}",
+                )
+
+    async def _resolve_job_claim(self, job_id: str) -> None:
+        delay = max(0.0, float(self.config.job_claim_window_seconds))
+        if delay:
+            await asyncio.sleep(delay)
+        async with self._claim_lock:
+            claimants = self._claim_buffer.pop(job_id, {})
+            self._claim_tasks.pop(job_id, None)
+        if not claimants:
+            return
+        try:
+            job = self.job_registry.get_job(job_id)
+        except KeyError:
+            return
+        if job.status != JobStatus.POSTED:
+            await self._broadcast_claim_declines(job_id, claimants, reason="job_unavailable")
+            return
+        selected = self._select_best_claimant(job, claimants.keys())
+        if selected is None:
+            await self._broadcast_claim_declines(job_id, claimants, reason="no_candidates")
+            return
+        try:
+            await self.assign_job(job_id, selected)
+            self._info(
+                "job_claim_resolved",
+                job_id=job_id,
+                assigned_agent=selected,
+                candidates=len(claimants),
+            )
+        except ValueError:
+            self._warning("job_claim_race", job_id=job_id, agent=selected)
+            await self._broadcast_claim_declines(job_id, claimants, reason="assignment_failed")
+            return
+        await self._broadcast_claim_declines(
+            job_id,
+            {agent: ts for agent, ts in claimants.items() if agent != selected},
+            reason="assigned_elsewhere",
+            assigned_agent=selected,
+        )
+
+    async def _broadcast_claim_declines(
+        self,
+        job_id: str,
+        claimants: Dict[str, datetime],
+        *,
+        reason: str,
+        assigned_agent: Optional[str] = None,
+    ) -> None:
+        for agent in claimants:
+            await self.bus.publish(
+                f"jobs:claim:declined:{job_id}",
+                {
+                    "job_id": job_id,
+                    "agent": agent,
+                    "reason": reason,
+                    "assigned_agent": assigned_agent,
+                },
+                "orchestrator",
+            )
 
     def _build_policy_rationale(
         self,
@@ -1272,6 +1381,7 @@ class Orchestrator:
                 "simulation_hours_per_tick",
                 "simulation_energy_scale",
                 "simulation_compute_scale",
+                "job_claim_window_seconds",
             ):
                 if field in config_updates:
                     value = config_updates[field]
@@ -1422,6 +1532,7 @@ class Orchestrator:
                 "status_counts": dict(status_counts),
                 "active_job_ids": active_jobs,
                 "root_job_ids": root_jobs,
+                "claim_window_seconds": self.config.job_claim_window_seconds,
             },
             "resources": {
                 "energy_available": resource_state.energy_available,

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 
 from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
     Orchestrator,
     OrchestratorConfig,
 )
 from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.simulation import SimulationState
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.jobs import JobRecord, JobSpec, JobStatus
 
 
 def test_simulation_action_updates_resources() -> None:
@@ -91,3 +93,30 @@ def test_policy_action_accounts_for_compute_scarcity() -> None:
 
     assert scarcity_action["stimulus"] >= baseline_action["stimulus"]
     assert scarcity_action["green_shift"] >= baseline_action["green_shift"]
+
+
+def test_select_best_claimant_prefers_skill_match_and_capacity() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=False))
+    job_spec = JobSpec(
+        title="Grid Stabilization",
+        description="Balance planetary grids.",
+        required_skills=["energy-architect", "supply-chain"],
+        reward_tokens=500.0,
+        deadline=datetime.now(timezone.utc) + timedelta(hours=1),
+        validation_window=timedelta(minutes=30),
+    )
+    job = JobRecord(
+        job_id="job-1",
+        spec=job_spec,
+        status=JobStatus.POSTED,
+        created_at=datetime.now(timezone.utc),
+    )
+    orchestrator._agent_skills = {
+        "energy-architect": ["energy-architect", "supply-chain"],
+        "supply-chain": ["supply-chain"],
+    }
+    orchestrator._unresponsive_agents = {"supply-chain"}
+
+    selected = orchestrator._select_best_claimant(job, ["energy-architect", "supply-chain"])
+
+    assert selected == "energy-architect"


### PR DESCRIPTION
### Motivation
- Prevent races and unfair assignment when multiple agents claim the same job simultaneously by introducing a deterministic, scored selection process.
- Prefer agents with matching skills, responsiveness, and available capacity to improve assignment quality.
- Surface the claim resolution window in status snapshots so operators can observe and tune claim arbitration behavior.
- Emit decline notifications to non-selected claimants so agents can respond to assignment outcomes programmatically.

### Description
- Add `job_claim_window_seconds` to `OrchestratorConfig` and include it in the status snapshot under `jobs.claim_window_seconds`.
- Implement buffered claim handling with `_handle_job_claim`, deferred resolution `_resolve_job_claim`, and per-job claim buffers/tasks to batch competing claims.
- Introduce scoring helpers `_score_claimant` and `_select_best_claimant` that rank claimants by skill match, responsiveness (unresponsive detection), and current load, and assign the best candidate via `assign_job`.
- Broadcast `jobs:claim:declined:{job_id}` notifications for non-selected or invalid claimants and add a unit test for claimant selection (`test_select_best_claimant_prefers_skill_match_and_capacity`).

### Testing
- Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests` which previously passed (12 passed) and confirmed no regressions in the demo suite.
- Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py` after changes and observed `5 passed`.
- The modified test covering claimant selection (`test_select_best_claimant_prefers_skill_match_and_capacity`) passed as part of the targeted test run.
- No automated test failures were observed for the modified components during these runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69507e506db083338f2a0dbca8931f15)