### PR TITLE
Add sentient welfare signals to omega demo policy loop

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -428,6 +428,7 @@ class Orchestrator:
             prosperity=state.prosperity_index,
             sustainability=state.sustainability_index,
             nash_welfare=state.nash_welfare,
+            sentient_welfare_index=state.sentient_welfare_index,
             free_energy=state.free_energy,
             entropy=state.entropy,
             hamiltonian=state.hamiltonian,
@@ -670,6 +671,8 @@ class Orchestrator:
         coordination_gap = max(0.0, 1.0 - state.coordination_index)
         game_theory_slack = max(0.0, min(1.0, state.game_theory_slack))
         nash_welfare = max(0.0, min(1.0, state.nash_welfare))
+        sentient_welfare_index = max(0.0, min(1.0, state.sentient_welfare_index))
+        welfare_floor = max(0.0, min(state.prosperity_index, state.sustainability_index))
         stability_index = max(0.0, min(1.0, state.stability_index))
         entropy = max(0.0, state.entropy)
         entropy_pressure = min(1.0, entropy / math.log(2.0))
@@ -697,12 +700,15 @@ class Orchestrator:
         coordination_damping = max(0.2, 1.0 - 0.3 * coordination_gap) * stability_factor
         compute_boost = 1.0 + 0.4 * compute_price_pressure
         entropy_damping = max(0.35, 1.0 - 0.6 * entropy_pressure)
+        welfare_urgency = max(0.0, 1.0 - sentient_welfare_index)
         return {
             "prosperity_gap": prosperity_gap,
             "sustainability_gap": sustainability_gap,
             "coordination_gap": coordination_gap,
             "game_theory_slack": game_theory_slack,
             "nash_welfare": nash_welfare,
+            "sentient_welfare_index": sentient_welfare_index,
+            "welfare_floor": welfare_floor,
             "stability_index": stability_index,
             "entropy": entropy,
             "entropy_pressure": entropy_pressure,
@@ -720,6 +726,7 @@ class Orchestrator:
             "coordination_damping": coordination_damping,
             "compute_boost": compute_boost,
             "entropy_damping": entropy_damping,
+            "welfare_urgency": welfare_urgency,
         }
 
     def _score_claimant(self, job: JobRecord, agent: str) -> Tuple[float, float, int, str]:
@@ -877,6 +884,7 @@ class Orchestrator:
             * (1.0 + 0.5 * signals["hamiltonian_pressure"])
             * signals["entropy_damping"]
         )
+        action_budget *= 0.9 + 0.6 * signals["welfare_urgency"]
         energy_action = action_budget * (0.8 + 0.4 * signals["coordination_damping"])
         stability_modifier = 0.7 + 0.6 * signals["stability_index"]
         stimulus = (
@@ -1496,11 +1504,12 @@ class Orchestrator:
         if self._latest_simulation_state is not None:
             simulation_state = {
                 "energy_output_gw": self._latest_simulation_state.energy_output_gw,
-            "prosperity_index": self._latest_simulation_state.prosperity_index,
-            "sustainability_index": self._latest_simulation_state.sustainability_index,
-            "nash_welfare": self._latest_simulation_state.nash_welfare,
-            "free_energy": self._latest_simulation_state.free_energy,
-            "entropy": self._latest_simulation_state.entropy,
+                "prosperity_index": self._latest_simulation_state.prosperity_index,
+                "sustainability_index": self._latest_simulation_state.sustainability_index,
+                "nash_welfare": self._latest_simulation_state.nash_welfare,
+                "sentient_welfare_index": self._latest_simulation_state.sentient_welfare_index,
+                "free_energy": self._latest_simulation_state.free_energy,
+                "entropy": self._latest_simulation_state.entropy,
                 "hamiltonian": self._latest_simulation_state.hamiltonian,
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -13,6 +13,7 @@ class SimulationState:
     prosperity_index: float
     sustainability_index: float
     nash_welfare: float = 0.0
+    sentient_welfare_index: float = 0.0
     free_energy: float = 0.0
     entropy: float = 0.0
     hamiltonian: float = 0.0
@@ -69,9 +70,12 @@ class SyntheticEconomySim(PlanetarySimulation):
         nash_welfare = math.sqrt(
             max(1e-6, self.prosperity_index) * max(1e-6, self.sustainability_index)
         )
+        welfare_floor = min(self.prosperity_index, self.sustainability_index)
+        sentient_welfare_index = 0.55 * nash_welfare + 0.45 * welfare_floor
         game_theory_slack = min(1.0, nash_welfare * (0.5 + 0.5 * coordination_index))
         return {
             "nash_welfare": nash_welfare,
+            "sentient_welfare_index": sentient_welfare_index,
             "free_energy": free_energy,
             "entropy": entropy,
             "hamiltonian": hamiltonian,
@@ -94,6 +98,7 @@ class SyntheticEconomySim(PlanetarySimulation):
             prosperity_index=self.prosperity_index,
             sustainability_index=self.sustainability_index,
             nash_welfare=metrics["nash_welfare"],
+            sentient_welfare_index=metrics["sentient_welfare_index"],
             free_energy=metrics["free_energy"],
             entropy=metrics["entropy"],
             hamiltonian=metrics["hamiltonian"],

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
@@ -95,6 +95,42 @@ def test_policy_action_accounts_for_compute_scarcity() -> None:
     assert scarcity_action["green_shift"] >= baseline_action["green_shift"]
 
 
+def test_policy_action_accounts_for_sentient_welfare() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
+    low_welfare_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.4,
+        sustainability_index=0.4,
+        nash_welfare=0.4,
+        sentient_welfare_index=0.2,
+        free_energy=0.2,
+        entropy=0.2,
+        hamiltonian=-0.1,
+        coordination_index=0.5,
+        game_theory_slack=0.5,
+        stability_index=0.6,
+    )
+    high_welfare_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.4,
+        sustainability_index=0.4,
+        nash_welfare=0.4,
+        sentient_welfare_index=0.9,
+        free_energy=0.2,
+        entropy=0.2,
+        hamiltonian=-0.1,
+        coordination_index=0.5,
+        game_theory_slack=0.5,
+        stability_index=0.6,
+    )
+
+    low_action = orchestrator._build_policy_action(low_welfare_state)
+    high_action = orchestrator._build_policy_action(high_welfare_state)
+
+    assert low_action["stimulus"] >= high_action["stimulus"]
+    assert low_action["green_shift"] >= high_action["green_shift"]
+
+
 def test_select_best_claimant_prefers_skill_match_and_capacity() -> None:
     orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=False))
     job_spec = JobSpec(


### PR DESCRIPTION
### Motivation
- Surface an interpretable sentient welfare signal derived from existing game-theoretic metrics so policy actions can prioritise equitable outcomes for sentient beings.
- Ground autonomous policy decisions in thermodynamic and game-theoretic signals (Gibbs free energy, Hamiltonian, Nash welfare) to align resource allocation with system stability and welfare.
- Ensure the orchestrator can report welfare state in status snapshots for observability and downstream automation.
- Provide a small, testable change that improves policy responsiveness without altering external APIs.

### Description
- Added `sentient_welfare_index` to `SimulationState` and computed it in `SyntheticEconomySim._compute_thermodynamic_metrics` as a weighted blend of Nash welfare and a welfare floor.
- Integrated `sentient_welfare_index` into `_compute_policy_signals` and exposed a `welfare_urgency` signal that scales the autonomous `action_budget` used by `_build_policy_decision`.
- Included `sentient_welfare_index` in orchestrator logging and the status snapshot emitted by `_collect_status_snapshot` for visibility.
- Added `test_policy_action_accounts_for_sentient_welfare` to `tests/test_simulation_actions.py` to ensure policy actions respond to welfare changes.

### Testing
- Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests` and all tests passed (`14 passed`).
- Executed the demo CLI wrapper smoke run with `python -m demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo --cycles 1 --no-sim` to validate runtime integration, which completed successfully.
- Existing demo unit suites were exercised as part of the local test loop (module-level tests for the changed demo were green).
- No new failing tests were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69508588dd088333b610cc2843a821a6)