### PR TITLE
Add alignment investment to omega simulation policy

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -652,7 +652,7 @@ class Orchestrator:
                     await self._handle_simulation_action(message.payload)
 
     def _normalize_simulation_action(self, payload: Dict[str, Any]) -> Dict[str, float]:
-        allowed_fields = ("build_dyson_nodes", "stimulus", "green_shift")
+        allowed_fields = ("build_dyson_nodes", "stimulus", "green_shift", "alignment_investment")
         normalized: Dict[str, float] = {}
         for field in allowed_fields:
             if field not in payload:
@@ -901,11 +901,18 @@ class Orchestrator:
             * signals["compute_boost"]
             * stability_modifier
         )
+        alignment_investment = (
+            action_budget
+            * signals["coordination_gap"]
+            * (0.6 + 0.4 * signals["welfare_urgency"])
+            * (0.7 + 0.3 * signals["stability_index"])
+        )
         normalized_action = self._normalize_simulation_action(
             {
                 "build_dyson_nodes": energy_action * signals["stability_factor"] * stability_modifier,
                 "stimulus": stimulus,
                 "green_shift": green_shift,
+                "alignment_investment": alignment_investment,
             }
         )
         rationale = self._build_policy_rationale(
@@ -917,6 +924,7 @@ class Orchestrator:
                 "energy_action": energy_action,
                 "stimulus": stimulus,
                 "green_shift": green_shift,
+                "alignment_investment": alignment_investment,
             },
         )
         return {"action": normalized_action, "rationale": rationale}

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -44,9 +44,20 @@ class SyntheticEconomySim(PlanetarySimulation):
         build_dyson_nodes = max(0.0, float(action.get("build_dyson_nodes", 0.0)))
         stimulus = max(0.0, float(action.get("stimulus", 0.0)))
         green_shift = max(0.0, float(action.get("green_shift", 0.0)))
+        alignment_investment = max(0.0, float(action.get("alignment_investment", 0.0)))
         self.energy_output_gw += build_dyson_nodes * 10_000
         self.prosperity_index = min(1.0, self.prosperity_index + stimulus * 0.01)
         self.sustainability_index = min(1.0, self.sustainability_index + green_shift * 0.02)
+        if alignment_investment:
+            gap = self.prosperity_index - self.sustainability_index
+            alignment_step = min(0.02 * alignment_investment, abs(gap))
+            if gap > 0:
+                self.sustainability_index = min(1.0, self.sustainability_index + alignment_step)
+            elif gap < 0:
+                self.prosperity_index = min(1.0, self.prosperity_index + alignment_step)
+            shared_boost = 0.003 * alignment_investment
+            self.prosperity_index = min(1.0, self.prosperity_index + shared_boost)
+            self.sustainability_index = min(1.0, self.sustainability_index + shared_boost)
         return self._snapshot_state()
 
     def _compute_thermodynamic_metrics(self) -> dict[str, float]:

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
@@ -131,6 +131,41 @@ def test_policy_action_accounts_for_sentient_welfare() -> None:
     assert low_action["green_shift"] >= high_action["green_shift"]
 
 
+def test_policy_action_invests_in_alignment_for_coordination_gap() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
+    low_coordination_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.7,
+        sustainability_index=0.2,
+        nash_welfare=0.4,
+        sentient_welfare_index=0.4,
+        free_energy=0.4,
+        entropy=0.4,
+        hamiltonian=-0.2,
+        coordination_index=0.2,
+        game_theory_slack=0.3,
+        stability_index=0.5,
+    )
+    high_coordination_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.6,
+        sustainability_index=0.6,
+        nash_welfare=0.6,
+        sentient_welfare_index=0.7,
+        free_energy=0.2,
+        entropy=0.2,
+        hamiltonian=-0.1,
+        coordination_index=0.9,
+        game_theory_slack=0.8,
+        stability_index=0.8,
+    )
+
+    low_action = orchestrator._build_policy_action(low_coordination_state)
+    high_action = orchestrator._build_policy_action(high_coordination_state)
+
+    assert low_action["alignment_investment"] >= high_action["alignment_investment"]
+
+
 def test_select_best_claimant_prefers_skill_match_and_capacity() -> None:
     orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=False))
     job_spec = JobSpec(


### PR DESCRIPTION
### Motivation
- Introduce a first-class `alignment_investment` action to allow autonomous policies to proactively reduce coordination gaps between prosperity and sustainability.
- Ground the autonomous decision logic in game-theoretic and thermodynamic signals (Gibbs free energy, Hamiltonian, coordination metrics) so policy actions are socio-physically informed.
- Provide a simple mechanism that boosts shared welfare and stability while remaining bounded and testable within the synthetic economy demo.

### Description
- Added `alignment_investment` handling to the simulation `apply_action` in `simulation.py` which nudges `prosperity_index` and `sustainability_index` toward alignment and provides a small shared boost. 
- Extended the orchestrator `._normalize_simulation_action` to accept `alignment_investment` and included `alignment_investment` in the autonomous policy decision computed by `._build_policy_decision` in `orchestrator.py`.
- The autonomous decision now computes `alignment_investment` from coordination and welfare signals (using `coordination_gap`, `welfare_urgency`, and `stability_index`) and includes it in the `rationale` for observability.
- Added a unit test `test_policy_action_invests_in_alignment_for_coordination_gap` to `tests/test_simulation_actions.py` asserting higher `alignment_investment` when coordination is low.

### Testing
- Ran the modified demo unit tests with `python -m pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py` and observed all tests passing. 
- The targeted test run completed successfully: `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951345cefe4833386c8fed038957138)