### PR TITLE
Add sentient welfare metrics to Omega energy oracle snapshot

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -1598,11 +1598,12 @@ class Orchestrator:
         if self._latest_simulation_state is not None:
             simulation_state = {
                 "energy_output_gw": self._latest_simulation_state.energy_output_gw,
-            "prosperity_index": self._latest_simulation_state.prosperity_index,
-            "sustainability_index": self._latest_simulation_state.sustainability_index,
-            "nash_welfare": self._latest_simulation_state.nash_welfare,
-            "free_energy": self._latest_simulation_state.free_energy,
-            "entropy": self._latest_simulation_state.entropy,
+                "prosperity_index": self._latest_simulation_state.prosperity_index,
+                "sustainability_index": self._latest_simulation_state.sustainability_index,
+                "nash_welfare": self._latest_simulation_state.nash_welfare,
+                "sentient_welfare_index": self._latest_simulation_state.sentient_welfare_index,
+                "free_energy": self._latest_simulation_state.free_energy,
+                "entropy": self._latest_simulation_state.entropy,
                 "hamiltonian": self._latest_simulation_state.hamiltonian,
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_energy_oracle_snapshot.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_energy_oracle_snapshot.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
+
+
+def test_energy_oracle_snapshot_exposes_welfare_metrics() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
+    assert orchestrator.simulation is not None
+    state = orchestrator.simulation.tick(hours=0.0)
+    orchestrator._apply_simulation_state(state, event="simulation_tick")
+
+    snapshot = orchestrator._collect_energy_snapshot()
+    simulation = snapshot["simulation"]
+
+    assert simulation is not None
+    assert simulation["sentient_welfare_index"] == state.sentient_welfare_index
+    assert simulation["nash_welfare"] == state.nash_welfare


### PR DESCRIPTION
### Motivation
- Expose higher-level welfare signals alongside thermodynamic indicators so energy oracle telemetry can inform policy and UI components.  
- Surface a `sentient_welfare_index` derived by the simulation so dashboards and autonomous policy logic can reason about welfare, not only raw energy metrics.  
- Keep the energy snapshot aligned with the simulation's enriched state (Gibbs/free-energy, Hamiltonian and game-theory signals).  

### Description
- Expand `_collect_energy_snapshot` in `orchestrator.py` to include `sentient_welfare_index` in the `simulation` payload returned to the energy oracle.  
- Add a unit test `demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_energy_oracle_snapshot.py` that exercises the simulation tick, applies state, collects a snapshot, and asserts welfare fields are present and correct.  
- Minor reformatting to keep the snapshot keys aligned and explicit when the latest simulation state is available.  

### Testing
- Ran the new unit test with `pytest demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/tests/test_energy_oracle_snapshot.py`, which passed.  
- A broader automated demo test run (`python demo/run_demo_tests.py`) was executed during investigation but was interrupted while system-level dependencies were installing, so the global run was not completed in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69513c218d608333bbfa7c84603a25f7)