### PR TITLE
Fix Kardashev dashboard runway gap rendering

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/ui/dashboard.js
@@ -276,9 +276,13 @@ function renderMonteCarloDetails(monteCarlo) {
     const runwayText = Number.isFinite(monteCarlo.runwayHours)
       ? ` · runway ${monteCarlo.runwayHours.toFixed(2)}h`
       : "";
+    const runwayGapText =
+      Number.isFinite(monteCarlo.runwayGapHours) && Number.isFinite(monteCarlo.runwayGapGwh)
+        ? ` (gap ${monteCarlo.runwayGapHours.toFixed(2)}h, ${formatNumber(monteCarlo.runwayGapGwh)} GWh)`
+        : "";
     freeEnergyElement.textContent = `Free energy margin ${formatNumber(
       monteCarlo.freeEnergyMarginGw
-    )} GW${freeEnergyPct}${gibbsText}${runwayText}`;
+    )} GW${freeEnergyPct}${gibbsText}${runwayText}${runwayGapText}`;
     applyStatus(freeEnergyElement, monteCarlo.maintainsBuffer ? "status-ok" : "status-warn");
   } else {
     freeEnergyElement.textContent = "Free energy margin unavailable.";

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -280,10 +280,6 @@ function renderMonteCarloDetails(monteCarlo) {
       Number.isFinite(monteCarlo.runwayGapHours) && Number.isFinite(monteCarlo.runwayGapGwh)
         ? ` (gap ${monteCarlo.runwayGapHours.toFixed(2)}h, ${formatNumber(monteCarlo.runwayGapGwh)} GWh)`
         : "";
-    const runwayGapText =
-      Number.isFinite(monteCarlo.runwayGapHours) && Number.isFinite(monteCarlo.runwayGapGwh)
-        ? ` (gap ${monteCarlo.runwayGapHours.toFixed(2)}h, ${formatNumber(monteCarlo.runwayGapGwh)} GWh)`
-        : "";
     freeEnergyElement.textContent = `Free energy margin ${formatNumber(
       monteCarlo.freeEnergyMarginGw
     )} GW${freeEnergyPct}${gibbsText}${runwayText}${runwayGapText}`;


### PR DESCRIPTION
### Motivation
- The dashboard had a duplicated `runwayGapText` declaration which produced a parse/duplication issue and prevented the runway gap from being shown reliably.  
- The UI should present the free-energy runway gap alongside free-energy margin so operators can see the shortfall at a glance.  
- Keep generated (output) bundle in sync with the source so offline dashboards show the same telemetry.  

### Description
- Removed the duplicate `runwayGapText` declaration in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js` to fix the parsing error.  
- Appended `runwayGapText` to the `Free energy margin` line so the dashboard displays the runway gap and GWh figure when available.  
- Propagated the same change to the bundled output file at `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/ui/dashboard.js` for the offline dashboard.  
- Committed the two updated files and ensured the orchestrator/CI validation remains consistent with the artefacts.  

### Testing
- Re-ran `npm run demo:kardashev-ii:ci` which completed successfully and reported artefacts and README verification as ✔.  
- Executed the orchestrator check with `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs --check` which validated the dossier (check mode) without error.  
- The repository's demo test runner (`python demo/run_demo_tests.py`) had previously completed with all demo suites passing (`All demo test suites passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695193fe65e48333affb166da8df028d)