### PR TITLE
Refine energy runway telemetry for Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -257,12 +257,14 @@ function simulateEnergyMonteCarlo(fabric, energyFeeds, energyConfig, energyModel
   const demandStdDevGw = Math.sqrt(variance);
   const freeEnergyMarginGw = availableGw - p95Demand;
   const freeEnergyMarginPct = availableGw === 0 ? 0 : Math.max(0, freeEnergyMarginGw / availableGw);
-  const runwayHours =
+  const grossRunwayHours =
     meanDemandGw > 0 ? Math.max(0, freeEnergyMarginGw) / meanDemandGw : 0;
+  const usableFreeEnergyGw = Math.max(0, freeEnergyMarginGw - marginGw);
+  const runwayHours = meanDemandGw > 0 ? usableFreeEnergyGw / meanDemandGw : 0;
   const runwayGapHours = Math.max(0, ENERGY_RUNWAY_TARGET_HOURS - runwayHours);
   const runwayGapGwh = meanDemandGw > 0 ? runwayGapHours * meanDemandGw : 0;
   const runwayGapGj = runwayGapGwh * 3600;
-  const gibbsFreeEnergyGj = Math.max(0, freeEnergyMarginGw) * 3600; // convert GW headroom into GJ over a one-hour horizon
+  const gibbsFreeEnergyGj = usableFreeEnergyGw * 3600; // convert buffered headroom into GJ over a one-hour horizon
   const hamiltonianStability = Math.max(
     0,
     Math.min(1, 0.5 * (1 - breachProbability) + 0.5 * freeEnergyMarginPct)
@@ -278,10 +280,12 @@ function simulateEnergyMonteCarlo(fabric, energyFeeds, energyConfig, energyModel
     marginGw,
     freeEnergyMarginGw,
     freeEnergyMarginPct,
+    grossRunwayHours,
     runwayHours,
     runwayGapHours,
     runwayGapGwh,
     runwayGapGj,
+    usableFreeEnergyGw,
     meanDemandGw,
     demandStdDevGw,
     entropyMargin: demandStdDevGw > 0 ? freeEnergyMarginGw / demandStdDevGw : freeEnergyMarginGw,
@@ -1738,6 +1742,8 @@ function buildEquilibriumLedger({
       energy: {
         score: round(energyScore, 4),
         freeEnergyMarginPct: round(energyMonteCarlo.freeEnergyMarginPct, 4),
+        usableFreeEnergyGw: round(energyMonteCarlo.usableFreeEnergyGw ?? 0, 4),
+        grossRunwayHours: round(energyMonteCarlo.grossRunwayHours ?? 0, 4),
         runwayHours: round(energyMonteCarlo.runwayHours ?? 0, 4),
         hamiltonianStability: round(energyMonteCarlo.hamiltonianStability, 4),
         gameTheorySlack: round(energyMonteCarlo.gameTheorySlack, 4),
@@ -1786,6 +1792,8 @@ function buildEquilibriumLedger({
     },
     thermodynamics: {
       freeEnergyMarginPct: round(energyMonteCarlo.freeEnergyMarginPct, 4),
+      usableFreeEnergyGw: round(energyMonteCarlo.usableFreeEnergyGw ?? 0, 4),
+      grossRunwayHours: round(energyMonteCarlo.grossRunwayHours ?? 0, 4),
       runwayHours: round(energyMonteCarlo.runwayHours ?? 0, 4),
       runwayGapHours: round(energyMonteCarlo.runwayGapHours ?? 0, 4),
       runwayGapGwh: round(energyMonteCarlo.runwayGapGwh ?? 0, 4),
@@ -1840,6 +1848,12 @@ function buildActionPathBriefing(equilibriumLedger) {
       thermodynamics.runwayGapHours,
       2
     )}h, ${formatFixedValue(thermodynamics.runwayGapGwh, 2)} GWh)`
+  );
+  lines.push(
+    `- Buffered free energy: ${formatFixedValue(thermodynamics.usableFreeEnergyGw, 2)} GW usable · gross runway ${formatFixedValue(
+      thermodynamics.grossRunwayHours,
+      2
+    )}h`
   );
   lines.push(
     `- Gibbs free energy: ${formatNumber(thermodynamics.gibbsFreeEnergyGj ?? 0)} GJ`

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -95,6 +95,8 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert energy["freeEnergyMarginGw"] > 0
     assert 0 < energy["freeEnergyMarginPct"] <= 1
     assert energy["runwayHours"] > 0
+    assert energy["grossRunwayHours"] >= energy["runwayHours"]
+    assert energy["usableFreeEnergyGw"] >= 0
     assert energy["runwayGapHours"] >= 0
     assert energy["runwayGapGwh"] >= 0
     assert energy["runwayGapGj"] >= 0
@@ -152,6 +154,11 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     equilibrium_payload = json.loads(equilibrium_ledger.read_text())
     assert equilibrium_payload["overallScore"] >= 0
     assert equilibrium_payload["components"]["energy"]["freeEnergyMarginPct"] > 0
+    assert equilibrium_payload["components"]["energy"]["usableFreeEnergyGw"] >= 0
+    assert (
+        equilibrium_payload["components"]["energy"]["grossRunwayHours"]
+        >= equilibrium_payload["components"]["energy"]["runwayHours"]
+    )
     assert 0 <= equilibrium_payload["components"]["allocation"]["strategyStability"] <= 1
     assert 0 <= equilibrium_payload["components"]["welfare"]["coalitionStability"] <= 1
     assert equilibrium_payload["components"]["compute"]["averageAvailabilityPct"] >= 0

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -273,8 +273,14 @@ function renderMonteCarloDetails(monteCarlo) {
     const gibbsText = Number.isFinite(monteCarlo.gibbsFreeEnergyGj)
       ? ` · Gibbs ${formatNumber(monteCarlo.gibbsFreeEnergyGj)} GJ`
       : "";
+    const usableText = Number.isFinite(monteCarlo.usableFreeEnergyGw)
+      ? ` · usable ${formatNumber(monteCarlo.usableFreeEnergyGw)} GW`
+      : "";
     const runwayText = Number.isFinite(monteCarlo.runwayHours)
       ? ` · runway ${monteCarlo.runwayHours.toFixed(2)}h`
+      : "";
+    const grossRunwayText = Number.isFinite(monteCarlo.grossRunwayHours)
+      ? ` (gross ${monteCarlo.grossRunwayHours.toFixed(2)}h)`
       : "";
     const runwayGapText =
       Number.isFinite(monteCarlo.runwayGapHours) && Number.isFinite(monteCarlo.runwayGapGwh)
@@ -282,7 +288,7 @@ function renderMonteCarloDetails(monteCarlo) {
         : "";
     freeEnergyElement.textContent = `Free energy margin ${formatNumber(
       monteCarlo.freeEnergyMarginGw
-    )} GW${freeEnergyPct}${gibbsText}${runwayText}${runwayGapText}`;
+    )} GW${freeEnergyPct}${gibbsText}${usableText}${runwayText}${grossRunwayText}${runwayGapText}`;
     applyStatus(freeEnergyElement, monteCarlo.maintainsBuffer ? "status-ok" : "status-warn");
   } else {
     freeEnergyElement.textContent = "Free energy margin unavailable.";


### PR DESCRIPTION
### Motivation

- Improve thermodynamic observability by distinguishing buffered (usable) free-energy headroom from gross runway estimates so operators can assess real absorbable reserves. 
- Surface buffered runway signals through the equilibrium ledger and action-path briefings to inform governance and corrective steps. 
- Make dashboard UX reflect the buffered/gross runway split for clearer situational awareness. 
- Add assertions to demo tests so automated validation covers the new telemetry fields.

### Description

- Compute `usableFreeEnergyGw` and `grossRunwayHours` in `simulateEnergyMonteCarlo` and include them in the returned `energyMonteCarlo` summary. 
- Surface the new fields in the equilibrium ledger (`components.energy` and `thermodynamics`) and add a brief line to the action-path briefing. 
- Update the dashboard UI (`ui/dashboard.js`) to display `usableFreeEnergyGw` and `grossRunwayHours` alongside existing Monte Carlo details. 
- Extend the demo test suite (`tests/test_run_demo.py`) to assert presence and basic invariants for `usableFreeEnergyGw` and `grossRunwayHours`.

### Testing

- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests -q` and the suite passed (`8 passed`).
- Executed the Node wrapper in check mode with `node run-demo.cjs --check` which completed successfully and reported expected telemetry summaries. 
- Generated full artefacts with `node run-demo.cjs --output-dir <tmp>` and verified produced outputs and updated telemetry JSON values. 
- Attempted to capture a dashboard screenshot with Playwright but the Chromium process crashed in this environment (SIGSEGV) so headless rendering failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951a014c2508333b6c01f4680ebb56f)