### PR TITLE
Skip optional Playwright e2e when Chromium or system deps are missing

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js
@@ -202,6 +202,7 @@ function main(options = {}) {
     buildPlaywrightEnv: buildEnv = buildPlaywrightEnv,
     runStep: run = runStep,
     canInstallDeps: canInstallDepsImpl = canInstallPlaywrightDeps,
+    depsProbe: depsProbeImpl = arePlaywrightDepsReady,
   } = options;
 
   // Forward npm-provided args to the Jest suite (demo runner passes --runInBand)
@@ -212,15 +213,16 @@ function main(options = {}) {
   const optionalE2E = isOptionalE2E(env);
   const optionalE2EOnFailure = isOptionalE2EOnFailure(env);
   const canInstallDeps = () => canInstallDepsImpl();
+  const systemDepsReady = () => depsProbeImpl();
 
   const playwrightEnv = buildEnv({ autoInstall: playwrightAutoInstall, env });
   process.env.PLAYWRIGHT_BROWSERS_PATH = playwrightEnv.PLAYWRIGHT_BROWSERS_PATH;
 
   run(npmBinary, ['run', 'test:unit', '--', ...forwardedArgs]);
   const cachedChromiumReady = hasWorkingChromium(require('@playwright/test').chromium.executablePath());
-  if (optionalE2E && !cachedChromiumReady) {
+  if (optionalE2E && (!cachedChromiumReady || !systemDepsReady())) {
     console.warn(
-      'Skipping Playwright e2e tests because PLAYWRIGHT_OPTIONAL_E2E is enabled and no cached Chromium binary is available.',
+      'Skipping Playwright e2e tests because PLAYWRIGHT_OPTIONAL_E2E is enabled and the environment lacks a cached Chromium build or required system dependencies.',
     );
     return;
   }


### PR DESCRIPTION
### Motivation
- Prevent false negative CI/local failures when Playwright e2e is optional but the host lacks a cached Chromium binary or required system libraries. 
- Make the optional-e2e decision respect both browser availability and system dependency probes for more robust local developer ergonomics. 
- Surface a clearer warning message when skipping optional e2e due to missing system prerequisites. 

### Description
- Threaded a `depsProbe` hook into `main` in `demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js` and defaulted it to `arePlaywrightDepsReady`. 
- Enhanced the optional-e2e short-circuit to skip tests when either a cached Chromium is missing or system deps are not ready. 
- Updated the skip `console.warn` to explain that the environment lacks either a cached Chromium build or required system dependencies. 

### Testing
- Ran `npm run test:unit -- --runInBand` in `demo/Phase-8-Universal-Value-Dominance` and all unit suites passed (6 suites, 50 tests). 
- Verified the modified branch preserves existing behavior for non-optional e2e and auto-install paths during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c0c4fa4c83338457509ec7d21125)