### PR TITLE
Treat negative Gibbs free energy as deficit in policy signals

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -689,7 +689,7 @@ class Orchestrator:
         else:
             prosperity_share = prosperity_weight / total_weight
             sustainability_share = sustainability_weight / total_weight
-        gibbs_drive = max(0.0, state.free_energy)
+        gibbs_drive = max(0.0, -state.free_energy)
         hamiltonian_pressure = min(1.0, abs(state.hamiltonian))
         stability_factor = (
             (0.6 + 0.4 * stability_index)
@@ -867,9 +867,9 @@ class Orchestrator:
 
         We use a Nash-style bargaining split between prosperity and sustainability
         gaps, and a Boltzmann weighting (statistical physics) to soften allocation
-        under coordination stress. Gibbs free energy and the Hamiltonian magnitude
-        shape the energy expansion push to keep the demo grounded in Kardashev-II
-        scaling dynamics.
+        under coordination stress. The Gibbs free-energy deficit and Hamiltonian
+        magnitude shape the energy expansion push to keep the demo grounded in
+        Kardashev-II scaling dynamics.
         """
 
         signals = self._compute_policy_signals(state)

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
+
 from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
     Orchestrator,
     OrchestratorConfig,
 )
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.simulation import SimulationState
 
 
 def test_autonomous_policy_action_updates_simulation(tmp_path: Path) -> None:
@@ -40,3 +43,32 @@ def test_autonomous_policy_action_updates_simulation(tmp_path: Path) -> None:
             await orchestrator.shutdown()
 
     asyncio.run(_run())
+
+
+def test_policy_signals_use_gibbs_deficit(tmp_path: Path) -> None:
+    orchestrator = Orchestrator(
+        OrchestratorConfig(
+            control_channel_file=tmp_path / "control.jsonl",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            status_output_path=None,
+            audit_log_path=None,
+            energy_oracle_path=None,
+        )
+    )
+    state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.7,
+        sustainability_index=0.6,
+        free_energy=-0.5,
+        entropy=0.4,
+        hamiltonian=-0.3,
+        stability_index=0.8,
+        coordination_index=0.9,
+        nash_welfare=0.65,
+        sentient_welfare_index=0.6,
+        game_theory_slack=0.7,
+    )
+
+    signals = orchestrator._compute_policy_signals(state)
+
+    assert signals["gibbs_drive"] == pytest.approx(0.5)


### PR DESCRIPTION
### Motivation

- The policy decision logic used `state.free_energy` directly which treated positive free energy as a driver, but thermodynamic intuition and the demo intent require a deficit (negative free energy) to trigger expansion actions.
- Align autonomous policy actions with Gibbs free-energy deficits so the orchestrator responds when the simulated economy has a free-energy shortfall.
- Improve clarity in the policy documentation to reflect that deficits (not surpluses) drive energy-expansion pushes.
- Add a focused test to prevent regressions in how the Gibbs signal is computed.

### Description

- Change the Gibbs drive computation in `orchestrator.py` from `max(0.0, state.free_energy)` to `max(0.0, -state.free_energy)` so negative free energy produces a positive drive signal.
- Update the `_build_policy_decision` docstring to clarify we use the Gibbs free-energy deficit when shaping actions.
- Add `test_policy_signals_use_gibbs_deficit` to `tests/test_policy_actions.py` to assert the new `gibbs_drive` behaviour for a negative `free_energy` state.

### Testing

- Ran the focused test file with `pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py"` and it passed (2 tests).
- The demo-wide test runner was executed earlier (`python demo/run_demo_tests.py`) and completed with all demo test suites passing.
- The new unit test verifies that a `SimulationState` with `free_energy=-0.5` yields `gibbs_drive≈0.5` in `_compute_policy_signals`.
- No tests failed related to the changed behaviour.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951ec96cfa88333a4a53ba85571188d)