### PR TITLE
Sync Kardashev II live energy feeds with manifest telemetry and persist Monte Carlo snapshot

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-action-path.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-action-path.md
@@ -1,6 +1,6 @@
 # Kardashev II Action Path
 
-Generated: 2025-12-29T00:07:49.355Z
+Generated: 2025-12-29T06:00:41.112Z
 
 ## Core equilibrium signals
 - Free energy margin: 67.33%

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -790,28 +790,47 @@ function buildEnergyModels(energyConfig, manifest, dyson) {
   };
 }
 
-function buildLiveEnergyFeeds(energyConfig, rng) {
+function buildLiveEnergyFeeds(energyConfig, manifest) {
   const tolerancePct = energyConfig.tolerancePct ?? 5;
-  const driftAlertPct = energyConfig.driftAlertPct ?? 8.5;
+  const driftAlertPct =
+    typeof energyConfig.driftAlertPct === 'number'
+      ? energyConfig.driftAlertPct
+      : tolerancePct * 1.5;
   const feeds = energyConfig.feeds.map((feed) => {
-    const deltaPct = Math.abs((rng() - 0.5) * driftAlertPct * 1.25);
+    const federation = manifest.federations.find(
+      (entry) => entry.slug === feed.federationSlug
+    );
+    const manifestGw = federation?.energy?.availableGw ?? 0;
+    const feedGw = (feed.nominalMw + feed.bufferMw) / 1000;
+    const deltaGw = manifestGw - feedGw;
+    const deltaPct =
+      manifestGw === 0 ? 0 : (Math.abs(deltaGw) / Math.max(manifestGw, 1)) * 100;
     const withinTolerance = deltaPct <= tolerancePct;
+    const driftAlert = deltaPct >= driftAlertPct;
     return {
       region: feed.region,
+      federationSlug: feed.federationSlug,
       type: feed.type,
+      telemetry: feed.telemetry,
+      manifestGw,
+      feedGw,
+      deltaGw,
       deltaPct,
       latencyMs: feed.latencyMs,
       withinTolerance,
-      driftAlert: deltaPct > driftAlertPct,
+      driftAlert,
     };
   });
   const latencies = feeds.map((feed) => feed.latencyMs);
+  const driftAlerts = feeds.filter((feed) => feed.driftAlert);
   return {
+    calibrationISO8601: energyConfig.calibrationISO8601 ?? null,
     tolerancePct,
     driftAlertPct,
     averageLatencyMs: average(latencies),
     maxLatencyMs: Math.max(...latencies),
     allWithinTolerance: feeds.every((feed) => feed.withinTolerance),
+    driftAlerts,
     feeds,
   };
 }
@@ -2466,7 +2485,7 @@ function main() {
     averageResilience: dominanceAverageResilience,
   };
 
-  const liveFeeds = buildLiveEnergyFeeds(calibratedEnergy, rng);
+  const liveFeeds = buildLiveEnergyFeeds(energy, manifest);
   const energyUtilisationPct = average(shardMetrics.map((metric) => metric.utilisation / 100));
   const energyMarginPct = clampRatio(energyMonteCarlo.freeEnergyMarginPct ?? 0);
   const energyModelDiff = Math.abs(energyModels.regionalSumGw - energyModels.dysonProjectionGw);
@@ -2874,6 +2893,23 @@ function main() {
     fs.writeFileSync(
       path.join(outputDir, 'kardashev-action-path.md'),
       `${buildActionPathBriefing(equilibriumLedger)}\n`
+    );
+    fs.writeFileSync(
+      path.join(outputDir, 'kardashev-energy-feeds.json'),
+      `${JSON.stringify(
+        {
+          calibrationISO8601: liveFeeds.calibrationISO8601,
+          tolerancePct: liveFeeds.tolerancePct,
+          driftAlertPct: liveFeeds.driftAlertPct,
+          feeds: liveFeeds.feeds,
+        },
+        null,
+        2
+      )}\n`
+    );
+    fs.writeFileSync(
+      path.join(outputDir, 'kardashev-monte-carlo.json'),
+      `${JSON.stringify(energyMonteCarlo, null, 2)}\n`
     );
 
     const telemetryPath = path.join(outputDir, 'kardashev-telemetry.json');


### PR DESCRIPTION
### Motivation
- Align live energy feed comparisons with authoritative manifest telemetry so feed drift and tolerances reflect declared federation availability rather than synthetic RNG values.
- Surface a reproducible energy feed snapshot and Monte Carlo output to `output/` so dashboards and CI can assert against stable artefacts.
- Make drift thresholds explicit and derived from configured `tolerancePct` when `driftAlertPct` is not provided.
- Ensure the offline operator artefacts (action path, feeds, monte-carlo) are regenerated and persisted deterministically for CI reconciliation.

### Description
- Reworked `buildLiveEnergyFeeds` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` to take the `manifest` and compute `manifestGw`, `feedGw`, `deltaGw`, and `deltaPct` from `feed.nominalMw`/`bufferMw` and `manifest.federations[*].energy.availableGw` instead of purely stochastic deltas.
- Normalised `driftAlertPct` fallback behavior to `tolerancePct * 1.5` when not provided and added `driftAlerts` metadata to the live feed result.
- Persisted live feed summaries and Monte Carlo results to `output/kardashev-energy-feeds.json` and `output/kardashev-monte-carlo.json` when generating artefacts, and ensured the offline `kardashev-action-path.md` remains in sync.
- Kept existing allocation enrichment and energy runway stabilisation logic but wired live feed construction to the manifest-backed `energy` config to remove inconsistent RNG-driven reporting.

### Testing
- Ran `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs --check` and observed: "✅ Kardashev II scale dossier validated (check mode)." (success).
- Ran `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` to generate artefacts and confirmed `output/kardashev-energy-feeds.json` and `output/kardashev-monte-carlo.json` were produced (success).
- Executed `npm run demo:kardashev-ii:orchestrate` and `npm run demo:kardashev-ii:ci` to regenerate and validate orchestrator artefacts, and both completed with expected outputs (success).
- Ran the demo test runner `python demo/run_demo_tests.py` which executed the demo suites and reported all demo test suites passed (41 suites, completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952174bef8483339069f4c497afe743)