### PR TITLE
Fix Kardashev II dashboard asset base for output build

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-action-path.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-action-path.md
@@ -1,6 +1,6 @@
 # Kardashev II Action Path
 
-Generated: 2025-12-29T06:00:41.112Z
+Generated: 2025-12-29T14:44:03.735Z
 
 ## Core equilibrium signals
 - Free energy margin: 67.33%

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/ui/dashboard.js
@@ -13,6 +13,11 @@ function resolveAssetBase() {
     return datasetBase.replace(/\/$/, "");
   }
 
+  const path = window.location?.pathname || "";
+  if (path.includes("/output/") || path.endsWith("/output")) {
+    return ".";
+  }
+
   return DEFAULT_ASSET_BASE;
 }
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -13,6 +13,11 @@ function resolveAssetBase() {
     return datasetBase.replace(/\/$/, "");
   }
 
+  const path = window.location?.pathname || "";
+  if (path.includes("/output/") || path.endsWith("/output")) {
+    return ".";
+  }
+
   return DEFAULT_ASSET_BASE;
 }
 


### PR DESCRIPTION
### Motivation
- The dashboard served from the demo `output/` directory failed to resolve inlined telemetry and diagram assets because the asset base inference assumed `./output` even when running from `output/` itself. 
- This caused the UI to attempt to fetch `output/...` paths while already located inside `output/`, breaking relative resolution.
- Make the operator experience frictionless when serving `output/index.html` directly or via the local `serve` helper.
- Keep generated artefacts in-sync with the orchestrator output when the dashboard code is updated.

### Description
- Adjusted `resolveAssetBase()` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js` to detect when the page is served from an `output/` path and return `.` as the asset base in that case.
- Updated the built/output copy `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/ui/dashboard.js` to match the source change so the static bundle works when opened from `output/`.
- Regenerated orchestrator artefacts which updated `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-action-path.md` timestamp and refreshed the `output/` assets.
- Committed the source and regenerated output changes to keep the repo CI validation passing.

### Testing
- Ran `pytest` suites for relevant demos: `demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo` tests (15 passed) and the `Kardashev-II Omega-Grade` tests (18 passed), both completed successfully. 
- Executed `npm run demo:kardashev-ii:orchestrate` to regenerate telemetry/ledgers and the output bundle, which completed and produced the expected artefacts. 
- Ran `npm run demo:kardashev-ii:ci` and verification passed after regenerating artifacts (initial drift was detected and resolved by the orchestrator run). 
- Started the local dashboard server `npm run demo:kardashev-ii:serve` and validated the page loads headlessly via Playwright, capturing a screenshot of the rendered dashboard successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695292eeabec83338fd2a53d3a4be3f8)