### PR TITLE
Strengthen omega demo stability guard behavior

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -701,6 +701,9 @@ class Orchestrator:
         compute_boost = 1.0 + 0.4 * compute_price_pressure
         entropy_damping = max(0.35, 1.0 - 0.6 * entropy_pressure)
         welfare_urgency = max(0.0, 1.0 - sentient_welfare_index)
+        stability_guard = 1.0 - 0.55 * entropy_pressure - 0.35 * coordination_gap - 0.2 * hamiltonian_pressure
+        stability_guard *= 0.6 + 0.4 * stability_index
+        stability_guard = min(1.0, max(0.2, stability_guard))
         return {
             "prosperity_gap": prosperity_gap,
             "sustainability_gap": sustainability_gap,
@@ -727,6 +730,7 @@ class Orchestrator:
             "compute_boost": compute_boost,
             "entropy_damping": entropy_damping,
             "welfare_urgency": welfare_urgency,
+            "stability_guard": stability_guard,
         }
 
     def _score_claimant(self, job: JobRecord, agent: str) -> Tuple[float, float, int, str]:
@@ -885,14 +889,22 @@ class Orchestrator:
             * signals["entropy_damping"]
         )
         action_budget *= 0.9 + 0.6 * signals["welfare_urgency"]
-        energy_action = action_budget * (0.8 + 0.4 * signals["coordination_damping"])
+        alignment_budget = (
+            action_budget
+            * (1.0 + 0.8 * signals["entropy_pressure"])
+            / max(0.6, signals["entropy_damping"])
+        )
+        stability_guard = signals["stability_guard"]
+        energy_action = action_budget * (0.8 + 0.4 * signals["coordination_damping"]) * stability_guard
         stability_modifier = 0.7 + 0.6 * signals["stability_index"]
+        stability_bias = 0.85 + 0.15 * stability_guard
         stimulus = (
             action_budget
             * signals["prosperity_share"]
             * signals["coordination_damping"]
             * signals["compute_boost"]
             * stability_modifier
+            * stability_bias
         )
         green_shift = (
             action_budget
@@ -900,12 +912,14 @@ class Orchestrator:
             * signals["coordination_damping"]
             * signals["compute_boost"]
             * stability_modifier
+            * stability_bias
         )
         alignment_investment = (
-            action_budget
+            alignment_budget
             * signals["coordination_gap"]
             * (0.6 + 0.4 * signals["welfare_urgency"])
             * (0.7 + 0.3 * signals["stability_index"])
+            * (1.0 + (1.0 - stability_guard))
         )
         normalized_action = self._normalize_simulation_action(
             {

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
@@ -166,6 +166,42 @@ def test_policy_action_invests_in_alignment_for_coordination_gap() -> None:
     assert low_action["alignment_investment"] >= high_action["alignment_investment"]
 
 
+def test_policy_action_escalates_alignment_when_entropy_high() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
+    low_entropy_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.55,
+        sustainability_index=0.45,
+        nash_welfare=0.45,
+        sentient_welfare_index=0.5,
+        free_energy=0.1,
+        entropy=0.1,
+        hamiltonian=-0.2,
+        coordination_index=0.5,
+        game_theory_slack=0.5,
+        stability_index=0.6,
+    )
+    high_entropy_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.55,
+        sustainability_index=0.45,
+        nash_welfare=0.45,
+        sentient_welfare_index=0.5,
+        free_energy=0.1,
+        entropy=0.9,
+        hamiltonian=-0.2,
+        coordination_index=0.5,
+        game_theory_slack=0.5,
+        stability_index=0.6,
+    )
+
+    low_action = orchestrator._build_policy_action(low_entropy_state)
+    high_action = orchestrator._build_policy_action(high_entropy_state)
+
+    assert high_action["alignment_investment"] >= low_action["alignment_investment"]
+    assert high_action["build_dyson_nodes"] <= low_action["build_dyson_nodes"]
+
+
 def test_select_best_claimant_prefers_skill_match_and_capacity() -> None:
     orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=False))
     job_spec = JobSpec(


### PR DESCRIPTION
### Motivation

- Improve the autonomous policy decision logic to avoid aggressive energy expansion under high entropy or poor coordination. 
- Introduce a stabilizing signal that blends thermodynamic (entropy/Gibbs) and game-theoretic (coordination/Hamiltonian) pressures. 
- Rebalance where action budget is allocated so alignment investments increase when disorder rises, while energy pushes are damped. 
- Add a focused test to ensure alignment investment escalates under high entropy.

### Description

- Add a `stability_guard` signal to the policy signal vector to capture entropy pressure, coordination gap and Hamiltonian pressure and clamp it to a safe range. 
- Introduce an `alignment_budget` derived from `action_budget` that is boosted by entropy pressure and used to compute `alignment_investment`. 
- Use `stability_guard` to damp the `energy_action` (build/expansion) and bias `stimulus`/`green_shift` allocations via a `stability_bias`. 
- Add test `test_policy_action_escalates_alignment_when_entropy_high` to `tests/test_simulation_actions.py` to assert alignment increases when entropy spikes and energy expansion is tempered.

### Testing

- Ran the modified unit tests for the demo policy file with `pytest -q demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py`, which passed (`8 passed`).
- The broader demo test runner had previously been executed and reported all demo suites green during investigation (local full-run observed success).
- The new test exercises both entropy-high and entropy-low `SimulationState` inputs and validates the expected policy behavior (alignment up, energy down).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ac997ab88333827a902018dbe09a)