### PR TITLE
Fix thermodynamic temperature baseline in omega-grade demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -79,7 +79,7 @@ class SyntheticEconomySim(PlanetarySimulation):
         )
         coordination_index = 1.0 - abs(self.prosperity_index - self.sustainability_index)
         coordination_index = min(1.0, max(0.0, coordination_index))
-        temperature = 1.0 + (1.0 - self.sustainability_index) + 0.5 * (1.0 - order_parameter)
+        temperature = 1.0 + (1.0 - self.sustainability_index)
         pressure = 1.0 + 0.5 * (1.0 - self.prosperity_index) + 0.5 * (1.0 - self.sustainability_index)
         volume = 1.0 + coordination_index
         internal_energy = self.energy_output_gw / 1_000_000.0


### PR DESCRIPTION
### Motivation
- The synthetic economy thermodynamic metrics must match the documented baseline used by the demo tests to avoid metric drift and failing assertions.
- A failing test revealed the temperature baseline included an extra dependence on the order parameter that diverged from expected formulas.

### Description
- Adjusted the temperature calculation inside `_compute_thermodynamic_metrics` in `demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py` to remove the `0.5 * (1.0 - order_parameter)` term and restore the intended baseline `1.0 + (1.0 - self.sustainability_index)`.
- No other metrics or downstream outputs were changed; `free_energy` and `gibbs_free_energy` are now computed using the corrected `temperature` value.

### Testing
- Ran `pytest demo/'Kardashev-II Omega-Grade-α-AGI Business-3'/tests/test_simulation_metrics.py` which passed (`1 passed`).
- The change addresses the previously observed failure in the Kardashev-II demo test suite where `free_energy` did not match the expected calculation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952cb3076748333a5e4124664ce9d1a)