### PR TITLE
Add thermodynamic insight payloads for omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -382,13 +382,63 @@ class Orchestrator:
     async def _insight_loop(self) -> None:
         while self._running:
             await self._paused.wait()
-            await self.bus.publish(
-                "insights",
-                {"idea": f"Dyson-swarm expansion cycle {self._cycle}"},
-                "orchestrator",
-            )
+            await self.bus.publish("insights", self._build_insight_payload(), "orchestrator")
             await self._persist_status_snapshot()
             await asyncio.sleep(self.config.insight_interval_seconds)
+
+    def _build_insight_payload(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "idea": f"Dyson-swarm expansion cycle {self._cycle}",
+            "cycle": self._cycle,
+        }
+        if self._latest_simulation_state is None:
+            return payload
+        state = self._latest_simulation_state
+        signals = self._compute_policy_signals(state)
+        decision = self._build_policy_decision(state)
+        if signals["gibbs_drive"] > 0.35 and signals["stability_guard"] > 0.6:
+            strategy_priority = "energy_expansion"
+            strategy_path = (
+                "Exploit the Gibbs deficit with guarded Dyson-node expansion while preserving "
+                "stability buffers."
+            )
+        elif signals["coordination_gap"] > 0.35 or signals["entropy_pressure"] > 0.5:
+            strategy_priority = "coordination_stability"
+            strategy_path = (
+                "Reduce entropy through alignment and green shift investments before accelerating "
+                "growth."
+            )
+        else:
+            strategy_priority = "balanced_growth"
+            strategy_path = "Blend stimulus, green shift, and alignment investment to maintain equilibrium."
+        payload.update(
+            {
+                "strategy_priority": strategy_priority,
+                "strategy_path": strategy_path,
+                "policy_recommendation": decision["action"],
+                "thermodynamics": {
+                    "gibbs_free_energy": state.gibbs_free_energy,
+                    "hamiltonian": state.hamiltonian,
+                    "entropy": state.entropy,
+                    "temperature": state.temperature,
+                    "enthalpy": state.enthalpy,
+                    "pressure": state.pressure,
+                },
+                "game_theory": {
+                    "nash_welfare": state.nash_welfare,
+                    "sentient_welfare_index": state.sentient_welfare_index,
+                    "game_theory_slack": state.game_theory_slack,
+                    "coordination_index": state.coordination_index,
+                },
+                "policy_signals": {
+                    "gibbs_drive": signals["gibbs_drive"],
+                    "hamiltonian_pressure": signals["hamiltonian_pressure"],
+                    "entropy_pressure": signals["entropy_pressure"],
+                    "stability_guard": signals["stability_guard"],
+                },
+            }
+        )
+        return payload
 
     def _apply_simulation_state(self, state: SimulationState, *, event: str) -> None:
         self._latest_simulation_state = state

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
@@ -72,3 +72,39 @@ def test_policy_signals_use_gibbs_deficit(tmp_path: Path) -> None:
     signals = orchestrator._compute_policy_signals(state)
 
     assert signals["gibbs_drive"] == pytest.approx(0.5)
+
+
+def test_insight_payload_surfaces_thermodynamic_strategy(tmp_path: Path) -> None:
+    orchestrator = Orchestrator(
+        OrchestratorConfig(
+            control_channel_file=tmp_path / "control.jsonl",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            status_output_path=None,
+            audit_log_path=None,
+            energy_oracle_path=None,
+        )
+    )
+    orchestrator._latest_simulation_state = SimulationState(
+        energy_output_gw=850_000.0,
+        prosperity_index=0.74,
+        sustainability_index=0.62,
+        free_energy=-0.2,
+        gibbs_free_energy=-0.8,
+        entropy=0.35,
+        hamiltonian=-0.1,
+        stability_index=0.82,
+        coordination_index=0.9,
+        nash_welfare=0.68,
+        sentient_welfare_index=0.66,
+        game_theory_slack=0.74,
+        temperature=1.4,
+        enthalpy=2.2,
+        pressure=1.1,
+    )
+
+    payload = orchestrator._build_insight_payload()
+
+    assert payload["strategy_priority"] == "energy_expansion"
+    assert "policy_recommendation" in payload
+    assert payload["thermodynamics"]["gibbs_free_energy"] == pytest.approx(-0.8)
+    assert payload["game_theory"]["game_theory_slack"] == pytest.approx(0.74)


### PR DESCRIPTION
### Motivation
- Enrich insight broadcasts with thermodynamic and game-theory context so autonomous policy actions are more explainable and operationally useful.
- Surface a simple, testable strategy recommendation (e.g. energy expansion vs coordination/stability vs balanced growth) driven by simulation metrics such as Gibbs free energy, Hamiltonian and entropy.
- Improve observability and operator guidance by including the policy recommendation and the signals that led to it in a single payload.

### Description
- Replace the previous ad-hoc insight publish with a new helper `Orchestrator._build_insight_payload` that composes a rich insight containing `policy_recommendation`, `thermodynamics`, `game_theory` and `policy_signals` and publish it from the insight loop.
- Use existing `self._compute_policy_signals` and `self._build_policy_decision` outputs to derive `strategy_priority` and `strategy_path` (choices: `energy_expansion`, `coordination_stability`, `balanced_growth`).
- Include explicit thermodynamic fields (`gibbs_free_energy`, `hamiltonian`, `entropy`, `temperature`, `enthalpy`, `pressure`) and game-theory fields (`nash_welfare`, `sentient_welfare_index`, `game_theory_slack`, `coordination_index`) in the payload.
- Add unit test `test_insight_payload_surfaces_thermodynamic_strategy` to validate payload composition and strategy selection.

### Testing
- Ran the unit test for the modified module with `pytest demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py -q`, which succeeded (`3 passed`).
- The new test verifies `Orchestrator._build_insight_payload` produces the expected `strategy_priority`, includes a `policy_recommendation`, and surfaces thermodynamic and game-theory values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d363180c8333880db0192bde0e63)