### PR TITLE
Skip Prisma generation when dependencies are missing

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -498,6 +498,14 @@ def _ensure_prisma_client(
     if _has_prisma_client(package_root):
         return True
 
+    node_modules = package_root / "node_modules"
+    if not node_modules.exists():
+        print(
+            "→ Skipping Prisma-dependent suite because node_modules is missing; "
+            f"run `npm install` in {package_root} to install dependencies."
+        )
+        return False
+
     print(f"→ Generating Prisma client for {package_root} (missing artifacts)")
     env = os.environ.copy()
     env.setdefault("CI", "1")


### PR DESCRIPTION
### Motivation
- `_ensure_prisma_client` attempted to run `npx prisma generate` even when a package's dependencies were not installed, which could hang or fail in CI and development environments.
- Running `npx` without `node_modules` can trigger large network downloads or long timeouts that block the demo test runner.
- Provide a clear, fast-fail behavior with actionable guidance instead of attempting generation in an environment that cannot succeed.

### Description
- Added a guard in `demo/run_demo_tests.py` inside `_ensure_prisma_client` to check for the presence of `node_modules` and return `False` if it is missing.
- When `node_modules` is absent the runner now prints a clear skip message instructing to run `npm install` in the package directory.
- Existing checks for `npx` availability, timeouts, and generation failure handling remain unchanged.

### Testing
- Ran the demo test orchestrator with `python demo/run_demo_tests.py` and observed successful completion of all demo test suites.
- The run reported: "All demo test suites passed (40 suites)" and completed without blocking on Prisma generation.
- The targeted demo unit tests for the modified runner also executed and passed during the run.
- No automated tests failed as a result of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952db8bd2e0833399deaedef334b98b)