### PR TITLE
Enhance Kardashev-II orchestrator: offline dashboard, action-path report, and demo entrypoint

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-action-path.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-action-path.md
@@ -1,44 +1,58 @@
 # Kardashev II Action Path
 
-Generated: 2025-12-29T14:44:03.735Z
+Generated: 2025-03-01T00:00:00Z
 
 ## Core equilibrium signals
-- Free energy margin: 67.33%
-- Free energy runway: 1.08 hours (gap 0.00h, 0.00 GWh)
-- Buffered free energy: 1172423.81 GW usable · gross runway 2.15h
-- Gibbs free energy: 4,220,725,703.75 GJ
-- Hamiltonian stability: 83.7%
-- Nash product: 10.0%
-- Coalition stability: 100.0%
-- Free energy per agent: 0.942126 GJ
-- Welfare potential: 95.1%
+- Free energy margin: -0.89%
+- Free energy runway: 0.00 hours (gap 1.00h, 1,093,911.26 GWh)
+- Buffered free energy: -10,199.14 GW above buffer (143,750.00 GW required)
+- Gibbs free energy: 0.00 GJ
+- Hamiltonian stability: 0.0%
+- Nash product: 85.6%
+- Coalition stability: 90.0%
+- Free energy per agent: 0.000000 GJ
+- Welfare potential: 67.9%
 
 ## Action path
-### Step 1: Capacity spillover capture
+### Step 1: Stabilize free energy buffer
 - Status: needs-action
-- Target: Unallocated headroom ≤ 1% of available energy.
-- Priority: 66.1%
-- Rationale: Unallocated 2280046.40 GW · capacity constraints 3
-- Action: Expand shard energy feeds or rebalance weights so free energy is absorbed without breaching per-shard capacity limits.
+- Target: Free energy margin ≥ 70%, runway ≥ 1h, and Hamiltonian stability ≥ 90%.
+- Priority: 100.0%
+- Rationale: Free energy -0.9% · Hamiltonian 0.0% · runway 0.00h
+- Action: Increase reserve buffers or smooth demand variance to restore Hamiltonian stability. Add ~1093911.26 GWh (3938080526 GJ) to hit the 1h runway.
 
-### Step 2: Mission Hamiltonian load-balance
+### Step 2: Stabilize mission Hamiltonian
 - Status: needs-action
-- Target: Mission Hamiltonian stability ≥ 90% with ≥ 5% free energy headroom.
-- Priority: 30.8%
-- Rationale: Mission stability 56.0% · headroom 95.1%
-- Action: Shift energy-intensive programmes, stretch critical-path timelines, and lower risk exposure until mission stability clears target.
+- Target: Mission Hamiltonian stability ≥ 90% and headroom ≥ 5%.
+- Priority: 57.3%
+- Rationale: Stability 61.0% · headroom 0.0%
+- Action: Rebalance mission timelines and energy buffers to regain Hamiltonian stability.
 
-### Step 3: Logistics entropy smoothing
+### Step 3: Reinforce sentient welfare balance
 - Status: needs-action
-- Target: Utilisation band 65–85% with entropy ratio ≥ 0.90.
-- Priority: 15.5%
-- Rationale: Utilisation 82.0% · entropy 0.68
-- Action: Shift corridor quotas toward the 0.75 equilibrium band to maximize logistics entropy and game-theory slack.
+- Target: Coalition stability ≥ 85% and inequality ≤ 30%.
+- Priority: 28.5%
+- Rationale: Coalition 90.0% · inequality 5.3%
+- Action: Boost cooperative rewards and reallocate buffers to reduce inequality.
 
-### Step 4: Thermodynamic headroom reset
-- Status: needs-action
-- Target: Free energy margin ≥ 8%, runway ≥ 1h, and Hamiltonian stability ≥ 90%.
-- Priority: 11.3%
-- Rationale: Gibbs free energy 4220725703.7 GJ · Hamiltonian 83.7% · runway 1.08h
-- Action: Increase Dyson reserve buffers, dampen demand variance, and re-run the Monte Carlo sweep until breach probability clears tolerance.
+### Step 4: Tighten Nash allocation
+- Status: on-track
+- Target: Deviation incentive ≤ 20% and strategy stability ≥ 85%.
+- Priority: 6.9%
+- Rationale: Deviation 12.1% · strategy 87.9%
+- Action: Keep incentive gradients aligned with Nash stability targets.
+
+### Step 5: Restore logistics game-theory slack
+- Status: on-track
+- Target: Game-theory slack ≥ 85% and entropy ratio ≥ 0.9.
+- Priority: 1.0%
+- Rationale: Slack 99.3% · entropy 1.00
+- Action: Maintain corridor utilisation within the equilibrium band.
+
+### Step 6: Secure compute quorum failover
+- Status: on-track
+- Target: Failover within quorum and availability ≥ 95%.
+- Priority: 0.7%
+- Rationale: Availability 98.2% · failover ok
+- Action: Sustain quorum failover coverage and monitor deviation drift.
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/run-kardashev-demo.ts
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/run-kardashev-demo.ts
@@ -1749,6 +1749,45 @@ function ensureOutputDir() {
   }
 }
 
+function formatPercent(value: number | undefined, digits = 1): string {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  return `${((value ?? 0) * 100).toFixed(digits)}%`;
+}
+
+function formatNumber(value: number | undefined, digits = 2): string {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  return (value ?? 0).toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+function writeOfflineDashboard() {
+  const uiSourceDir = join(DEMO_ROOT, "ui");
+  const uiTargetDir = join(OUTPUT_DIR, "ui");
+  if (!existsSync(uiTargetDir)) {
+    mkdirSync(uiTargetDir, { recursive: true });
+  }
+
+  const uiFiles = ["style.css", "dashboard.js"];
+  for (const filename of uiFiles) {
+    const sourcePath = join(uiSourceDir, filename);
+    const targetPath = join(uiTargetDir, filename);
+    const content = readFileSync(sourcePath, "utf8");
+    writeFileSync(targetPath, content);
+  }
+
+  const indexTemplate = readFileSync(join(DEMO_ROOT, "index.html"), "utf8");
+  const offlineIndex = indexTemplate
+    .replace('window.__KARDASHEV_ASSET_BASE__ = "./output";', 'window.__KARDASHEV_ASSET_BASE__ = ".";')
+    .replace(/src="\.\/output\//g, 'src="./');
+  writeFileSync(join(OUTPUT_DIR, "index.html"), offlineIndex);
+}
+
 function slugToId(slug: string): string {
   return keccak256(toUtf8Bytes(slug));
 }
@@ -5220,6 +5259,56 @@ function buildEquilibriumLedger(manifest: Manifest, telemetry: Telemetry) {
   };
 }
 
+type EquilibriumLedger = ReturnType<typeof buildEquilibriumLedger>;
+
+function renderActionPathReport(telemetry: Telemetry, equilibriumLedger: EquilibriumLedger): string {
+  const thermodynamics = equilibriumLedger.thermodynamics;
+  const gameTheory = equilibriumLedger.gameTheory;
+  const welfare = telemetry.sentientWelfare;
+  const monteCarlo = telemetry.energy.monteCarlo;
+  const actionPath = equilibriumLedger.actionPath ?? [];
+  const generatedAt = equilibriumLedger.generatedAt ?? new Date().toISOString();
+
+  const lines = ["# Kardashev II Action Path", "", `Generated: ${generatedAt}`, "", "## Core equilibrium signals"];
+  lines.push(`- Free energy margin: ${formatPercent(thermodynamics.freeEnergyMarginPct, 2)}`);
+  lines.push(
+    `- Free energy runway: ${formatNumber(thermodynamics.runwayHours, 2)} hours (gap ${formatNumber(
+      thermodynamics.runwayGapHours,
+      2
+    )}h, ${formatNumber(thermodynamics.runwayGapGwh, 2)} GWh)`
+  );
+  lines.push(
+    `- Buffered free energy: ${formatNumber(monteCarlo.freeEnergyMarginGw, 2)} GW above buffer (${formatNumber(
+      monteCarlo.marginGw,
+      2
+    )} GW required)`
+  );
+  lines.push(`- Gibbs free energy: ${formatNumber(thermodynamics.gibbsFreeEnergyGj, 2)} GJ`);
+  lines.push(`- Hamiltonian stability: ${formatPercent(thermodynamics.hamiltonianStability, 1)}`);
+  lines.push(`- Nash product: ${formatPercent(gameTheory.nashProduct, 1)}`);
+  lines.push(`- Coalition stability: ${formatPercent(gameTheory.coalitionStability, 1)}`);
+  lines.push(`- Free energy per agent: ${formatNumber(welfare.freeEnergyPerAgentGj, 6)} GJ`);
+  lines.push(`- Welfare potential: ${formatPercent(welfare.welfarePotential, 1)}`);
+  lines.push("");
+  lines.push("## Action path");
+
+  if (actionPath.length === 0) {
+    lines.push("No immediate corrective steps required. Maintain equilibrium cadence.");
+  } else {
+    actionPath.forEach((step) => {
+      lines.push(`### Step ${step.rank}: ${step.title}`);
+      lines.push(`- Status: ${step.status}`);
+      lines.push(`- Target: ${step.target}`);
+      lines.push(`- Priority: ${formatPercent(step.priorityScore, 1)}`);
+      lines.push(`- Rationale: ${step.rationale}`);
+      lines.push(`- Action: ${step.action}`);
+      lines.push("");
+    });
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
 function buildSafeBatch(manifest: Manifest, transactions: SafeTransaction[]) {
   const parsedCreatedAt =
     typeof manifest.generatedAt === "number" ? manifest.generatedAt : Date.parse(manifest.generatedAt);
@@ -5309,6 +5398,7 @@ function run() {
   const dysonTimeline = buildDysonTimeline(manifest);
   const runbook = buildRunbook(manifest, telemetryWithScenarios, dominanceScore, scenarioSweep);
   const operatorBriefing = buildOperatorBriefing(manifest, telemetryWithScenarios, equilibriumLedger);
+  const actionPathReport = renderActionPathReport(telemetryWithScenarios, equilibriumLedger);
 
   const telemetryJson = `${JSON.stringify(telemetryWithScenarios, null, 2)}\n`;
   const safeJson = `${JSON.stringify(safeBatch, null, 2)}\n`;
@@ -5377,6 +5467,7 @@ function run() {
     { suffix: "logistics-ledger.json", content: logisticsJson },
     { suffix: "mermaid.mmd", content: `${mermaid}\n` },
     { suffix: "orchestration-report.md", content: `${runbook}\n` },
+    { suffix: "action-path.md", content: actionPathReport },
     { suffix: "dyson.mmd", content: `${dysonTimeline}\n` },
     { suffix: "task-hierarchy.mmd", content: `${missionTelemetry.mermaid}\n` },
     { suffix: "operator-briefing.md", content: `${operatorBriefing}\n` },
@@ -5405,6 +5496,8 @@ function run() {
     console.log("✔ Kardashev-II artefacts are up-to-date.");
     return;
   }
+
+  writeOfflineDashboard();
 
   console.log("✔ Kardashev-II orchestration artefacts generated.");
   console.log(`   Dominance score: ${dominanceScore.toFixed(1)} / 100.`);

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "demo:aurora:report": "ts-node --transpile-only demo/aurora/bin/aurora-report.ts",
     "demo:aurora:sepolia": "npx hardhat run demo/aurora/aurora.demo.ts --network sepolia",
     "demo:flagship": "demo/cosmic-omni-sovereign-symphony/bin/flagship-demo.sh",
-    "demo:kardashev": "node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs",
+    "demo:kardashev": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/run-kardashev-demo.ts",
     "demo:kardashev-ii:serve": "node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/serve-dashboard.cjs",
     "demo:kardashev-ii-lattice:ci": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/stellar-civilization-lattice/scripts/ci-validate.ts",
     "demo:kardashev-ii-lattice:orchestrate": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/stellar-civilization-lattice/scripts/orchestrate.ts",


### PR DESCRIPTION
### Motivation
- Ensure the Kardashev-II demo produces consistent, inspectable artefacts for offline dashboards and operator workflows. 
- Surface an actionable equilibrium `action-path` report that distils thermodynamic and game-theoretic signals into prioritized steps. 
- Make the `demo:kardashev` entrypoint route through the TypeScript orchestrator for parity with CI and developer flows. 
- Reduce manual post-processing and fragile HTML fetch issues when serving from `file://` or packaged `output/` directories.

### Description
- Added utility formatters `formatPercent` and `formatNumber` and an offline dashboard writer `writeOfflineDashboard` to `scripts/run-kardashev-demo.ts` to emit `ui/` assets and an adjusted `index.html` inside `output/` for local serving. 
- Implemented `renderActionPathReport` and an `EquilibriumLedger` alias to synthesise and write a readable `action-path.md` derived from the equilibrium ledger and telemetry. 
- Hooked the new `action-path.md` into the orchestrator outputs so it is generated alongside `telemetry`, `ledgers`, and diagrams. 
- Updated `package.json` so the `demo:kardashev` script runs the TypeScript orchestrator (`scripts/run-kardashev-demo.ts`) for consistent behaviour, and regenerated the `output/kardashev-action-path.md` artefact.

### Testing
- Ran the orchestrator end-to-end with `npm run demo:kardashev-ii:orchestrate` and observed: "✔ Kardashev-II orchestration artefacts generated." (success). 
- Verified check mode with `npm run demo:kardashev-ii:orchestrate -- --check` which returned: "✔ Kardashev-II artefacts are up-to-date." (success). 
- Executed the demo CI validator `npm run demo:kardashev-ii:ci` to confirm README and invariants (validation passed for the Kardashev tree). 
- Executed the demo test runner (`python demo/run_demo_tests.py` / selected `pytest` suites) which ran the Kardashev demo tests and related demo suites (core Kardashev tests passed; some external npm/hardhat suites were skipped or interrupted due to environment tooling).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e4f614508333a0cb46fe6ebb0550)