### PR TITLE
Enrich K2 Omega simulation with thermodynamic & game-theory metrics and expose them in status snapshots

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade/orchestrator.py
@@ -305,6 +305,7 @@ class Orchestrator:
             await self._propagate_completion(parent)
 
     async def _emit_status(self) -> None:
+        simulation_snapshot = self.simulation.get_state() if self.simulation else None
         snapshot = {
             "mission": self.config.mission_name,
             "resources": {
@@ -314,6 +315,7 @@ class Orchestrator:
             },
             "ledger": self.resource_manager.ledger.snapshot(),
             "jobs": [job.to_dict() for job in self.registry.jobs()],
+            "simulation": simulation_snapshot,
         }
         with self.status_output_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(snapshot) + "\n")
@@ -331,4 +333,3 @@ class Orchestrator:
             return
         result = self.simulation.apply_action(action)
         await self.bus.publish("simulation:events", {"action": action, "result": result})
-

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade/simulation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Dict
 
@@ -39,13 +40,65 @@ class SyntheticEconomySim(PlanetarySim):
         self.history.append(snapshot)
         return snapshot
 
-    def get_state(self) -> Dict[str, float]:
+    def _compute_metrics(self) -> Dict[str, float]:
+        energy_per_capita = self.energy_output / max(self.population, 1.0)
+        compute_per_capita = self.compute_output / max(self.population, 1.0)
+
+        prosperity_index = math.tanh(energy_per_capita * 1e3)
+        sustainability_index = math.tanh(compute_per_capita * 1e3)
+        innovation_boost = 0.85 + 0.15 * math.tanh(self.innovation_index / 3)
+        sustainability_boost = 0.8 + 0.2 * math.tanh(self.innovation_index / 2)
+        prosperity_index = min(1.0, max(0.0, prosperity_index * innovation_boost))
+        sustainability_index = min(1.0, max(0.0, sustainability_index * sustainability_boost))
+
+        order_parameter = (prosperity_index + sustainability_index) / 2.0
+        order_parameter = min(1.0 - 1e-6, max(1e-6, order_parameter))
+        entropy = -(
+            order_parameter * math.log(order_parameter)
+            + (1.0 - order_parameter) * math.log(1.0 - order_parameter)
+        )
+        coordination_index = 1.0 - abs(prosperity_index - sustainability_index)
+        coordination_index = min(1.0, max(0.0, coordination_index))
+        temperature = 1.0 + (1.0 - sustainability_index)
+        pressure = 1.0 + (1.0 - prosperity_index)
+        volume = 1.0 + coordination_index
+        internal_energy = (self.energy_output + self.compute_output) / 2_000_000.0
+        enthalpy = internal_energy + pressure * volume
+        free_energy = internal_energy - temperature * entropy
+        gibbs_free_energy = enthalpy - temperature * entropy
+        hamiltonian = -internal_energy * order_parameter * (1.0 + 0.1 * math.log1p(self.innovation_index))
+        stability_index = math.exp(-entropy) * (0.5 + 0.5 * coordination_index)
+        stability_index = min(1.0, max(0.0, stability_index))
+        nash_welfare = math.sqrt(max(1e-6, prosperity_index) * max(1e-6, sustainability_index))
+        welfare_floor = min(prosperity_index, sustainability_index)
+        sentient_welfare_index = 0.55 * nash_welfare + 0.45 * welfare_floor
+        game_theory_slack = min(1.0, nash_welfare * (0.6 + 0.4 * coordination_index))
         return {
+            "prosperity_index": prosperity_index,
+            "sustainability_index": sustainability_index,
+            "nash_welfare": nash_welfare,
+            "sentient_welfare_index": sentient_welfare_index,
+            "free_energy": free_energy,
+            "gibbs_free_energy": gibbs_free_energy,
+            "entropy": entropy,
+            "hamiltonian": hamiltonian,
+            "stability_index": stability_index,
+            "coordination_index": coordination_index,
+            "game_theory_slack": game_theory_slack,
+            "temperature": temperature,
+            "enthalpy": enthalpy,
+            "pressure": pressure,
+        }
+
+    def get_state(self) -> Dict[str, float]:
+        state = {
             "energy_output": self.energy_output,
             "compute_output": self.compute_output,
             "population": self.population,
             "innovation_index": self.innovation_index,
         }
+        state.update(self._compute_metrics())
+        return state
 
     @classmethod
     def from_config(cls, config: Dict[str, float]) -> "SyntheticEconomySim":
@@ -55,4 +108,3 @@ class SyntheticEconomySim(PlanetarySim):
             population=float(config.get("population", 1e9)),
             innovation_index=float(config.get("innovation_index", 1.0)),
         )
-

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade/tests/test_simulation_metrics.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade/tests/test_simulation_metrics.py
@@ -1,0 +1,61 @@
+import asyncio
+import json
+
+from kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
+from kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade.simulation import (
+    SyntheticEconomySim,
+)
+
+
+def test_simulation_metrics_are_populated() -> None:
+    sim = SyntheticEconomySim.from_config({})
+    state = sim.get_state()
+
+    expected_keys = {
+        "prosperity_index",
+        "sustainability_index",
+        "nash_welfare",
+        "sentient_welfare_index",
+        "free_energy",
+        "gibbs_free_energy",
+        "entropy",
+        "hamiltonian",
+        "stability_index",
+        "coordination_index",
+        "game_theory_slack",
+        "temperature",
+        "enthalpy",
+        "pressure",
+    }
+    assert expected_keys.issubset(state.keys())
+    assert 0.0 <= state["prosperity_index"] <= 1.0
+    assert 0.0 <= state["sustainability_index"] <= 1.0
+    assert 0.0 <= state["stability_index"] <= 1.0
+    assert state["entropy"] >= 0.0
+
+
+def test_emit_status_includes_simulation_snapshot(tmp_path) -> None:
+    config = OrchestratorConfig(
+        mission_name="omega-k2-test",
+        operator_account="operator",
+        base_agent_tokens=1e3,
+        energy_capacity=1e6,
+        compute_capacity=1e6,
+        validator_names=[],
+        worker_definitions=[],
+        checkpoint_dir=tmp_path / "checkpoints",
+        status_output_path=tmp_path / "status.jsonl",
+        governance_params={},
+        simulation_params={"type": "synthetic_economy"},
+    )
+    orchestrator = Orchestrator(config)
+    orchestrator._load_simulation()
+
+    asyncio.run(orchestrator._emit_status())
+
+    snapshot = json.loads(config.status_output_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert snapshot["simulation"] is not None
+    assert "gibbs_free_energy" in snapshot["simulation"]


### PR DESCRIPTION
### Motivation
- Improve the fidelity of the K2 Omega upgrade demo simulation by deriving thermodynamic and game-theory inspired metrics from basic simulation state.
- Surface those richer telemetry signals in the orchestrator status snapshots so operators and downstream tooling can observe emergent metrics.
- Provide deterministic, testable metrics (prosperity/sustainability, Gibbs/free energy, Hamiltonian, stability, coordination, Nash welfare, etc.) to enable higher-level policy and governance logic.
- Add tests to guard against regressions and validate the new telemetry plumbing.

### Description
- Implemented `_compute_metrics` and integrated it into `get_state` in `demo/.../kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade/simulation.py` to compute and return metrics such as `prosperity_index`, `sustainability_index`, `nash_welfare`, `sentient_welfare_index`, `free_energy`, `gibbs_free_energy`, `entropy`, `hamiltonian`, `stability_index`, `coordination_index`, `game_theory_slack`, `temperature`, `enthalpy`, and `pressure`.
- Updated the orchestrator in `demo/.../kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade/orchestrator.py` so `_emit_status` includes the simulation snapshot under the `"simulation"` key in the JSONL status output.
- Added unit tests at `demo/.../kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade/tests/test_simulation_metrics.py` covering that simulation metrics are populated and that `_emit_status` writes a snapshot including `gibbs_free_energy`.
- Minor imports and formatting updates (added `import math`) as required by the new metric computations.

### Testing
- Ran the targeted test suite with `pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_k2_omega_upgrade/tests"` and observed `2 passed`.
- The newly added tests validate both the presence and sensible bounds of the computed metrics and that the orchestrator status output contains the simulation telemetry.
- Existing demo test harness was exercised earlier in the session and reported green across suites; the change was implemented to be backwards compatible with existing orchestration flows.
- No automated tests failed during the local test runs performed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953173270808333b49579943de918f8)