### PR TITLE
Enhance sentient welfare telemetry details in Kardashev II dashboard

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -402,8 +402,16 @@ function renderSentientWelfare(welfare) {
   const actionText = Number.isFinite(welfare.collectiveActionPotential)
     ? `${(welfare.collectiveActionPotential * 100).toFixed(1)}%`
     : "n/a";
+  const payoffText = Number.isFinite(welfare.payoffCoefficient)
+    ? `${(welfare.payoffCoefficient * 100).toFixed(1)}%`
+    : "n/a";
+  const riskIndex =
+    Number.isFinite(welfare.inequalityIndex) && Number.isFinite(welfare.coalitionStability)
+      ? Math.min(1, Math.max(0, 0.6 * welfare.inequalityIndex + 0.4 * (1 - welfare.coalitionStability)))
+      : null;
+  const riskText = riskIndex !== null ? `${(riskIndex * 100).toFixed(1)}%` : "n/a";
 
-  details.textContent = `Cooperation ${cooperationText} · inequality ${inequalityText} · Pareto slack ${paretoText} · welfare potential ${potentialText} · coalition stability ${coalitionText} · collective action ${actionText}`;
+  details.textContent = `Cooperation ${cooperationText} · inequality ${inequalityText} · Pareto slack ${paretoText} · welfare potential ${potentialText} · coalition stability ${coalitionText} · collective action ${actionText} · payoff dispersion ${payoffText} · welfare risk ${riskText}`;
 
   if (Number.isFinite(welfare.equilibriumScore)) {
     const score = welfare.equilibriumScore;


### PR DESCRIPTION
### Motivation
- Improve clarity of the Kardashev II demo UI by surfacing additional game‑theory and thermodynamics signals related to sentient welfare. 
- Make payoff dispersion and a compact welfare risk indicator visible to non‑technical stewards to aid rapid decision making. 
- Preserve existing equilibrium status semantics while enriching the dashboard readout for better interpretation. 
- Target the most relevant UX gap in the demo to make the path from telemetry → action simpler.

### Description
- Augment `renderSentientWelfare` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js` to display `payoffCoefficient` as "payoff dispersion". 
- Compute a derived `welfare risk` index from `inequalityIndex` and `coalitionStability` and append it to the sentient welfare detail line. 
- Keep the existing equilibrium status logic and thresholds intact so behaviour and badges remain unchanged. 
- Commit: updated `ui/dashboard.js` to include the new fields and formatted detail string.

### Testing
- Ran the demo-specific test suite with `python -m pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py`, all tests passed (9 passed). 
- Executed the full demo test runner via `python demo/run_demo_tests.py` and the overall demo suites completed successfully (all demo test suites passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69533717b1348333ade93f2ac1b68fdb)