### PR TITLE
Add policy brief insights to omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -416,6 +416,7 @@ class Orchestrator:
                 "strategy_priority": strategy_priority,
                 "strategy_path": strategy_path,
                 "policy_recommendation": decision["action"],
+                "policy_brief": self._build_policy_brief(state, decision, signals),
                 "thermodynamics": {
                     "gibbs_free_energy": state.gibbs_free_energy,
                     "hamiltonian": state.hamiltonian,
@@ -931,6 +932,53 @@ class Orchestrator:
             for key, value in raw_action.items():
                 rationale[f"{key}_raw"] = value
         return rationale
+
+    def _format_policy_steps(self, action: Dict[str, float]) -> list[str]:
+        steps: list[str] = []
+        ordered_actions = (
+            ("build_dyson_nodes", "Deploy Dyson nodes"),
+            ("stimulus", "Launch prosperity stimulus"),
+            ("green_shift", "Accelerate green transition"),
+            ("alignment_investment", "Invest in alignment"),
+        )
+        for key, label in ordered_actions:
+            value = float(action.get(key, 0.0))
+            if value <= 0:
+                continue
+            steps.append(f"{label}: {value:.2f}")
+        if not steps:
+            steps.append("Hold steady; no material policy action recommended this cycle.")
+        return steps
+
+    def _build_policy_brief(
+        self,
+        state: SimulationState,
+        decision: Dict[str, Dict[str, float] | Dict[str, float | str]],
+        signals: Dict[str, float],
+    ) -> Dict[str, Any]:
+        action = decision["action"]
+        if not isinstance(action, dict):
+            action = {}
+        gibbs_reference = state.gibbs_free_energy if state.gibbs_free_energy is not None else state.free_energy
+        focus = "energy_expansion" if signals["gibbs_drive"] > 0.35 else "stability_balancing"
+        return {
+            "focus": focus,
+            "next_steps": self._format_policy_steps(action),
+            "action": action,
+            "energy_dynamics": {
+                "gibbs_reference": gibbs_reference,
+                "gibbs_drive": signals["gibbs_drive"],
+                "hamiltonian_pressure": signals["hamiltonian_pressure"],
+                "entropy_pressure": signals["entropy_pressure"],
+                "stability_guard": signals["stability_guard"],
+            },
+            "game_theory_snapshot": {
+                "nash_welfare": state.nash_welfare,
+                "sentient_welfare_index": state.sentient_welfare_index,
+                "coordination_index": state.coordination_index,
+                "game_theory_slack": state.game_theory_slack,
+            },
+        }
 
     def _build_policy_decision(self, state: SimulationState) -> Dict[str, Dict[str, float] | Dict[str, float | str]]:
         """Derive a cooperative policy action from thermodynamic signals.

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_policy_brief.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_policy_brief.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.simulation import SimulationState
+
+
+def test_insight_payload_includes_policy_brief() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=False))
+    state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.55,
+        sustainability_index=0.45,
+        nash_welfare=0.45,
+        sentient_welfare_index=0.5,
+        free_energy=0.2,
+        gibbs_free_energy=-0.3,
+        entropy=0.2,
+        hamiltonian=-0.2,
+        coordination_index=0.5,
+        game_theory_slack=0.5,
+        stability_index=0.6,
+    )
+    orchestrator._latest_simulation_state = state
+
+    payload = orchestrator._build_insight_payload()
+
+    brief = payload["policy_brief"]
+    assert isinstance(brief["next_steps"], list)
+    assert brief["next_steps"]
+    assert brief["energy_dynamics"]["gibbs_reference"] == state.gibbs_free_energy
+    assert brief["game_theory_snapshot"]["nash_welfare"] == state.nash_welfare


### PR DESCRIPTION
### Motivation
- Provide a concise, actionable policy brief in the orchestrator insight payload so operators and automated systems can see next steps derived from simulation signals.
- Surface thermodynamic and game-theory derived signals (Gibbs free energy, Hamiltonian pressure, entropy, Nash welfare) in a structured form to improve interpretability.
- Keep policy rationale and raw decision data while adding human-friendly step guidance for the Omega-grade orchestrator.

### Description
- Added `_format_policy_steps` to convert normalized action vectors into readable step strings with labels like `Deploy Dyson nodes` and `Invest in alignment`.
- Added `_build_policy_brief` which packages `action`, `next_steps`, `energy_dynamics`, and `game_theory_snapshot` into a JSON-serialisable brief using `SimulationState` and computed `signals`.
- Integrated the brief into the insight payload by adding `policy_brief` next to the existing `policy_recommendation` in `_build_insight_payload`.
- Added test `demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_policy_brief.py` that asserts the brief is emitted and contains expected fields.

### Testing
- Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests` and the suite passed with all tests green (`18 passed` in ~0.48s).
- The change was limited to the Omega demo package and covered by the new unit test `test_insight_payload_includes_policy_brief`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953404eb6f08333981bc825435c3d22)