### PR TITLE
Scale omega demo treasury for initial allocations

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -82,11 +82,13 @@ class Orchestrator:
         if config.audit_log_path:
             self.audit = AuditTrail(config.audit_log_path)
             self.bus.register_listener(self.audit.record_message)
+        operator_treasury = self._operator_treasury_tokens(config)
         self.resources = ResourceManager(
             energy_capacity=config.energy_capacity,
             compute_capacity=config.compute_capacity,
-            base_token_supply=config.base_agent_tokens * 10,
+            base_token_supply=operator_treasury,
         )
+        self._operator_treasury = operator_treasury
         self.job_registry = JobRegistry()
         self.scheduler = EventScheduler(self._dispatch_scheduled_event)
         self.checkpoint = CheckpointManager(config.checkpoint_path)
@@ -130,6 +132,14 @@ class Orchestrator:
         self._claim_tasks: Dict[str, asyncio.Task[None]] = {}
         self._claim_lock = asyncio.Lock()
 
+    @staticmethod
+    def _operator_treasury_tokens(config: OrchestratorConfig) -> float:
+        reserve = config.base_agent_tokens * 10
+        worker_tokens = config.base_agent_tokens * len(config.worker_specs)
+        validator_tokens = config.base_agent_tokens * 0.5 * len(config.validator_names)
+        strategist_tokens = config.base_agent_tokens * len(config.strategist_names)
+        return reserve + worker_tokens + validator_tokens + strategist_tokens
+
     def _log(self, level: int, event: str, **fields: object) -> None:
         self.log.log(level, event, extra={"event": event, **fields})
 
@@ -168,7 +178,7 @@ class Orchestrator:
             self._tasks.append(asyncio.create_task(self._energy_oracle_loop(), name="energy-oracle"))
 
     async def _bootstrap_state(self) -> None:
-        self.resources.ensure_account(self.config.operator_account, self.config.base_agent_tokens * 10)
+        self.resources.ensure_account(self.config.operator_account, self._operator_treasury)
         self._control_path = self.config.control_channel_file
         self._control_path.parent.mkdir(parents=True, exist_ok=True)
         self._control_path.touch(exist_ok=True)

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_resources.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_resources.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
 from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.resources import ResourceManager
 
 
@@ -83,3 +89,29 @@ def test_restore_state_clears_accounts_and_ledger_when_absent() -> None:
     assert manager.reserved_compute == 0
     assert manager.energy_available == 1_500
     assert manager.compute_available == 2_500
+
+
+def test_orchestrator_bootstrap_balances_token_supply(tmp_path) -> None:
+    config = OrchestratorConfig(
+        control_channel_file=tmp_path / "control.jsonl",
+        checkpoint_path=tmp_path / "checkpoint.json",
+        resume_from_checkpoint=False,
+    )
+    orchestrator = Orchestrator(config)
+
+    asyncio.run(orchestrator._bootstrap_state())
+
+    snapshot = orchestrator.resources.to_serializable()
+    accounts = snapshot["accounts"]
+    total_tokens = sum(
+        float(payload.get("tokens", 0.0)) + float(payload.get("locked", 0.0))
+        for payload in accounts.values()
+    )
+    circulating = orchestrator.resources.token_supply + orchestrator.resources.locked_supply
+    assert total_tokens == pytest.approx(circulating)
+    for worker in config.worker_specs:
+        assert accounts[worker]["tokens"] == pytest.approx(config.base_agent_tokens)
+    for validator in config.validator_names:
+        assert accounts[validator]["tokens"] == pytest.approx(config.base_agent_tokens / 2.0)
+    for strategist in config.strategist_names:
+        assert accounts[strategist]["tokens"] == pytest.approx(config.base_agent_tokens)


### PR DESCRIPTION
### Motivation

- Ensure the Omega-grade demo seeds operator and agent accounts with a treasury large enough to cover configured initial allocations so the ledger remains balanced as agent counts scale.
- Prevent underfunding when initial agent counts or per-agent base tokens increase by making the operator treasury derived from configuration rather than a fixed constant.

### Description

- Compute an operator treasury from `OrchestratorConfig` (workers, validators, strategists and reserve) in `_operator_treasury_tokens` and store it on the orchestrator. 
- Use the computed treasury as the `ResourceManager` `base_token_supply` and seed the operator account with `_operator_treasury` during `_bootstrap_state`.
- Add a unit test `test_orchestrator_bootstrap_balances_token_supply` to verify initial allocations and circulating supply balance after bootstrap, and tidy test imports/fixtures.

### Testing

- Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_resources.py` and observed all tests pass (`5 passed`).
- The new test asserts per-agent initial token balances for workers, validators, and strategists and checks circulating supply equals summed account balances.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d3e8b73c8333b0a20a27a24daab7)