### PR TITLE
Improve offline Mermaid fallback for Kardashev II demo dashboard

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -2410,16 +2410,38 @@ function ensureDir(dirPath) {
 
 function copyMermaidBundle(outputDir) {
   const targetDir = path.join(outputDir, 'mermaid');
-  const targetPath = path.join(targetDir, 'mermaid.esm.min.mjs');
-  try {
-    const sourcePath = require.resolve('mermaid/dist/mermaid.esm.min.mjs');
-    ensureDir(targetDir);
-    fs.copyFileSync(sourcePath, targetPath);
-  } catch (error) {
+  const bundleTargets = [
+    {
+      label: 'ESM',
+      source: 'mermaid/dist/mermaid.esm.min.mjs',
+      target: 'mermaid.esm.min.mjs',
+    },
+    {
+      label: 'UMD',
+      source: 'mermaid/dist/mermaid.min.js',
+      target: 'mermaid.min.js',
+    },
+  ];
+  const failures = [];
+  let copiedAny = false;
+  for (const bundle of bundleTargets) {
+    try {
+      const sourcePath = require.resolve(bundle.source);
+      ensureDir(targetDir);
+      fs.copyFileSync(sourcePath, path.join(targetDir, bundle.target));
+      copiedAny = true;
+    } catch (error) {
+      failures.push(`${bundle.label}: ${error?.message ?? error}`);
+    }
+  }
+
+  if (!copiedAny) {
     console.warn(
       '⚠️ Mermaid bundle unavailable. Diagrams will fall back to source rendering only.',
-      error?.message ?? error
+      failures.join(' | ')
     );
+  } else if (failures.length > 0) {
+    console.warn('⚠️ Mermaid bundle partially unavailable.', failures.join(' | '));
   }
 }
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -32,6 +32,35 @@ function assetPath(filename) {
   return `${base}/${filename}`;
 }
 
+function loadMermaidScript(url) {
+  if (!url) {
+    return Promise.resolve(null);
+  }
+  if (window.mermaid) {
+    return Promise.resolve(window.mermaid);
+  }
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[data-mermaid-src="${url}"]`);
+    if (existing) {
+      existing.addEventListener("load", () => resolve(window.mermaid || null), { once: true });
+      existing.addEventListener(
+        "error",
+        () => reject(new Error(`Failed to load mermaid script from ${url}`)),
+        { once: true }
+      );
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = url;
+    script.async = true;
+    script.dataset.mermaidSrc = url;
+    script.onload = () => resolve(window.mermaid || null);
+    script.onerror = () => reject(new Error(`Failed to load mermaid script from ${url}`));
+    document.head.appendChild(script);
+  });
+}
+
 async function loadMermaid() {
   if (mermaidModule !== undefined) {
     return mermaidModule;
@@ -54,6 +83,23 @@ async function loadMermaid() {
       const mermaidNamespace = await import(source.url);
       mermaidModule = mermaidNamespace?.default ?? mermaidNamespace;
       return mermaidModule;
+    } catch (error) {
+      console.warn(`Failed to load mermaid from ${source.label}`, error);
+    }
+  }
+
+  const scriptSources = [
+    { label: "local script", url: assetPath("mermaid/mermaid.min.js") },
+    { label: "cdn script", url: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js" },
+  ];
+
+  for (const source of scriptSources) {
+    try {
+      const mermaidNamespace = await loadMermaidScript(source.url);
+      if (mermaidNamespace) {
+        mermaidModule = mermaidNamespace;
+        return mermaidModule;
+      }
     } catch (error) {
       console.warn(`Failed to load mermaid from ${source.label}`, error);
     }


### PR DESCRIPTION
### Motivation

- Ensure the demo dashboard renders diagrams reliably when running offline or when dynamic module imports are blocked by the browser.
- Provide a secondary, more compatible UMD script asset for Mermaid to increase resilience across environments.
- Surface actionable diagnostics when bundle copying or loading partially fails to make troubleshooting easier.

### Description

- Update `copyMermaidBundle` in `run-demo.cjs` to attempt copying both ESM (`mermaid.esm.min.mjs`) and UMD (`mermaid.min.js`) bundles into the demo `output/mermaid` directory and emit warnings on partial or complete failures.
- Add a `loadMermaidScript` helper and a script-tag fallback path in `ui/dashboard.js` so the dashboard will load the UMD script if dynamic `import()` of the ESM bundle fails.
- Preserve prior behavior of attempting ESM dynamic import first and keep clear warnings when bundles are missing or only partially available.

### Testing

- Ran `pytest -q demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and all tests passed (`9 passed`).
- Executed `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` and the demo generated artefacts successfully (report, telemetry and ledgers were produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e47d30e483339d13f7379235d509)