### PR TITLE
Fix default output dir handling in Kardashev II demo wrapper

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
@@ -31,7 +31,10 @@ def _ensure_node_available() -> str:
     return node_path
 
 
-def _normalize_output_dir(raw: str) -> Path:
+def _normalize_output_dir(raw: str | Path) -> Path:
+    if isinstance(raw, Path):
+        return raw.expanduser()
+
     parsed = urlparse(raw)
     if parsed.scheme == "file":
         parsed_path = unquote(parsed.path)

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -32,6 +32,20 @@ def test_run_demo_check_mode(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
+def test_run_demo_check_mode_with_default_output_dir() -> None:
+    """The wrapper should accept the default output directory in check mode."""
+
+    result = subprocess.run(
+        [sys.executable, str(PYTHON_ENTRYPOINT), "--check"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "validated (check mode)" in result.stdout
+
+
+@pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
 def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     """Running without --check should emit the expected report artefacts."""
 


### PR DESCRIPTION
### Motivation

- The Python wrapper passed a `Path` default into `urlparse`, which led to an `AttributeError` because `urlparse` expects a string/bytes value. 
- This caused `python demo/.../run_demo.py --check` to fail when the default `DEFAULT_OUTPUT_DIR` (a `Path`) was used. 
- The goal is to robustly accept both `str` and `Path` inputs for the output directory and avoid surprising crashes. 
- Add a focused test to guard the wrapper behavior when the default output directory is relied on.

### Description

- Change `_normalize_output_dir` to accept `str | Path` and return early when `raw` is a `Path` by expanding it with `Path.expanduser()`.
- Preserve existing URL handling for `file:`-style strings and fallback behavior for other string inputs. 
- Add `test_run_demo_check_mode_with_default_output_dir` to `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` to exercise check-mode with the default output directory. 
- No changes were made to the Node demo invocation logic beyond normalizing the output directory input type.

### Testing

- Ran `pytest -q demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` and the suite passed (`10 passed in 3.10s`).
- Executed `python demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py --check` and it completed successfully with exit code 0. 
- The new test verifies that the wrapper accepts the default `Path` output directory in check mode. 
- All modified tests pass locally against the updated wrapper.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f66e755083339104ca9f8a759175)