### PR TITLE
Add config-root/profile support to Kardashev demo runner

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -38,9 +38,9 @@ function createRng(seed) {
   };
 }
 
-function resolveConfigPath(envVar, fallbackRelative) {
+function resolveConfigPath(envVar, fallbackRelative, baseDir = __dirname) {
   const override = normalizePathOverride(process.env[envVar]);
-  const target = override ? path.resolve(override) : path.join(__dirname, fallbackRelative);
+  const target = override ? path.resolve(override) : path.join(baseDir, fallbackRelative);
 
   if (!fs.existsSync(target)) {
     throw new Error(
@@ -2445,8 +2445,8 @@ function copyMermaidBundle(outputDir) {
   }
 }
 
-function writeOfflineDashboard(outputDir) {
-  const uiSourceDir = path.join(__dirname, 'ui');
+function writeOfflineDashboard(outputDir, demoRoot = __dirname) {
+  const uiSourceDir = path.join(demoRoot, 'ui');
   const uiTargetDir = path.join(outputDir, 'ui');
   ensureDir(uiTargetDir);
   for (const filename of ['style.css', 'dashboard.js']) {
@@ -2454,7 +2454,7 @@ function writeOfflineDashboard(outputDir) {
   }
   copyMermaidBundle(outputDir);
 
-  const indexTemplate = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+  const indexTemplate = fs.readFileSync(path.join(demoRoot, 'index.html'), 'utf8');
   const assetBaseMarker = 'window.__KARDASHEV_ASSET_BASE__ = "./output";';
   const offlineIndex = indexTemplate
     .replace(assetBaseMarker, 'window.__KARDASHEV_ASSET_BASE__ = ".";')
@@ -2468,12 +2468,20 @@ function parseArgs(argv) {
     outputDir: process.env.OUTPUT_DIR,
     check: false,
     printCommands: false,
+    configRoot: null,
+    profile: null,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
     const flag = argv[i];
     if (flag === '--output-dir' && argv[i + 1]) {
       args.outputDir = argv[i + 1];
+      i += 1;
+    } else if (flag === '--config-root' && argv[i + 1]) {
+      args.configRoot = argv[i + 1];
+      i += 1;
+    } else if (flag === '--profile' && argv[i + 1]) {
+      args.profile = argv[i + 1];
       i += 1;
     } else if (flag === '--check') {
       args.check = true;
@@ -2485,25 +2493,60 @@ function parseArgs(argv) {
   return args;
 }
 
-function resolveOutputDir(rawOutputDir, { ensure = true } = {}) {
+function resolveOutputDir(rawOutputDir, demoRoot, { ensure = true } = {}) {
   const override = normalizePathOverride(rawOutputDir);
-  const dir = override ? path.resolve(override) : path.join(__dirname, 'output');
+  const dir = override ? path.resolve(override) : path.join(demoRoot, 'output');
   if (ensure) {
     ensureDir(dir);
   }
   return dir;
 }
 
+function resolveDemoRoot({ profile, configRoot } = {}) {
+  if (profile) {
+    const candidate = path.resolve(__dirname, profile);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    throw new Error(`Profile directory not found: ${candidate}`);
+  }
+  if (configRoot) {
+    const candidate = normalizePathOverride(configRoot);
+    const resolved = candidate ? path.resolve(candidate) : path.resolve(configRoot);
+    if (fs.existsSync(resolved)) {
+      return resolved;
+    }
+    throw new Error(`Config root override not found: ${resolved}`);
+  }
+  return __dirname;
+}
+
 function main() {
+  const { outputDir: cliOutputDir, check, printCommands, configRoot, profile } = parseArgs(
+    process.argv.slice(2)
+  );
+  let demoRoot;
+  try {
+    demoRoot = resolveDemoRoot({ profile, configRoot });
+  } catch (err) {
+    console.error('❌ Kardashev configuration root resolution failed.');
+    console.error(`   - ${err.message}`);
+    process.exitCode = 1;
+    return;
+  }
   let fabric;
   let energy;
   let manifest;
   let taskLattice;
   try {
-    const fabricPath = resolveConfigPath('KARDASHEV_FABRIC_PATH', 'config/fabric.json');
-    const energyPath = resolveConfigPath('KARDASHEV_ENERGY_FEEDS_PATH', 'config/energy-feeds.json');
-    const manifestPath = resolveConfigPath('KARDASHEV_MANIFEST_PATH', 'config/kardashev-ii.manifest.json');
-    const taskLatticePath = resolveConfigPath('KARDASHEV_TASK_LATTICE_PATH', 'config/task-lattice.json');
+    const fabricPath = resolveConfigPath('KARDASHEV_FABRIC_PATH', 'config/fabric.json', demoRoot);
+    const energyPath = resolveConfigPath('KARDASHEV_ENERGY_FEEDS_PATH', 'config/energy-feeds.json', demoRoot);
+    const manifestPath = resolveConfigPath(
+      'KARDASHEV_MANIFEST_PATH',
+      'config/kardashev-ii.manifest.json',
+      demoRoot
+    );
+    const taskLatticePath = resolveConfigPath('KARDASHEV_TASK_LATTICE_PATH', 'config/task-lattice.json', demoRoot);
     fabric = loadJson(fabricPath);
     energy = loadJson(energyPath);
     manifest = loadJson(manifestPath);
@@ -2672,10 +2715,7 @@ function main() {
     runwayAdjustment: energyRunwayAdjustment,
   });
 
-  const { outputDir: cliOutputDir, check, printCommands } = parseArgs(
-    process.argv.slice(2)
-  );
-  const outputDir = resolveOutputDir(cliOutputDir, { ensure: !check });
+  const outputDir = resolveOutputDir(cliOutputDir, demoRoot, { ensure: !check });
   const mermaidDir = path.join(outputDir, 'mermaid');
   const dysonHierarchyPath = path.join(mermaidDir, 'dyson-hierarchy.mmd');
   const taskHierarchyPath = path.join(outputDir, 'kardashev-task-hierarchy.mmd');
@@ -3035,7 +3075,7 @@ function main() {
       })};\n`
     );
 
-    writeOfflineDashboard(outputDir);
+    writeOfflineDashboard(outputDir, demoRoot);
 
     const legacyTelemetryPath = path.join(outputDir, 'telemetry.json');
     if (fs.existsSync(legacyTelemetryPath)) {

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
@@ -54,6 +54,10 @@ def _build_command(args: argparse.Namespace) -> list[str]:
         if not args.check:
             output_dir.mkdir(parents=True, exist_ok=True)
         cmd.extend(["--output-dir", str(output_dir)])
+    if args.config_root:
+        cmd.extend(["--config-root", args.config_root])
+    if args.profile:
+        cmd.extend(["--profile", args.profile])
     if args.check:
         cmd.append("--check")
     if args.print_commands:
@@ -77,6 +81,14 @@ def run(argv: Sequence[str] | None = None) -> int:
         "--print-commands",
         action="store_true",
         help="Show governance commands produced by the Node demo.",
+    )
+    parser.add_argument(
+        "--config-root",
+        help="Override the demo configuration root (expects a directory containing config/).",
+    )
+    parser.add_argument(
+        "--profile",
+        help="Load a sub-profile directory within the demo root.",
     )
     args = parser.parse_args(argv)
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -46,6 +46,28 @@ def test_run_demo_check_mode_with_default_output_dir() -> None:
 
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
+def test_run_demo_check_mode_with_config_root(tmp_path: Path) -> None:
+    """The wrapper should accept a config root override and still validate."""
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PYTHON_ENTRYPOINT),
+            "--output-dir",
+            str(tmp_path),
+            "--config-root",
+            str(DEMO_ROOT),
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "validated (check mode)" in result.stdout
+
+
+@pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
 def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     """Running without --check should emit the expected report artefacts."""
 


### PR DESCRIPTION
### Motivation
- Allow the Kardashev-II demo to be run against an alternate configuration root or a named profile so CI and operator workflows can point at different config bundles without changing code.
- Ensure offline dashboard assets (`index.html`, `ui/*`) and manifest/config lookups resolve relative to the selected demo root/profile rather than assuming the script directory.
- Surface the configuration options through the Python wrapper so higher-level tooling and CI can pass overrides easily.
- Add a small test to prevent regressions and to validate the `--config-root` flow in check mode.

### Description
- Add `--config-root` and `--profile` CLI flags to the Node runner (`run-demo.cjs`) and to the Python wrapper (`run_demo.py`) and propagate them when invoking the Node script.
- Make `resolveConfigPath` accept a `baseDir` and use the resolved demo root when locating `config/*.json` files, and make `writeOfflineDashboard` read assets from the resolved demo root.
- Implement `resolveDemoRoot({ profile, configRoot })` and thread `demoRoot` through output path resolution so `--output-dir` behavior remains consistent with config-root overrides.
- Add `test_run_demo_check_mode_with_config_root` to exercise `--config-root` in check mode and update the wrapper to forward the new flags.

### Testing
- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and the suite passed (11 tests, all green).
- Ran the Kardashev demo CI validator via `npm run demo:kardashev-ii:ci` which completed successfully and reported artefacts up-to-date.
- Executed the Python wrapper in check mode with `python demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py --check` and observed successful validation output.
- Full repo demo test runner `python demo/run_demo_tests.py` was exercised during verification and completed with test suites passing for the demo tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695407756c2c833395113bc098359499)