### PR TITLE
Harden allocation thermodynamics and surface partition function in dashboard

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -681,11 +681,17 @@ function allocateWithCapacityCaps({ weights, capacities, availableGw }) {
 }
 
 function computeAllocationPolicy(shardMetrics, energyMonteCarlo) {
-  const temperature = Math.max(0.15, 1 - energyMonteCarlo.hamiltonianStability);
+  const hamiltonianStability = Number.isFinite(energyMonteCarlo?.hamiltonianStability)
+    ? energyMonteCarlo.hamiltonianStability
+    : 0.9;
+  const temperature = Math.max(0.15, 1 - hamiltonianStability);
   const scores = shardMetrics.map((metric) => {
-    const utilisationPenalty = metric.utilisation / 100;
-    const latencyPenalty = Math.min(1, metric.settlementLagMinutes / 180);
-    return metric.resilience - 0.6 * utilisationPenalty - 0.2 * latencyPenalty;
+    const resilience = Number.isFinite(metric.resilience) ? metric.resilience : 0;
+    const utilisationPenalty = Number.isFinite(metric.utilisation) ? metric.utilisation / 100 : 0;
+    const latencyPenalty = Number.isFinite(metric.settlementLagMinutes)
+      ? Math.min(1, metric.settlementLagMinutes / 180)
+      : 0;
+    return resilience - 0.6 * utilisationPenalty - 0.2 * latencyPenalty;
   });
   const { weights: rawWeights, partition } = softmaxScores(scores, temperature);
   const diversificationTarget = Math.max(
@@ -694,7 +700,7 @@ function computeAllocationPolicy(shardMetrics, energyMonteCarlo) {
   );
   const diversification = diversifyWeights(rawWeights, diversificationTarget);
   const weights = diversification.weights;
-  const availableGw = energyMonteCarlo.availableGw;
+  const availableGw = Number.isFinite(energyMonteCarlo?.availableGw) ? energyMonteCarlo.availableGw : 0;
   const capacities = shardMetrics.map((metric) => {
     if (Number.isFinite(metric.capacityGw)) {
       return metric.capacityGw;
@@ -760,6 +766,7 @@ function computeAllocationPolicy(shardMetrics, energyMonteCarlo) {
     allocationEntropy,
     fairnessIndex,
     gibbsPotential,
+    partitionFunction: partition,
     allocations,
     availableGw,
     unallocatedGw,

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -1191,7 +1191,10 @@ function renderAllocationPolicy(policy) {
   )} · Nash welfare ${formatMaybeNumber(policy.nashProduct, (value) => (value * 100).toFixed(2))}% · fairness ${formatMaybeNumber(
     policy.fairnessIndex,
     (value) => (value * 100).toFixed(1)
-  )}% · Gibbs potential ${formatMaybeNumber(policy.gibbsPotential, (value) => value.toFixed(3))}`;
+  )}% · Gibbs potential ${formatMaybeNumber(policy.gibbsPotential, (value) => value.toFixed(3))} · partition Z ${formatMaybeNumber(
+    policy.partitionFunction,
+    (value) => value.toFixed(3)
+  )}`;
   stability.textContent = `Strategy stability ${formatMaybeNumber(
     policy.strategyStability,
     (value) => (value * 100).toFixed(1)


### PR DESCRIPTION
### Motivation
- Prevent fragile allocation calculations when Monte Carlo or shard metrics are missing or non-finite by applying defensive defaults and numeric checks. 
- Improve observability of the allocation thermodynamic model by exposing the softmax partition function (statistical physics perspective) for debugging and analysis. 

### Description
- Added defensive handling in `computeAllocationPolicy` to treat missing/non-finite `energyMonteCarlo` and `shardMetrics` fields with sensible defaults (e.g. default `hamiltonianStability`, guarded numeric computations, and safe `availableGw`).
- Retained existing allocation logic but wired the softmax partition value into the returned telemetry as `partitionFunction`.
- Updated the dashboard summary in `ui/dashboard.js` to display the new `partitionFunction` value alongside Gibbs temperature and Gibbs potential.
- Files changed: `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` and `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js`.

### Testing
- Ran `pytest -q demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` which completed successfully (`11 passed`).
- Executed the Node demo runner with `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs --output-dir <tmpdir>` and it exited successfully while producing the expected artefacts (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954364c8d508333a34bbfac5bec3016)