### PR TITLE
Add exergy recovery action to Kardashev‑II policy demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -720,7 +720,13 @@ class Orchestrator:
                     await self._handle_simulation_action(message.payload)
 
     def _normalize_simulation_action(self, payload: Dict[str, Any]) -> Dict[str, float]:
-        allowed_fields = ("build_dyson_nodes", "stimulus", "green_shift", "alignment_investment")
+        allowed_fields = (
+            "build_dyson_nodes",
+            "stimulus",
+            "green_shift",
+            "alignment_investment",
+            "exergy_recovery",
+        )
         normalized: Dict[str, float] = {}
         for field in allowed_fields:
             if field not in payload:
@@ -745,6 +751,7 @@ class Orchestrator:
         entropy = max(0.0, state.entropy)
         entropy_pressure = min(1.0, entropy / math.log(2.0))
         exergy_balance = max(-1.0, min(1.0, state.exergy_balance))
+        exergy_pressure = max(0.0, min(1.0, (1.0 - exergy_balance) / 2.0))
         pareto_efficiency = max(0.0, min(1.0, state.pareto_efficiency))
         pareto_gap = max(0.0, 1.0 - pareto_efficiency)
         energy_price_pressure = max(0.0, self.resources.energy_price - 1.0)
@@ -793,6 +800,7 @@ class Orchestrator:
             "entropy": entropy,
             "entropy_pressure": entropy_pressure,
             "exergy_balance": exergy_balance,
+            "exergy_pressure": exergy_pressure,
             "pareto_efficiency": pareto_efficiency,
             "pareto_gap": pareto_gap,
             "energy_price_pressure": energy_price_pressure,
@@ -956,6 +964,7 @@ class Orchestrator:
             ("stimulus", "Launch prosperity stimulus"),
             ("green_shift", "Accelerate green transition"),
             ("alignment_investment", "Invest in alignment"),
+            ("exergy_recovery", "Recover exergy"),
         )
         for key, label in ordered_actions:
             value = float(action.get(key, 0.0))
@@ -1054,12 +1063,20 @@ class Orchestrator:
             * (0.7 + 0.6 * signals["pareto_gap"])
             * (1.0 + (1.0 - stability_guard))
         )
+        exergy_recovery = (
+            action_budget
+            * signals["exergy_pressure"]
+            * signals["entropy_damping"]
+            * (0.6 + 0.4 * signals["stability_index"])
+            * signals["coordination_damping"]
+        )
         normalized_action = self._normalize_simulation_action(
             {
                 "build_dyson_nodes": energy_action * signals["stability_factor"] * stability_modifier,
                 "stimulus": stimulus,
                 "green_shift": green_shift,
                 "alignment_investment": alignment_investment,
+                "exergy_recovery": exergy_recovery,
             }
         )
         rationale = self._build_policy_rationale(
@@ -1072,6 +1089,7 @@ class Orchestrator:
                 "stimulus": stimulus,
                 "green_shift": green_shift,
                 "alignment_investment": alignment_investment,
+                "exergy_recovery": exergy_recovery,
             },
         )
         return {"action": normalized_action, "rationale": rationale}

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -55,9 +55,15 @@ class SyntheticEconomySim(PlanetarySimulation):
         stimulus = max(0.0, float(action.get("stimulus", 0.0)))
         green_shift = max(0.0, float(action.get("green_shift", 0.0)))
         alignment_investment = max(0.0, float(action.get("alignment_investment", 0.0)))
+        exergy_recovery = max(0.0, float(action.get("exergy_recovery", 0.0)))
         self.energy_output_gw += build_dyson_nodes * 10_000
+        if exergy_recovery:
+            self.energy_output_gw += exergy_recovery * 4_000
         self.prosperity_index = min(1.0, self.prosperity_index + stimulus * 0.01)
         self.sustainability_index = min(1.0, self.sustainability_index + green_shift * 0.02)
+        if exergy_recovery:
+            self.prosperity_index = min(1.0, self.prosperity_index + exergy_recovery * 0.004)
+            self.sustainability_index = min(1.0, self.sustainability_index + exergy_recovery * 0.006)
         if alignment_investment:
             gap = self.prosperity_index - self.sustainability_index
             alignment_step = min(0.02 * alignment_investment, abs(gap))

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_exergy_recovery.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_exergy_recovery.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.simulation import SyntheticEconomySim
+
+
+def test_exergy_recovery_boosts_energy_and_stability() -> None:
+    sim = SyntheticEconomySim()
+    initial_state = sim.tick(hours=0.0)
+
+    updated_state = sim.apply_action({"exergy_recovery": 4.0})
+
+    assert updated_state.energy_output_gw > initial_state.energy_output_gw
+    assert updated_state.sustainability_index >= initial_state.sustainability_index
+    assert updated_state.prosperity_index >= initial_state.prosperity_index

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
@@ -108,3 +108,19 @@ def test_insight_payload_surfaces_thermodynamic_strategy(tmp_path: Path) -> None
     assert "policy_recommendation" in payload
     assert payload["thermodynamics"]["gibbs_free_energy"] == pytest.approx(-0.8)
     assert payload["game_theory"]["game_theory_slack"] == pytest.approx(0.74)
+
+
+def test_policy_steps_include_exergy_recovery(tmp_path: Path) -> None:
+    orchestrator = Orchestrator(
+        OrchestratorConfig(
+            control_channel_file=tmp_path / "control.jsonl",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            status_output_path=None,
+            audit_log_path=None,
+            energy_oracle_path=None,
+        )
+    )
+
+    steps = orchestrator._format_policy_steps({"exergy_recovery": 2.5})
+
+    assert any("Recover exergy" in step for step in steps)


### PR DESCRIPTION
### Motivation

- Introduce an `exergy_recovery` policy action to give the orchestrator a lever that explicitly targets recoverable work (exergy) alongside Dyson‑scale expansion and social policy instruments.  
- Ground autonomous policy decisions in thermodynamic and game‑theoretic signals so the demo better reflects energy/stability tradeoffs at Kardashev‑II scale.  
- Provide a simple, testable simulation effect for exergy recovery to make policy-to-simulation feedback explicit and auditable.  

### Description

- Added `exergy_recovery` to action normalization and to the ordered policy steps in `orchestrator.py`.  
- Derived a new `exergy_pressure` signal in `_compute_policy_signals` and incorporated it into `_build_policy_decision` so actions can allocate budget to `exergy_recovery`.  
- Extended `SyntheticEconomySim.apply_action` in `simulation.py` to accept `exergy_recovery` and apply modest boosts to `energy_output_gw`, `prosperity_index`, and `sustainability_index`.  
- Added `tests/test_exergy_recovery.py` and updated `tests/test_policy_actions.py` to cover the new action and policy formatting.  

### Testing

- Added the unit test `demo/.../tests/test_exergy_recovery.py` and a policy‑steps assertion in `test_policy_actions.py`.  
- Executed the demo test runner with `python demo/run_demo_tests.py --demo "Kardashev-II Omega-Grade-α-AGI Business-3"`.  
- The targeted demo suites completed successfully with the modified tests (the demo-specific run reported all tests passing).  
- No failing automated tests were observed after these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69545a809a50833389237cdfbef5e54e)