### PR TITLE
Add federation energy equity ledger to Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -1072,8 +1072,12 @@ function buildIdentity(identityProtocols) {
   const totalRevocations = sum(federations.map((fed) => fed.credentialRevocations24h ?? 0));
   const totalIssuances = sum(federations.map((fed) => fed.credentialIssuances24h ?? 0));
   const revocationRatePpm = totalAgents > 0 ? (totalRevocations / totalAgents) * 1_000_000 : 0;
-  const minCoveragePct = Math.min(...federations.map((fed) => fed.coveragePct ?? 1));
-  const maxLatency = Math.max(...federations.map((fed) => fed.attestationLatencySeconds ?? 0));
+  const minCoveragePct = federations.length
+    ? Math.min(...federations.map((fed) => fed.coveragePct ?? 1))
+    : 0;
+  const maxLatency = federations.length
+    ? Math.max(...federations.map((fed) => fed.attestationLatencySeconds ?? 0))
+    : 0;
 
   return {
     global,
@@ -1090,6 +1094,59 @@ function buildIdentity(identityProtocols) {
       maxAttestationLatencySeconds: maxLatency,
     },
     withinQuorum: anchorsMeetingQuorum === federations.length,
+  };
+}
+
+function buildFederationEquity(manifestFederations, identity, energyMonteCarlo) {
+  const identityFederations = identity?.federations ?? [];
+  const identityBySlug = new Map(identityFederations.map((fed) => [fed.slug, fed]));
+  const totalAvailableGw = sum(manifestFederations.map((fed) => fed.energy?.availableGw ?? 0));
+  const totalAgents = sum(
+    manifestFederations.map((fed) => {
+      const identityFed = identityBySlug.get(fed.slug);
+      return identityFed?.totalAgents ?? fed.compute?.agents ?? 0;
+    })
+  );
+  const totalFreeEnergyGj = energyMonteCarlo?.gibbsFreeEnergyGj ?? 0;
+
+  const entries = manifestFederations.map((fed) => {
+    const identityFed = identityBySlug.get(fed.slug);
+    const agents = identityFed?.totalAgents ?? fed.compute?.agents ?? 0;
+    const availableGw = fed.energy?.availableGw ?? 0;
+    const energySharePct = totalAvailableGw > 0 ? availableGw / totalAvailableGw : 0;
+    const agentSharePct = totalAgents > 0 ? agents / totalAgents : 0;
+    const freeEnergyShareGj = totalFreeEnergyGj * energySharePct;
+    const freeEnergyPerAgentGj = agents > 0 ? freeEnergyShareGj / agents : 0;
+    return {
+      federation: fed.slug,
+      name: fed.name ?? fed.slug,
+      agents,
+      availableGw,
+      energySharePct,
+      agentSharePct,
+      freeEnergyShareGj,
+      freeEnergyPerAgentGj,
+      equityGapPct: energySharePct - agentSharePct,
+    };
+  });
+
+  const perAgentValues = entries
+    .map((entry) => entry.freeEnergyPerAgentGj)
+    .filter((value) => Number.isFinite(value) && value > 0);
+  const inequalityIndex = computeGiniIndex(perAgentValues);
+  const payoffCoefficient = computeCoefficientOfVariation(perAgentValues);
+  const coalitionStability = clamp01(1 - payoffCoefficient);
+  const equityScore = clamp01(0.6 * (1 - inequalityIndex) + 0.4 * coalitionStability);
+
+  return {
+    totalAvailableGw,
+    totalAgents,
+    totalFreeEnergyGj,
+    inequalityIndex,
+    payoffCoefficient,
+    coalitionStability,
+    equityScore,
+    entries,
   };
 }
 
@@ -1746,6 +1803,7 @@ function buildEquilibriumLedger({
   energyMonteCarlo,
   allocationPolicy,
   sentientWelfare,
+  federationEquity,
   logistics,
   computeFabric,
   missionThermodynamics,
@@ -1848,6 +1906,7 @@ function buildEquilibriumLedger({
     energyMonteCarlo,
     allocationPolicy,
     sentientWelfare,
+    federationEquity,
     logistics,
     computeFabric,
     missionThermodynamics,
@@ -2122,6 +2181,7 @@ function buildEquilibriumActionPath({
   energyMonteCarlo,
   allocationPolicy,
   sentientWelfare,
+  federationEquity,
   logistics,
   computeFabric,
   missionThermodynamics,
@@ -2220,6 +2280,22 @@ function buildEquilibriumActionPath({
     )}% · Gini ${(sentientWelfare.inequalityIndex * 100).toFixed(1)}%`,
     action:
       'Redistribute cooperative rewards and re-weight federation incentives to preserve Pareto-optimal welfare.',
+  });
+
+  const equityScore = federationEquity?.equityScore ?? 1;
+  const equityNeeds =
+    equityScore < 0.85 || (federationEquity?.inequalityIndex ?? 0) > 0.25;
+  steps.push({
+    key: 'equity',
+    score: scores?.welfare ?? 0,
+    title: 'Federation free-energy equity',
+    status: equityNeeds ? 'needs-action' : 'on-track',
+    target: 'Equity score ≥ 85% with inequality ≤ 25%.',
+    rationale: `Equity ${(equityScore * 100).toFixed(1)}% · inequality ${(
+      (federationEquity?.inequalityIndex ?? 0) * 100
+    ).toFixed(1)}%`,
+    action:
+      'Rebalance Dyson reserve allocations and welfare grants so free energy per agent converges across federations.',
   });
 
   const averageUtilisation = logistics?.verification?.averageUtilisationPct ?? 0;
@@ -2674,6 +2750,7 @@ function main() {
 
   const identity = buildIdentity(manifest.identityProtocols);
   const sentientWelfare = buildSentientWelfare(identity, allocationPolicy, energyMonteCarlo);
+  const federationEquity = buildFederationEquity(manifest.federations ?? [], identity, energyMonteCarlo);
   const computeFabric = buildComputeFabric(manifest.computeFabrics);
   const orchestrationFabric = buildOrchestrationFabric(fabric.shards, manifest.federations);
   const missionLattice = buildMissionLattice(taskLattice, manifest);
@@ -2715,6 +2792,7 @@ function main() {
     energyMonteCarlo,
     allocationPolicy,
     sentientWelfare,
+    federationEquity,
     logistics,
     computeFabric,
     missionThermodynamics,
@@ -2803,6 +2881,11 @@ function main() {
     `- **Sentient Coalition Stability:** ${(sentientWelfare.coalitionStability * 100).toFixed(1)}% · collective action ${(sentientWelfare.collectiveActionPotential * 100).toFixed(1)}% · payoff dispersion ${(sentientWelfare.payoffCoefficient * 100).toFixed(1)}%.`
   );
   reportLines.push(
+    `- **Federation Energy Equity:** ${(federationEquity.equityScore * 100).toFixed(1)}% · inequality ${(
+      federationEquity.inequalityIndex * 100
+    ).toFixed(1)}% · coalition stability ${(federationEquity.coalitionStability * 100).toFixed(1)}%.`
+  );
+  reportLines.push(
     `- **Equilibrium Ledger:** ${(equilibriumLedger.overallScore * 100).toFixed(1)}% (${equilibriumLedger.status}); energy ${(equilibriumLedger.components.energy.score * 100).toFixed(1)}%, allocation ${(equilibriumLedger.components.allocation.score * 100).toFixed(1)}%, welfare ${(equilibriumLedger.components.welfare.score * 100).toFixed(1)}%.`
   );
   reportLines.push(
@@ -2840,6 +2923,22 @@ function main() {
         round(allocation.payoff, 3),
       ]),
       ['Shard', 'Boltzmann Weight', 'Effective Weight', 'Recommended GW', 'Capacity GW', 'Nash Payoff']
+    )
+  );
+  reportLines.push('');
+
+  reportLines.push('## Federation Equity Ledger');
+  reportLines.push('');
+  reportLines.push(
+    toTable(
+      federationEquity.entries.map((entry) => [
+        entry.name,
+        `${(entry.energySharePct * 100).toFixed(1)}%`,
+        `${(entry.agentSharePct * 100).toFixed(1)}%`,
+        `${entry.freeEnergyPerAgentGj.toFixed(6)} GJ`,
+        `${(entry.equityGapPct * 100).toFixed(2)}%`,
+      ]),
+      ['Federation', 'Energy Share', 'Agent Share', 'Free Energy/Agent', 'Equity Gap']
     )
   );
   reportLines.push('');
@@ -2924,6 +3023,7 @@ function main() {
     energyMonteCarlo,
     allocationPolicy,
     sentientWelfare,
+    federationEquity,
     energy: {
       utilisationPct: energyUtilisationPct,
       marginPct: energyMarginPct,

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -173,6 +173,23 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert 0 <= sentient["welfarePotential"] <= 1
     assert 0 <= sentient["collectiveActionPotential"] <= 1
 
+    federation_equity = telemetry_payload["federationEquity"]
+    assert federation_equity["totalAvailableGw"] > 0
+    assert federation_equity["totalAgents"] > 0
+    assert federation_equity["totalFreeEnergyGj"] >= 0
+    assert 0 <= federation_equity["inequalityIndex"] <= 1
+    assert 0 <= federation_equity["coalitionStability"] <= 1
+    assert 0 <= federation_equity["equityScore"] <= 1
+    assert federation_equity["entries"]
+    for entry in federation_equity["entries"]:
+        assert entry["federation"]
+        assert entry["agents"] >= 0
+        assert entry["availableGw"] >= 0
+        assert 0 <= entry["energySharePct"] <= 1
+        assert 0 <= entry["agentSharePct"] <= 1
+        assert entry["freeEnergyPerAgentGj"] >= 0
+        assert -1 <= entry["equityGapPct"] <= 1
+
     mission_thermo = telemetry_payload["missionThermodynamics"]
     assert 0 <= mission_thermo["hamiltonianLoad"] <= 1
     assert 0 <= mission_thermo["hamiltonianStability"] <= 1


### PR DESCRIPTION
### Motivation

- Surface cross-federation fairness by quantifying free-energy per agent and energy/agent imbalances for governance and remediation.
- Integrate economic/game-theoretic measures (Gini, coefficient of variation, coalition stability) into the demo's telemetry and decision path.
- Harden identity handling for demos with empty or partial federation identity payloads to avoid runtime exceptions.

### Description

- Add `buildFederationEquity(...)` which computes per-federation entries, free-energy-per-agent, inequality (Gini), payoff dispersion, coalition stability, and an `equityScore` derived from those metrics.
- Wire `federationEquity` into the main pipeline so it is used by `buildEquilibriumLedger`, `buildEquilibriumActionPath`, the generated report (`kardashev-report.md`), and the telemetry payload (`kardashev-telemetry.json`).
- Harden `buildIdentity` defaults for empty `federations` by safely computing `minCoveragePct` and `maxAttestationLatencySeconds` when lists are empty.
- Extend tests in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` to assert the presence and sanity of `federationEquity` fields and per-entry values.

### Testing

- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` and the suite passed: `11 passed`.
- Executed the demo Python/Node wrapper end-to-end checks exercised by the test file and confirmed artefacts and telemetry keys were produced successfully.
- Existing demo unit tests in the repository were not modified and the focused demo tests covering the changes succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695465c0d31483339afe53943c971002)