### PR TITLE
Fix AGI Alpha Node demo import isolation

### DIFF
--- a/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/knowledge/__init__.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/knowledge/__init__.py
@@ -1,4 +1,4 @@
 """Knowledge lake exports."""
-from .lake import KnowledgeItem, KnowledgeLake
+from .lake import KnowledgeEntry, KnowledgeItem, KnowledgeLake
 
-__all__ = ["KnowledgeItem", "KnowledgeLake"]
+__all__ = ["KnowledgeEntry", "KnowledgeItem", "KnowledgeLake"]

--- a/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/knowledge/lake.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/alpha_node/knowledge/lake.py
@@ -1,12 +1,13 @@
 """Persistent knowledge lake implementation."""
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
 import pathlib
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,14 @@ class KnowledgeItem:
     key: str
     embedding: List[float]
     payload: Dict[str, str]
+
+
+@dataclass(slots=True)
+class KnowledgeEntry:
+    topic: str
+    insight: str
+    impact: float
+    job_id: str
 
 
 @dataclass(slots=True)
@@ -50,6 +59,18 @@ class KnowledgeLake:
         norm = math.sqrt(sum(v * v for v in vector)) or 1.0
         return [v / norm for v in vector]
 
+    def _embed_text(self, text: str) -> List[float]:
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        values = []
+        for index in range(self.embedding_dim):
+            value = digest[index % len(digest)]
+            values.append((value / 255.0) * 2 - 1)
+        return self._normalise(values)
+
+    def _entry_key(self, entry: KnowledgeEntry) -> str:
+        seed = f"{entry.topic}:{entry.job_id}:{entry.insight}"
+        return hashlib.blake2b(seed.encode("utf-8"), digest_size=16).hexdigest()
+
     def upsert(self, key: str, embedding: Iterable[float], payload: Dict[str, str]) -> None:
         normalised = self._normalise(embedding)
         self._items[key] = KnowledgeItem(key=key, embedding=normalised, payload=payload)
@@ -73,5 +94,41 @@ class KnowledgeLake:
             self._save()
             logger.info("Erased knowledge item", extra={"key": key})
 
+    def add_entry(self, entry: KnowledgeEntry) -> None:
+        payload = {
+            "topic": entry.topic,
+            "insight": entry.insight,
+            "impact": f"{entry.impact:.6f}",
+            "job_id": entry.job_id,
+        }
+        embedding = self._embed_text(f"{entry.topic} {entry.insight}")
+        key = self._entry_key(entry)
+        self._items[key] = KnowledgeItem(key=key, embedding=embedding, payload=payload)
+        self._save()
 
-__all__ = ["KnowledgeLake", "KnowledgeItem"]
+    def export(self) -> List[KnowledgeEntry]:
+        entries: List[KnowledgeEntry] = []
+        for item in self._items.values():
+            payload = item.payload
+            if {"topic", "insight", "impact", "job_id"}.issubset(payload):
+                try:
+                    impact = float(payload["impact"])
+                except (TypeError, ValueError):
+                    impact = 0.0
+                entries.append(
+                    KnowledgeEntry(
+                        topic=payload["topic"],
+                        insight=payload["insight"],
+                        impact=impact,
+                        job_id=payload["job_id"],
+                    )
+                )
+        return entries
+
+    def find(self, topic: str) -> Optional[KnowledgeEntry]:
+        matches = [entry for entry in self.export() if topic.lower() in entry.topic.lower()]
+        matches.sort(key=lambda entry: entry.impact, reverse=True)
+        return matches[0] if matches else None
+
+
+__all__ = ["KnowledgeLake", "KnowledgeItem", "KnowledgeEntry"]

--- a/demo/AGI-Alpha-Node-v0/run_alpha_node.py
+++ b/demo/AGI-Alpha-Node-v0/run_alpha_node.py
@@ -18,6 +18,13 @@ for path in (DEMO_ROOT, DEMO_PARENT):
     if path_str not in sys.path:
         sys.path.insert(0, path_str)
 
+for name in list(sys.modules):
+    if name == "alpha_node" or name.startswith("alpha_node."):
+        sys.modules.pop(name)
+
+grand_demo_path = str(DEMO_ROOT / "grand_demo")
+sys.path = [path for path in sys.path if path != grand_demo_path]
+
 if os.environ.get("DEMO_SYS_PATH_DEBUG"):
     import importlib.util
 


### PR DESCRIPTION
### Motivation
- The demo was failing test collection due to import collisions between the repository-level `alpha_node` package and the `grand_demo` variant, causing `ImportError`s for types like `KnowledgeEntry` and `ComplianceReport`.
- Provide a backwards-compatible knowledge API so the orchestrator and other consumers can rely on a consistent `KnowledgeEntry` model across variants.
- Make CLI startup deterministic by removing stale in-memory modules and conflicting `grand_demo` path entries so the correct package is imported at runtime.

### Description
- Add a `KnowledgeEntry` dataclass and compatibility helpers to `grand_demo/alpha_node/knowledge/lake.py`, including `add_entry`, `export`, and `find` to mirror the simpler demo API.
- Implement a deterministic placeholder embedding generator (`_embed_text`) and stable entry keying (`_entry_key`) to allow knowledge items to be stored and queried consistently.
- Export `KnowledgeEntry` from `grand_demo/alpha_node/knowledge/__init__.py` and update `__all__` to expose the compatibility symbol.
- Make `run_alpha_node.py` scrub any loaded `alpha_node` modules from `sys.modules` and remove the `grand_demo` path from `sys.path` before importing to avoid cross-package shadowing.

### Testing
- Ran `pytest -q` in `demo/AGI-Alpha-Node-v0` to validate the demo test suite, and all tests passed: `14 passed in 2.86s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69546f763fd4833398ab466663016fdf)