### PR TITLE
Skip Prisma generation when node_modules is missing

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -498,6 +498,14 @@ def _ensure_prisma_client(
     if _has_prisma_client(package_root):
         return True
 
+    node_modules = package_root / "node_modules"
+    if not node_modules.exists():
+        print(
+            "→ Skipping Prisma-dependent suite because node_modules is missing; "
+            "install dependencies for this demo before rerunning tests."
+        )
+        return False
+
     print(f"→ Generating Prisma client for {package_root} (missing artifacts)")
     env = os.environ.copy()
     env.setdefault("CI", "1")

--- a/demo/tests/test_run_demo_tests_runner.py
+++ b/demo/tests/test_run_demo_tests_runner.py
@@ -624,6 +624,7 @@ def test_prisma_client_generation_is_triggered(
     }
     (project_dir / "package.json").write_text(json.dumps(package_json))
     (project_dir / "package-lock.json").write_text("{}\n")
+    (project_dir / "node_modules").mkdir()
     (tests_dir / "ledger.test.ts").write_text("describe('ok', () => {});")
 
     calls: list[tuple[Path, dict[str, object] | None]] = []
@@ -706,6 +707,7 @@ def test_prisma_client_generation_is_cached_per_package(
     }
     (package_root / "package.json").write_text(json.dumps(package_json))
     (package_root / "package-lock.json").write_text("{}\n")
+    (package_root / "node_modules").mkdir()
 
     calls: list[tuple[Path, dict[str, object] | None]] = []
     monkeypatch.setattr(run_demo_tests, "_has_prisma_client", lambda _: False)


### PR DESCRIPTION
### Motivation
- The demo test runner attempted to run `npx prisma generate` even when a project had no `node_modules`, which could hang CI or cause confusing failures.
- Make the Prisma generation step robust and provide a clear operator-facing message when dependencies are not installed.
- Improve developer feedback and avoid unnecessary external calls during test discovery.

### Description
- Add a guard in `_ensure_prisma_client` to check for `node_modules` and skip Prisma generation with a clear message when it is absent.
- Preserve existing checks for generated Prisma artifacts and `npx` availability; only short-circuit when `node_modules` is missing.
- Update tests in `demo/tests/test_run_demo_tests_runner.py` to create a `node_modules` directory in fixtures that expect Prisma generation so the tests exercise the new guard.
- Modified files: `demo/run_demo_tests.py` and `demo/tests/test_run_demo_tests_runner.py`.

### Testing
- Ran `pytest -q demo/tests/test_run_demo_tests_runner.py`, which completed successfully with `44 passed` in the CI environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954859e2104833398635ae7966fb7d7)