### PR TITLE
Load default config with resolved paths for Kardashev II demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
@@ -12,6 +12,8 @@ from typing import Any, Optional
 from .governance import GovernanceParameters
 from .orchestrator import Orchestrator, OrchestratorConfig
 
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "default.json"
+
 
 def _require_positive(value: float, *, field: str, allow_zero: bool = False) -> None:
     """Validate that numeric CLI arguments remain within safe bounds.
@@ -115,7 +117,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=10.0,
         help="Seconds between autonomous policy actions",
     )
-    parser.add_argument("--config", type=Path, help="Optional JSON file overriding orchestrator configuration")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help=(
+            "Optional JSON file overriding orchestrator configuration "
+            f"(defaults to {DEFAULT_CONFIG_PATH.as_posix()})"
+        ),
+    )
     return parser
 
 
@@ -131,10 +140,14 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
     """
 
     overrides = overrides or {}
-    if args.config:
-        if not args.config.exists():
-            raise FileNotFoundError(f"Config file not found: {args.config}")
-        data = json.loads(args.config.read_text(encoding="utf-8"))
+    config_path = args.config or (DEFAULT_CONFIG_PATH if DEFAULT_CONFIG_PATH.exists() else None)
+    if config_path:
+        if not config_path.exists():
+            raise FileNotFoundError(f"Config file not found: {config_path}")
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        config_base = (
+            DEFAULT_CONFIG_PATH.parent.parent if config_path == DEFAULT_CONFIG_PATH else config_path.parent
+        )
         for path_field in (
             "checkpoint_path",
             "control_channel_file",
@@ -143,7 +156,10 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
             "energy_oracle_path",
         ):
             if path_field in data and data[path_field] is not None:
-                data[path_field] = Path(data[path_field])
+                candidate = Path(data[path_field])
+                if not candidate.is_absolute():
+                    candidate = config_base / candidate
+                data[path_field] = candidate
         if "governance" in data:
             gov_data = dict(data["governance"])
             if "validator_commit_window" in gov_data:

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cli_defaults.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cli_defaults.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.cli import build_config, parse_args
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.cli import (
+    DEFAULT_CONFIG_PATH,
+    build_config,
+    parse_args,
+)
 
 
 def test_default_cycles_are_finite():
@@ -17,6 +21,18 @@ def test_zero_cycles_runs_indefinitely():
     config = build_config(args)
 
     assert config.max_cycles is None
+
+
+def test_default_config_paths_resolve_from_module_root() -> None:
+    args = parse_args([])
+    config = build_config(args)
+
+    module_root = DEFAULT_CONFIG_PATH.parent.parent
+
+    assert config.status_output_path == module_root / "logs/omega-status.jsonl"
+    assert config.audit_log_path == module_root / "logs/omega-audit.jsonl"
+    assert config.energy_oracle_path == module_root / "logs/omega-energy-oracle.jsonl"
+    assert config.checkpoint_path == module_root / "checkpoint.json"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- Provide a frictionless default so the Kardashev-II demo CLI uses the bundled config when no `--config` is supplied.
- Ensure file paths in the config (logs, checkpoint, oracle, control channel) are resolved relative to the module root so outputs land where operators expect them.
- Avoid surprising behavior when demo is launched from different working directories by canonicalising config-relative paths.
- Add a small unit test to lock in expected default-path behaviour.

### Description

- Add `DEFAULT_CONFIG_PATH` pointing at the demo's `config/default.json` and expose it in the CLI help string.
- Update the `--config` handling in `build_config` to fall back to the bundled config when present and to compute a `config_base` so relative paths are resolved against the module root.
- Convert config path fields (`checkpoint_path`, `control_channel_file`, `audit_log_path`, `status_output_path`, `energy_oracle_path`) into absolute `Path` objects using the resolved `config_base` when they are not already absolute.
- Add test coverage that imports `DEFAULT_CONFIG_PATH` and asserts the resolved `status_output_path`, `audit_log_path`, `energy_oracle_path`, and `checkpoint_path` match the module's `logs/` and `checkpoint.json` locations.

### Testing

- Ran the focused unit test suite with `python -m pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_cli_defaults.py"` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69549fb04f2883339a1c25820873643a)