### PR TITLE
Add welfare guardrails to Kardashev-II policy decisions

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -747,6 +747,7 @@ class Orchestrator:
         nash_welfare = max(0.0, min(1.0, state.nash_welfare))
         sentient_welfare_index = max(0.0, min(1.0, state.sentient_welfare_index))
         welfare_floor = max(0.0, min(state.prosperity_index, state.sustainability_index))
+        welfare_gap = max(0.0, 1.0 - welfare_floor)
         stability_index = max(0.0, min(1.0, state.stability_index))
         entropy = max(0.0, state.entropy)
         entropy_pressure = min(1.0, entropy / math.log(2.0))
@@ -754,6 +755,7 @@ class Orchestrator:
         exergy_pressure = max(0.0, min(1.0, (1.0 - exergy_balance) / 2.0))
         pareto_efficiency = max(0.0, min(1.0, state.pareto_efficiency))
         pareto_gap = max(0.0, 1.0 - pareto_efficiency)
+        equity_pressure = min(1.0, 0.6 * welfare_gap + 0.4 * pareto_gap)
         energy_price_pressure = max(0.0, self.resources.energy_price - 1.0)
         compute_price_pressure = max(0.0, self.resources.compute_price - 1.0)
         reserved_energy_ratio = self.resources.reserved_energy / max(self.resources.energy_capacity, 1.0)
@@ -796,6 +798,7 @@ class Orchestrator:
             "nash_welfare": nash_welfare,
             "sentient_welfare_index": sentient_welfare_index,
             "welfare_floor": welfare_floor,
+            "welfare_gap": welfare_gap,
             "stability_index": stability_index,
             "entropy": entropy,
             "entropy_pressure": entropy_pressure,
@@ -803,6 +806,7 @@ class Orchestrator:
             "exergy_pressure": exergy_pressure,
             "pareto_efficiency": pareto_efficiency,
             "pareto_gap": pareto_gap,
+            "equity_pressure": equity_pressure,
             "energy_price_pressure": energy_price_pressure,
             "compute_price_pressure": compute_price_pressure,
             "reserved_energy_ratio": reserved_energy_ratio,
@@ -990,6 +994,12 @@ class Orchestrator:
             "focus": focus,
             "next_steps": self._format_policy_steps(action),
             "action": action,
+            "welfare_guardrails": {
+                "welfare_floor": signals["welfare_floor"],
+                "welfare_gap": signals["welfare_gap"],
+                "equity_pressure": signals["equity_pressure"],
+                "welfare_urgency": signals["welfare_urgency"],
+            },
             "energy_dynamics": {
                 "gibbs_reference": gibbs_reference,
                 "gibbs_drive": signals["gibbs_drive"],
@@ -1029,12 +1039,13 @@ class Orchestrator:
             * (1.0 + 0.5 * signals["hamiltonian_pressure"])
             * signals["entropy_damping"]
         )
-        action_budget *= 0.9 + 0.6 * signals["welfare_urgency"]
+        action_budget *= 0.9 + 0.6 * signals["welfare_urgency"] + 0.3 * signals["equity_pressure"]
         alignment_budget = (
             action_budget
             * (1.0 + 0.8 * signals["entropy_pressure"])
             / max(0.6, signals["entropy_damping"])
         )
+        alignment_budget *= 1.0 + 0.6 * signals["equity_pressure"]
         stability_guard = signals["stability_guard"]
         energy_action = action_budget * (0.8 + 0.4 * signals["coordination_damping"]) * stability_guard
         stability_modifier = 0.7 + 0.6 * signals["stability_index"]
@@ -1061,6 +1072,7 @@ class Orchestrator:
             * (0.6 + 0.4 * signals["welfare_urgency"])
             * (0.7 + 0.3 * signals["stability_index"])
             * (0.7 + 0.6 * signals["pareto_gap"])
+            * (0.7 + 0.3 * signals["equity_pressure"])
             * (1.0 + (1.0 - stability_guard))
         )
         exergy_recovery = (

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_policy_brief.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_policy_brief.py
@@ -30,5 +30,9 @@ def test_insight_payload_includes_policy_brief() -> None:
     brief = payload["policy_brief"]
     assert isinstance(brief["next_steps"], list)
     assert brief["next_steps"]
+    assert brief["welfare_guardrails"]["welfare_floor"] == min(
+        state.prosperity_index, state.sustainability_index
+    )
+    assert brief["welfare_guardrails"]["welfare_gap"] >= 0.0
     assert brief["energy_dynamics"]["gibbs_reference"] == state.gibbs_free_energy
     assert brief["game_theory_snapshot"]["nash_welfare"] == state.nash_welfare

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
@@ -131,6 +131,41 @@ def test_policy_action_accounts_for_sentient_welfare() -> None:
     assert low_action["green_shift"] >= high_action["green_shift"]
 
 
+def test_policy_action_escalates_for_low_welfare_floor() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
+    low_floor_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.6,
+        sustainability_index=0.3,
+        nash_welfare=0.42,
+        sentient_welfare_index=0.45,
+        free_energy=0.2,
+        entropy=0.2,
+        hamiltonian=-0.1,
+        coordination_index=0.6,
+        game_theory_slack=0.6,
+        stability_index=0.6,
+    )
+    high_floor_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.6,
+        sustainability_index=0.6,
+        nash_welfare=0.6,
+        sentient_welfare_index=0.6,
+        free_energy=0.2,
+        entropy=0.2,
+        hamiltonian=-0.1,
+        coordination_index=0.6,
+        game_theory_slack=0.6,
+        stability_index=0.6,
+    )
+
+    low_action = orchestrator._build_policy_action(low_floor_state)
+    high_action = orchestrator._build_policy_action(high_floor_state)
+
+    assert low_action["alignment_investment"] >= high_action["alignment_investment"]
+
+
 def test_policy_action_invests_in_alignment_for_coordination_gap() -> None:
     orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
     low_coordination_state = SimulationState(


### PR DESCRIPTION
### Motivation
- Improve the demo's policy engine to explicitly account for welfare and equity when deriving planetary-scale actions using thermodynamic and game-theory signals. 
- Make policy decisions more socially-aware by surfacing welfare guardrails so automated actions better balance prosperity, sustainability and sentient welfare. 

### Description
- Added `welfare_gap` and `equity_pressure` signals in `_compute_policy_signals` and included them in the returned signals dictionary in `orchestrator.py`. 
- Scaled `action_budget` and `alignment_budget` using `equity_pressure`, and incorporated it into the `alignment_investment` multiplier so alignment spending responds to welfare/equity pressure. 
- Exposed a `welfare_guardrails` section in `_build_policy_brief` containing `welfare_floor`, `welfare_gap`, `equity_pressure`, and `welfare_urgency`. 
- Added unit test coverage (updated `test_policy_brief.py` and `test_simulation_actions.py`) to validate the new guardrails and behavior under low welfare-floor conditions. 

### Testing
- Ran the full demo test runner via `python demo/run_demo_tests.py`, which completed successfully (all demo suites passed). 
- Ran the modified demo's unit tests with `python -m pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests`, resulting in `20 passed` tests. 
- The targeted tests for the updated behavior (`test_policy_brief.py` and `test_simulation_actions.py`) passed as part of the above runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695522b95fb88333befc25c172459785)