### PR TITLE
Allow zero-latency shards in Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -1590,8 +1590,8 @@ function validateFabric(fabric) {
     if (typeof shard.id !== 'string' || shard.id.trim() === '') {
       throw new Error(`Shard #${idx} is missing an id.`);
     }
-    if (!Number.isFinite(shard.latencyMs) || shard.latencyMs <= 0) {
-      throw new Error(`Shard ${shard.id} latencyMs must be positive.`);
+    if (!Number.isFinite(shard.latencyMs) || shard.latencyMs < 0) {
+      throw new Error(`Shard ${shard.id} latencyMs must be non-negative.`);
     }
   });
 

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -68,6 +68,44 @@ def test_run_demo_check_mode_with_config_root(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
+def test_run_demo_accepts_zero_latency_shards(tmp_path: Path) -> None:
+    """The demo should allow local shards that declare zero latency."""
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+
+    for filename in (
+        "fabric.json",
+        "energy-feeds.json",
+        "kardashev-ii.manifest.json",
+        "task-lattice.json",
+    ):
+        shutil.copy(DEMO_ROOT / "config" / filename, config_dir / filename)
+
+    fabric_path = config_dir / "fabric.json"
+    fabric_payload = json.loads(fabric_path.read_text())
+    fabric_payload["shards"][0]["latencyMs"] = 0
+    fabric_path.write_text(json.dumps(fabric_payload, indent=2))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PYTHON_ENTRYPOINT),
+            "--output-dir",
+            str(tmp_path / "output"),
+            "--config-root",
+            str(tmp_path),
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "validated (check mode)" in result.stdout
+
+
+@pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
 def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     """Running without --check should emit the expected report artefacts."""
 


### PR DESCRIPTION
### Motivation

- The demo's fabric validation required strictly positive `latencyMs`, which rejected legitimate local/zero-latency shard configurations.
- Allowing non-negative latency enables testing and running the demo with local shards and improves realism for on-host simulations.
- Add a regression to ensure future changes don't reintroduce the strict-positive requirement.

### Description

- Relaxed the fabric shard validation to accept non-negative `latencyMs` by changing the check to disallow negative values only (`latencyMs < 0`).
- Added `test_run_demo_accepts_zero_latency_shards` to `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` which copies the demo config, sets a shard's `latencyMs` to `0`, and runs the Python wrapper in `--check` mode.
- Kept behavior and outputs unchanged for normal runs; the change is narrowly scoped to validation.

### Testing

- Ran `python -m pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` and the suite completed with `12 passed`.
- The new regression test (`test_run_demo_accepts_zero_latency_shards`) executed successfully as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955411545f48333aa5e474e23b0f260)