### PR TITLE
Add replicator stability guardrails and surface replicator metrics in Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -1900,6 +1900,15 @@ function buildEquilibriumLedger({
   if (allocationPolicy.deviationIncentive > 0.2) {
     recommendations.push('Reduce deviation incentives to reinforce Nash equilibrium adherence.');
   }
+  const replicatorStability = Number.isFinite(allocationPolicy.replicatorStability)
+    ? allocationPolicy.replicatorStability
+    : allocationPolicy.strategyStability ?? 0;
+  const replicatorDrift = allocationPolicy.replicatorDrift ?? 0;
+  if (replicatorStability < 0.85 || replicatorDrift > 0.15) {
+    recommendations.push(
+      'Raise replicator stability (≥ 85%) and reduce drift (≤ 0.15) by tightening payoff alignment across shards.'
+    );
+  }
   if ((allocationPolicy.concentrationIndex ?? 0) > (allocationPolicy.diversificationTarget ?? DIVERSIFICATION_TARGET_HHI)) {
     recommendations.push('Reduce allocation concentration by broadening energy weights across shards.');
   }
@@ -2107,6 +2116,8 @@ function buildEquilibriumLedger({
       nashProduct: round(allocationPolicy.nashProduct, 4),
       logisticsNashWelfare: round(logisticsNashWelfare, 4),
       coalitionStability: round(sentientWelfare.coalitionStability, 4),
+      replicatorStability: round(allocationPolicy.replicatorStability ?? 0, 4),
+      replicatorDrift: round(allocationPolicy.replicatorDrift ?? 0, 4),
     },
     pathways,
     actionPath: prioritizedActionPath,
@@ -2170,6 +2181,12 @@ function buildActionPathBriefing(equilibriumLedger) {
     `- Hamiltonian stability: ${formatPercentValue(thermodynamics.hamiltonianStability)}`
   );
   lines.push(`- Nash product: ${formatPercentValue(gameTheory.nashProduct)}`);
+  lines.push(
+    `- Replicator stability: ${formatPercentValue(gameTheory.replicatorStability)} (drift ${formatFixedValue(
+      gameTheory.replicatorDrift,
+      3
+    )})`
+  );
   lines.push(
     `- Coalition stability: ${formatPercentValue(gameTheory.coalitionStability)}`
   );
@@ -2268,17 +2285,26 @@ function buildEquilibriumActionPath({
       'Shift energy-intensive programmes, stretch critical-path timelines, and lower risk exposure until mission stability clears target.',
   });
 
+  const replicatorDrift = allocationPolicy.replicatorDrift ?? 0;
+  const replicatorStability = Number.isFinite(allocationPolicy.replicatorStability)
+    ? allocationPolicy.replicatorStability
+    : allocationPolicy.strategyStability;
   const deviationNeeds =
-    allocationPolicy.deviationIncentive > 0.2 || allocationPolicy.strategyStability < 0.85;
+    allocationPolicy.deviationIncentive > 0.2 ||
+    allocationPolicy.strategyStability < 0.85 ||
+    replicatorStability < 0.85 ||
+    replicatorDrift > 0.15;
   steps.push({
     key: 'allocation',
     score: scores?.allocation ?? 0,
     title: 'Nash deviation suppression',
     status: deviationNeeds ? 'needs-action' : 'on-track',
-    target: 'Deviation incentive ≤ 20% with strategy stability ≥ 85%.',
+    target: 'Deviation incentive ≤ 20%, strategy stability ≥ 85%, replicator stability ≥ 85%, drift ≤ 0.15.',
     rationale: `Deviation ${(allocationPolicy.deviationIncentive * 100).toFixed(
       1
-    )}% · Nash ${(allocationPolicy.nashProduct * 100).toFixed(1)}%`,
+    )}% · Nash ${(allocationPolicy.nashProduct * 100).toFixed(1)}% · replicator ${(
+      replicatorStability * 100
+    ).toFixed(1)}% · drift ${replicatorDrift.toFixed(3)}`,
     action:
       'Retune reward weights with a Boltzmann temperature drop and align shard payoffs to reduce exploitable gradients.',
   });

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -1717,6 +1717,10 @@ function renderEquilibriumLedger(ledger) {
     `Nash product: ${formatPercent(gameTheory.nashProduct)}`,
     `Coalition stability: ${formatPercent(gameTheory.coalitionStability)}`,
     `Logistics Nash welfare: ${formatPercent(gameTheory.logisticsNashWelfare)}`,
+    `Replicator stability: ${formatPercent(gameTheory.replicatorStability)} · drift ${formatFixed(
+      gameTheory.replicatorDrift,
+      3
+    )}`,
   ];
   gameTheoryItems.forEach((item) => {
     const li = document.createElement("li");


### PR DESCRIPTION
### Motivation
- Strengthen allocation action-path guardrails by accounting for replicator stability and drift to reduce exploitable gradients in shard payoffs.
- Make replicator-level signals observable in the equilibrium ledger so operators can monitor evolutionary drift alongside Nash- and Hamiltonian-based signals.
- Surface replicator metrics in the command-deck UI to give a concise game-theory summary for operators and automated monitoring.

### Description
- Tighten allocation action-path checks to include `replicatorStability` and `replicatorDrift` thresholds when deciding an `allocation` step requires action, and extend the action target and rationale strings accordingly in `run-demo.cjs`.
- Add `replicatorStability` and `replicatorDrift` into the `gameTheory` section of the equilibrium ledger payload produced by `buildEquilibriumLedger` in `run-demo.cjs`.
- Add a summary line for replicator stability and drift to the action-path briefing via `buildActionPathBriefing` in `run-demo.cjs`.
- Surface the new replicator metrics in the dashboard by adding a `Replicator stability · drift` entry to the game-theory panel in `ui/dashboard.js`.

### Testing
- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` and all tests passed (`12 passed`).
- Executed the demo wrapper `python demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py --output-dir demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output` and it generated artefacts successfully with the expected telemetry and ledger fields.
- Loaded the generated dashboard over HTTP and captured a screenshot to validate the new game-theory UI panel rendered the replicator metrics (screenshot artifact produced).
- No automated tests failed as part of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69556d6b91b483338dbcd65e17977005)