### PR TITLE
Fix Kardashev II demo config-root resolution

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -2629,7 +2629,7 @@ function resolveOutputDir(rawOutputDir, demoRoot, { ensure = true } = {}) {
   return dir;
 }
 
-function resolveDemoRoot({ profile, configRoot } = {}) {
+function resolveDemoRoot({ profile } = {}) {
   if (profile) {
     const candidate = path.resolve(__dirname, profile);
     if (fs.existsSync(candidate)) {
@@ -2637,15 +2637,34 @@ function resolveDemoRoot({ profile, configRoot } = {}) {
     }
     throw new Error(`Profile directory not found: ${candidate}`);
   }
-  if (configRoot) {
-    const candidate = normalizePathOverride(configRoot);
-    const resolved = candidate ? path.resolve(candidate) : path.resolve(configRoot);
-    if (fs.existsSync(resolved)) {
-      return resolved;
-    }
+  return __dirname;
+}
+
+function resolveConfigRoot({ configRoot, demoRoot }) {
+  if (!configRoot) {
+    return demoRoot;
+  }
+  const candidate = normalizePathOverride(configRoot);
+  const resolved = candidate ? path.resolve(candidate) : path.resolve(configRoot);
+  if (!fs.existsSync(resolved)) {
     throw new Error(`Config root override not found: ${resolved}`);
   }
-  return __dirname;
+  if (fs.existsSync(path.join(resolved, 'config'))) {
+    return resolved;
+  }
+  const configFiles = [
+    'fabric.json',
+    'energy-feeds.json',
+    'kardashev-ii.manifest.json',
+    'task-lattice.json',
+  ];
+  if (configFiles.some((filename) => fs.existsSync(path.join(resolved, filename)))) {
+    const parent = path.dirname(resolved);
+    if (fs.existsSync(path.join(parent, 'config'))) {
+      return parent;
+    }
+  }
+  return resolved;
 }
 
 function main() {
@@ -2653,8 +2672,10 @@ function main() {
     process.argv.slice(2)
   );
   let demoRoot;
+  let resolvedConfigRoot;
   try {
-    demoRoot = resolveDemoRoot({ profile, configRoot });
+    demoRoot = resolveDemoRoot({ profile });
+    resolvedConfigRoot = resolveConfigRoot({ configRoot, demoRoot });
   } catch (err) {
     console.error('❌ Kardashev configuration root resolution failed.');
     console.error(`   - ${err.message}`);
@@ -2666,14 +2687,26 @@ function main() {
   let manifest;
   let taskLattice;
   try {
-    const fabricPath = resolveConfigPath('KARDASHEV_FABRIC_PATH', 'config/fabric.json', demoRoot);
-    const energyPath = resolveConfigPath('KARDASHEV_ENERGY_FEEDS_PATH', 'config/energy-feeds.json', demoRoot);
+    const fabricPath = resolveConfigPath(
+      'KARDASHEV_FABRIC_PATH',
+      'config/fabric.json',
+      resolvedConfigRoot
+    );
+    const energyPath = resolveConfigPath(
+      'KARDASHEV_ENERGY_FEEDS_PATH',
+      'config/energy-feeds.json',
+      resolvedConfigRoot
+    );
     const manifestPath = resolveConfigPath(
       'KARDASHEV_MANIFEST_PATH',
       'config/kardashev-ii.manifest.json',
-      demoRoot
+      resolvedConfigRoot
     );
-    const taskLatticePath = resolveConfigPath('KARDASHEV_TASK_LATTICE_PATH', 'config/task-lattice.json', demoRoot);
+    const taskLatticePath = resolveConfigPath(
+      'KARDASHEV_TASK_LATTICE_PATH',
+      'config/task-lattice.json',
+      resolvedConfigRoot
+    );
     fabric = loadJson(fabricPath);
     energy = loadJson(energyPath);
     manifest = loadJson(manifestPath);

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -68,6 +68,38 @@ def test_run_demo_check_mode_with_config_root(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
+def test_run_demo_check_mode_with_config_dir(tmp_path: Path) -> None:
+    """The wrapper should accept a direct config directory as the config root."""
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    for filename in (
+        "fabric.json",
+        "energy-feeds.json",
+        "kardashev-ii.manifest.json",
+        "task-lattice.json",
+    ):
+        shutil.copy(DEMO_ROOT / "config" / filename, config_dir / filename)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PYTHON_ENTRYPOINT),
+            "--output-dir",
+            str(tmp_path),
+            "--config-root",
+            str(config_dir),
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "validated (check mode)" in result.stdout
+
+
+@pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
 def test_run_demo_accepts_zero_latency_shards(tmp_path: Path) -> None:
     """The demo should allow local shards that declare zero latency."""
 


### PR DESCRIPTION
### Motivation
- The demo allowed overriding the config root in a way that could break UI asset resolution because the asset root and config root were coupled.  
- Users need to be able to point the demo at a standalone `config/` directory (or a parent project) without losing offline UI generation.  
- Make config-root handling robust for CI and contributor workflows that mount only configuration artifacts.  
- Keep API stable for `--profile` while adding explicit config-root resolution semantics.  

### Description
- Decoupled demo asset root from configuration lookup by simplifying `resolveDemoRoot` and adding a new `resolveConfigRoot` helper in `run-demo.cjs`.  
- `resolveConfigRoot` accepts direct `config/` directories, parent-project layouts, and supports `file:` and `~` path overrides via `normalizePathOverride`.  
- Switched config file resolution calls to use the resolved config root (`resolvedConfigRoot`) while preserving `demoRoot` for UI asset copying and offline dashboard generation.  
- Added a new test `test_run_demo_check_mode_with_config_dir` and updated `tests/test_run_demo.py` to cover direct config-directory overrides.  

### Testing
- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and all tests passed (`13 passed`).  
- Executed the Node demo in check mode with `node run-demo.cjs --check` and observed a successful validation (exit code 0 and expected summary output).  
- Ran the demo CI check via `npm run demo:kardashev -- --check` which completed successfully and reported artefacts up-to-date.  
- Ran `npm run demo:kardashev-ii:ci` earlier during validation and it completed successfully (CI validations passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695597e865a88333aa476274b87223e9)