### PR TITLE
Add equilibrium forecast signals to omega demo telemetry

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -1017,6 +1017,36 @@ class Orchestrator:
             },
         }
 
+    def _build_equilibrium_forecast(self, state: SimulationState) -> Dict[str, float]:
+        """Project a cooperative equilibrium forecast for the next planning window."""
+
+        signals = self._compute_policy_signals(state)
+        gibbs_reference = state.gibbs_free_energy if state.gibbs_free_energy is not None else state.free_energy
+        gibbs_drive = max(0.0, -gibbs_reference)
+        hamiltonian_load = min(1.0, abs(state.hamiltonian))
+        coordination = max(0.0, min(1.0, state.coordination_index))
+        cooperation_target = 0.4 + 0.35 * state.game_theory_slack + 0.25 * coordination
+        cooperation_target = max(0.0, min(1.0, cooperation_target))
+        welfare_gain = (
+            0.08 * gibbs_drive
+            + 0.05 * signals["stability_index"]
+            + 0.04 * signals["coordination_damping"]
+            + 0.03 * signals["pareto_efficiency"]
+            - 0.06 * signals["entropy_pressure"]
+            - 0.04 * hamiltonian_load
+        )
+        forecasted_welfare = max(0.0, min(1.0, state.sentient_welfare_index + welfare_gain))
+        exergy_headroom = 1.0 - max(0.0, signals["exergy_pressure"])
+        risk_budget = max(0.0, min(1.0, signals["stability_guard"] * signals["entropy_damping"]))
+        return {
+            "cooperation_target": cooperation_target,
+            "forecasted_welfare": forecasted_welfare,
+            "gibbs_drive": gibbs_drive,
+            "hamiltonian_load": hamiltonian_load,
+            "exergy_headroom": exergy_headroom,
+            "risk_budget": risk_budget,
+        }
+
     def _build_policy_decision(self, state: SimulationState) -> Dict[str, Dict[str, float] | Dict[str, float | str]]:
         """Derive a cooperative policy action from thermodynamic signals.
 
@@ -1705,6 +1735,7 @@ class Orchestrator:
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,
                 "game_theory_slack": self._latest_simulation_state.game_theory_slack,
+                "equilibrium_forecast": self._build_equilibrium_forecast(self._latest_simulation_state),
             }
         pending_events = list(self.scheduler.pending_events())
         pending_counts = Counter(event.event_type for event in pending_events)
@@ -1797,6 +1828,7 @@ class Orchestrator:
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,
                 "game_theory_slack": self._latest_simulation_state.game_theory_slack,
+                "equilibrium_forecast": self._build_equilibrium_forecast(self._latest_simulation_state),
             }
         return {
             "mission": self.config.mission_name,

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_energy_oracle_snapshot.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_energy_oracle_snapshot.py
@@ -18,3 +18,7 @@ def test_energy_oracle_snapshot_exposes_welfare_metrics() -> None:
     assert simulation is not None
     assert simulation["sentient_welfare_index"] == state.sentient_welfare_index
     assert simulation["nash_welfare"] == state.nash_welfare
+    assert "equilibrium_forecast" in simulation
+    forecast = simulation["equilibrium_forecast"]
+    assert 0.0 <= forecast["forecasted_welfare"] <= 1.0
+    assert 0.0 <= forecast["cooperation_target"] <= 1.0


### PR DESCRIPTION
### Motivation
- Surface a compact cooperative equilibrium forecast derived from thermodynamic and game-theory signals so downstream tools and operators get a clear next-step projection.
- Improve telemetry for the Omega demo to include forecasted welfare and cooperation targets that help guide policy actions.
- Make the demo more informative for research into Gibbs/Hamiltonian-informed policy heuristics without changing runtime behaviour.

### Description
- Add a new `_build_equilibrium_forecast` helper in `orchestrator.py` that computes `cooperation_target`, `forecasted_welfare`, `gibbs_drive`, `hamiltonian_load`, `exergy_headroom`, and `risk_budget` from the `SimulationState` and policy signals.
- Expose the equilibrium forecast in telemetry by attaching `"equilibrium_forecast"` to both the orchestrator status snapshot and the energy oracle snapshot returned by `_collect_status_snapshot` and `_collect_energy_snapshot`.
- Update `demo/.../tests/test_energy_oracle_snapshot.py` to assert the new forecast is present and that its `forecasted_welfare` and `cooperation_target` are in the expected ranges.

### Testing
- The full demo test runner (prior to the patch) completed successfully: all demo suites passed (`42 suites` reported in the run transcript). 
- Ran the focused test for the change with `python -m pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_energy_oracle_snapshot.py"` and it passed (`1 passed`).
- No additional runtime or integration changes were required and the new fields are emitted within existing JSON snapshots for downstream consumers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955a3f143608333b54d5e3b6511a52e)