### PR TITLE
Add composite Hamiltonian stability guidance to Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -14,6 +14,7 @@ const debugEnabled = (process.env.DEBUG || '')
   .includes(DEBUG_TOKEN);
 const DIVERSIFICATION_TARGET_HHI = 0.3;
 const ENERGY_RUNWAY_TARGET_HOURS = 1;
+const HAMILTONIAN_TARGET_STABILITY = 0.9;
 
 function debugLog(section, payload) {
   if (!debugEnabled) {
@@ -1877,6 +1878,10 @@ function buildEquilibriumLedger({
   const missionScore = clamp01(
     0.7 * missionHamiltonian + 0.3 * clamp01(missionHeadroom / 0.05)
   );
+  const compositeHamiltonian = clamp01(
+    (energyMonteCarlo.hamiltonianStability + missionHamiltonian + hamiltonianStability) / 3
+  );
+  const hamiltonianDelta = round(HAMILTONIAN_TARGET_STABILITY - compositeHamiltonian, 4);
 
   const overallScore = clamp01(
     0.25 * energyScore +
@@ -1926,6 +1931,13 @@ function buildEquilibriumLedger({
   }
   if (missionScore < 0.85) {
     recommendations.push('Rebalance mission timelines and energy allocations to raise mission Hamiltonian stability.');
+  }
+  if (compositeHamiltonian < HAMILTONIAN_TARGET_STABILITY) {
+    recommendations.push(
+      `Lift composite Hamiltonian stability by ${(hamiltonianDelta * 100).toFixed(
+        1
+      )}% using reserve buffers, mission slack, and logistics entropy smoothing.`
+    );
   }
 
   const actionPath = buildEquilibriumActionPath({
@@ -2110,6 +2122,9 @@ function buildEquilibriumLedger({
       gibbsFreeEnergyGj: round(energyMonteCarlo.gibbsFreeEnergyGj, 2),
       entropyMargin: round(energyMonteCarlo.entropyMargin, 4),
       hamiltonianStability: round(energyMonteCarlo.hamiltonianStability, 4),
+      hamiltonianComposite: round(compositeHamiltonian, 4),
+      hamiltonianTarget: HAMILTONIAN_TARGET_STABILITY,
+      hamiltonianDelta,
       runwayAdjustment: runwayAdjustmentSummary,
     },
     gameTheory: {
@@ -2180,6 +2195,16 @@ function buildActionPathBriefing(equilibriumLedger) {
   lines.push(
     `- Hamiltonian stability: ${formatPercentValue(thermodynamics.hamiltonianStability)}`
   );
+  if (Number.isFinite(thermodynamics.hamiltonianComposite)) {
+    const delta = thermodynamics.hamiltonianDelta ?? 0;
+    const deltaText =
+      delta > 0 ? ` (Δ ${(delta * 100).toFixed(1)}% to target)` : ' (target met)';
+    lines.push(
+      `- Composite Hamiltonian stability: ${formatPercentValue(
+        thermodynamics.hamiltonianComposite
+      )}${deltaText}`
+    );
+  }
   lines.push(`- Nash product: ${formatPercentValue(gameTheory.nashProduct)}`);
   lines.push(
     `- Replicator stability: ${formatPercentValue(gameTheory.replicatorStability)} (drift ${formatFixedValue(

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -176,6 +176,8 @@ function applyStatus(element, status) {
 function renderGlobalFailure(message) {
   const main = document.querySelector("main");
   if (!main) return;
+  const detail =
+    message instanceof Error ? message.message : typeof message === "string" ? message : JSON.stringify(message);
 
   const alert = document.createElement("section");
   alert.classList.add("card", "status-fail");
@@ -183,7 +185,7 @@ function renderGlobalFailure(message) {
     <div class="section-title">
       <h2>Telemetry unavailable</h2>
     </div>
-    <p class="lede">${message}</p>
+    <p class="lede">${detail}</p>
     <p class="lede">Regenerate artefacts with <code>npm run demo:kardashev-ii:orchestrate</code> and refresh the dashboard.</p>
   `;
 
@@ -1682,6 +1684,11 @@ function renderEquilibriumLedger(ledger) {
     `Gibbs free energy: ${formatFixed(thermodynamics.gibbsFreeEnergyGj, 2)} GJ`,
     `Entropy buffer: ${formatFixed(thermodynamics.entropyMargin, 2)}σ`,
     `Hamiltonian stability: ${formatPercent(thermodynamics.hamiltonianStability)}`,
+    Number.isFinite(thermodynamics.hamiltonianComposite)
+      ? `Composite Hamiltonian stability: ${formatPercent(thermodynamics.hamiltonianComposite)}${Number.isFinite(
+          thermodynamics.hamiltonianDelta
+        ) ? ` (Δ ${(thermodynamics.hamiltonianDelta * 100).toFixed(1)}% to target)` : ""}`
+      : null,
   ];
   if (thermodynamics.runwayAdjustment?.perFeedBoosts?.length) {
     const boosts = thermodynamics.runwayAdjustment.perFeedBoosts
@@ -1700,7 +1707,7 @@ function renderEquilibriumLedger(ledger) {
       : "Runway adjustment plan";
     thermoItems.push(`${planLabel}: ${boosts} (total +${total} GW)`);
   }
-  thermoItems.forEach((item) => {
+  thermoItems.filter(Boolean).forEach((item) => {
     const li = document.createElement("li");
     li.textContent = item;
     li.classList.add(


### PR DESCRIPTION
### Motivation

- Provide a concise thermodynamic target that combines energy, mission and logistics Hamiltonian signals to make corrective actions actionable.
- Surface a single composite Hamiltonian metric so operators can reason about Gibbs/Hamiltonian stability and game-theoretic slack in one place.
- Improve dashboard diagnostics so telemetry-loading failures render a clearer error message for local/offline use.

### Description

- Compute a `compositeHamiltonian` and `hamiltonianDelta` toward a new `HAMILTONIAN_TARGET_STABILITY` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` and include them in the equilibrium telemetry payload. 
- Add a recommendation to the equilibrium `recommendations` when the composite Hamiltonian is below target and surface the composite value in the action path briefing via `buildActionPathBriefing`.
- Update `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js` to show `Composite Hamiltonian stability` (and the delta to target) in the equilibrium thermodynamics list and to improve `renderGlobalFailure` message formatting.
- Tidy UI list rendering by filtering falsy thermal items so the dashboard avoids rendering `null` entries.

### Testing

- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and all collected tests passed (13 passed).
- The modified demo wrapper was exercised end-to-end during generation and the dashboard assets were exercised via a local HTTP serve and headless browser capture (no automated failures observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955ae496d888333a2e3251ffe62a703)