### PR TITLE
Include equilibrium forecast in Kardashev‑II policy brief

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -989,11 +989,13 @@ class Orchestrator:
         if not isinstance(action, dict):
             action = {}
         gibbs_reference = state.gibbs_free_energy if state.gibbs_free_energy is not None else state.free_energy
+        equilibrium_forecast = self._build_equilibrium_forecast(state)
         focus = "energy_expansion" if signals["gibbs_drive"] > 0.35 else "stability_balancing"
         return {
             "focus": focus,
             "next_steps": self._format_policy_steps(action),
             "action": action,
+            "equilibrium_forecast": equilibrium_forecast,
             "welfare_guardrails": {
                 "welfare_floor": signals["welfare_floor"],
                 "welfare_gap": signals["welfare_gap"],

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_policy_brief.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_policy_brief.py
@@ -30,6 +30,8 @@ def test_insight_payload_includes_policy_brief() -> None:
     brief = payload["policy_brief"]
     assert isinstance(brief["next_steps"], list)
     assert brief["next_steps"]
+    assert "equilibrium_forecast" in brief
+    assert brief["equilibrium_forecast"]["cooperation_target"] >= 0.0
     assert brief["welfare_guardrails"]["welfare_floor"] == min(
         state.prosperity_index, state.sustainability_index
     )


### PR DESCRIPTION
### Motivation
- Surface a short-term equilibrium forecast in operator policy briefs so dashboards receive forward-looking coordination metrics for planning.
- Improve observability of thermodynamic and game‑theoretic signals used by autonomous policy actions to support safer operator decisions.
- Make the policy brief payload self-contained for UI consumption and downstream analytics.

### Description
- Call `self._build_equilibrium_forecast(state)` inside `_build_policy_brief` and attach the returned `equilibrium_forecast` to the brief payload.
- Update the policy brief test to assert the `equilibrium_forecast` field is present and its `cooperation_target` is non‑negative.
- Modified files: `demo/.../orchestrator.py` and `demo/.../tests/test_policy_brief.py`.

### Testing
- Ran the demo test runner with `python demo/run_demo_tests.py` and observed all demo suites pass (42 suites, all passed).
- Ran the focused unit test with `python -m pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_policy_brief.py` and it passed.
- No automated tests failed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955bb5f1b348333b950b76a9d5dfbf2)