### PR TITLE
Guard Phase-8 Playwright installs when apt/downloads are unreachable

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import time
 import ctypes.util
+import socket
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
@@ -237,17 +238,28 @@ def _run_suite(
             # failing outright on locked-down runners.
             user_pref = user_playwright_pref
             if user_pref is None:
-                if _can_install_playwright_deps() and not _playwright_system_deps_ready():
+                can_install_deps = _can_install_playwright_deps()
+                deps_ready = _playwright_system_deps_ready()
+                apt_reachable = _apt_repos_reachable() if can_install_deps else False
+                if can_install_deps and apt_reachable and not deps_ready:
                     env["PLAYWRIGHT_INSTALL_WITH_DEPS"] = "1"
                 else:
                     env["PLAYWRIGHT_INSTALL_WITH_DEPS"] = "0"
-                    if not _playwright_system_deps_ready():
+                    if not deps_ready:
                         env.setdefault("PLAYWRIGHT_OPTIONAL_E2E", "1")
             else:
                 env["PLAYWRIGHT_INSTALL_WITH_DEPS"] = user_pref
                 if user_pref == "0" and not _playwright_system_deps_ready():
                     env.setdefault("PLAYWRIGHT_OPTIONAL_E2E", "1")
             env.setdefault("PLAYWRIGHT_OPTIONAL_E2E_ON_FAILURE", "1")
+            if (
+                user_pref is None
+                and not _playwright_cache_ready(env)
+                and not _playwright_downloads_reachable()
+            ):
+                env.setdefault("PLAYWRIGHT_AUTO_INSTALL", "0")
+                env.setdefault("PLAYWRIGHT_OPTIONAL_E2E", "1")
+                env["PLAYWRIGHT_INSTALL_WITH_DEPS"] = "0"
         binary = suite.runner
         cmd = [binary, "test", *_node_runner_args(suite.demo_root)]
         description = f"{suite.tests_dir} via {binary} test"
@@ -617,6 +629,54 @@ _PLAYWRIGHT_LIB_PATHS = (
     Path("/usr/lib/x86_64-linux-gnu/libatk-1.0.so.0"),
     Path("/usr/lib/x86_64-linux-gnu/libgtk-3.so.0"),
 )
+_PLAYWRIGHT_DOWNLOAD_HOSTS = (
+    "cdn.playwright.dev",
+    "playwright.download.prss.microsoft.com",
+)
+
+
+def _playwright_downloads_reachable() -> bool:
+    """Return True when Playwright download hosts resolve in DNS.
+
+    The Phase-8 demo can auto-install browsers. In sandboxed environments the
+    DNS resolution fails, which turns the install step into a long, noisy
+    failure. A lightweight probe lets us skip auto-install when downloads are
+    clearly unreachable.
+    """
+
+    try:
+        for host in _PLAYWRIGHT_DOWNLOAD_HOSTS:
+            socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+    except OSError:
+        return False
+    return True
+
+
+def _apt_repos_reachable(timeout: float = 3.0) -> bool:
+    """Return True when apt repositories can be reached without errors."""
+
+    if not sys.platform.startswith("linux"):
+        return False
+
+    codename = "noble"
+    try:
+        codename = platform.freedesktop_os_release().get("VERSION_CODENAME", codename)
+    except OSError:
+        pass
+
+    urls = [
+        f"http://archive.ubuntu.com/ubuntu/dists/{codename}/InRelease",
+        f"http://security.ubuntu.com/ubuntu/dists/{codename}-security/InRelease",
+    ]
+    for url in urls:
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as response:
+                if response.status < 400:
+                    return True
+        except (urllib.error.URLError, ValueError):
+            continue
+
+    return False
 
 
 def _playwright_system_deps_ready() -> bool:


### PR DESCRIPTION
### Motivation
- Prevent noisy, slow, or failing Playwright browser installation attempts when running the Phase-8 demo in constrained or offline environments. 
- Keep end-to-end tests optional in hosts that cannot reach apt repositories or Playwright download hosts while preserving full e2e behavior when the environment supports it. 
- Reduce flakiness and long timeouts caused by automatic `playwright` installs in CI-like, sandboxed runners. 

### Description
- Add a DNS probe `_playwright_downloads_reachable()` that checks Playwright download hosts via `socket.getaddrinfo`. 
- Add an HTTP probe `_apt_repos_reachable()` that verifies apt repositories are reachable before attempting `--with-deps` installs. 
- Change Phase-8 demo environment logic to prefer installing system deps only when apt is reachable and system deps are missing, and to disable `PLAYWRIGHT_AUTO_INSTALL` and enable `PLAYWRIGHT_OPTIONAL_E2E` when downloads or apt are unreachable. 
- Import `socket` and wire the probes into the existing Playwright/setup flow in `demo/run_demo_tests.py`. 

### Testing
- Ran `python demo/run_demo_tests.py --demo Phase-8-Universal-Value-Dominance --fail-fast` and the Phase-8 unit suites completed successfully with Playwright e2e skipped when the environment could not download browsers. 
- The modified demo test runner was exercised end-to-end and reported: "✅ All demo test suites passed" for the targeted Phase-8 runs. 
- Existing unit and integration demo suites (Phase-8 scripts/tests) continued to pass under the guarded behavior. 
- No new failing automated tests were introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e350aa248333befb4b2826fac758)