### PR TITLE
Harden Playwright dependency detection for Phase-8 demo tests

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
@@ -226,13 +226,17 @@ describe('canInstallPlaywrightDeps', () => {
 
   test('returns true on linux when apt-get and sudo are available for non-root users', () => {
     const { canInstallPlaywrightDeps } = require('../run-tests.js');
-    spawnSync.mockReturnValueOnce({ status: 0 }).mockReturnValueOnce({ status: 0 });
+    spawnSync
+      .mockReturnValueOnce({ status: 0 })
+      .mockReturnValueOnce({ status: 0 })
+      .mockReturnValueOnce({ status: 0 });
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
     Object.defineProperty(process, 'getuid', { value: () => 1000, configurable: true });
 
     expect(canInstallPlaywrightDeps()).toBe(true);
     expect(spawnSync).toHaveBeenNthCalledWith(1, 'which', ['apt-get'], { stdio: 'ignore' });
     expect(spawnSync).toHaveBeenNthCalledWith(2, 'which', ['sudo'], { stdio: 'ignore' });
+    expect(spawnSync).toHaveBeenNthCalledWith(3, 'sudo', ['-n', 'true'], { stdio: 'ignore' });
   });
 
   test('returns false when apt-get is unavailable', () => {
@@ -253,6 +257,21 @@ describe('canInstallPlaywrightDeps', () => {
 
     expect(canInstallPlaywrightDeps()).toBe(false);
     expect(spawnSync).toHaveBeenCalledWith('which', ['sudo'], { stdio: 'ignore' });
+  });
+
+  test('returns false when sudo exists but requires a password', () => {
+    const { canInstallPlaywrightDeps } = require('../run-tests.js');
+    spawnSync
+      .mockReturnValueOnce({ status: 0 })
+      .mockReturnValueOnce({ status: 0 })
+      .mockReturnValueOnce({ status: 1 });
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    Object.defineProperty(process, 'getuid', { value: () => 1000, configurable: true });
+
+    expect(canInstallPlaywrightDeps()).toBe(false);
+    expect(spawnSync).toHaveBeenNthCalledWith(1, 'which', ['apt-get'], { stdio: 'ignore' });
+    expect(spawnSync).toHaveBeenNthCalledWith(2, 'which', ['sudo'], { stdio: 'ignore' });
+    expect(spawnSync).toHaveBeenNthCalledWith(3, 'sudo', ['-n', 'true'], { stdio: 'ignore' });
   });
 
   test('returns false on non-linux platforms', () => {

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js
@@ -121,7 +121,9 @@ function canInstallPlaywrightDeps() {
   // Avoid triggering sudo prompts (or immediate failures) in non-interactive
   // environments by confirming privilege escalation is available before asking
   // Playwright to install system packages.
-  return hasBinary('sudo');
+  if (!hasBinary('sudo')) return false;
+  const sudoProbe = spawnSync('sudo', ['-n', 'true'], { stdio: 'ignore' });
+  return sudoProbe.status === 0;
 }
 
 function ensureChromiumAvailable({


### PR DESCRIPTION
### Motivation

- Avoid attempting to install Playwright system packages on hosts where `sudo` is present but requires a password, which can hang or fail CI runs.  
- Make the Phase-8 demo runner more robust in constrained/non-interactive environments by probing for non-interactive `sudo` capability.  
- Add unit coverage to codify the expected probing behaviour and prevent regressions.  

### Description

- Change `canInstallPlaywrightDeps` in `demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js` to require a passwordless `sudo` by executing `spawnSync('sudo', ['-n', 'true'], { stdio: 'ignore' })` and returning true only when that probe exits `0`.  
- Preserve earlier checks for platform and `apt-get`, and keep root users allowed to install without probing `sudo`.  
- Update `demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts` to mock the extra `spawnSync` probe and add a test covering the case where `sudo` exists but requires a password.  
- Commit includes the two updated files implementing the hardened detection and tests.  

### Testing

- Ran the Phase-8 JavaScript unit suite with `npm run test:unit -- --runInBand` and all tests passed (`51 passed, 4 snapshots`), indicating the new probe and tests behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69567af58cd48333bb22ab70d1fcb525)