### PR TITLE
Add policy snapshot to status telemetry for omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -405,7 +405,7 @@ class Orchestrator:
             return payload
         state = self._latest_simulation_state
         signals = self._compute_policy_signals(state)
-        decision = self._build_policy_decision(state)
+        decision = self._build_policy_decision(state, signals=signals)
         if signals["gibbs_drive"] > 0.35 and signals["stability_guard"] > 0.6:
             strategy_priority = "energy_expansion"
             strategy_path = (
@@ -1049,7 +1049,12 @@ class Orchestrator:
             "risk_budget": risk_budget,
         }
 
-    def _build_policy_decision(self, state: SimulationState) -> Dict[str, Dict[str, float] | Dict[str, float | str]]:
+    def _build_policy_decision(
+        self,
+        state: SimulationState,
+        *,
+        signals: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, Dict[str, float] | Dict[str, float | str]]:
         """Derive a cooperative policy action from thermodynamic signals.
 
         We use a Nash-style bargaining split between prosperity and sustainability
@@ -1059,7 +1064,7 @@ class Orchestrator:
         Kardashev-II scaling dynamics.
         """
 
-        signals = self._compute_policy_signals(state)
+        signals = signals or self._compute_policy_signals(state)
         action_budget = (
             1.5
             + 3.0 * signals["energy_price_pressure"]
@@ -1137,6 +1142,16 @@ class Orchestrator:
             },
         )
         return {"action": normalized_action, "rationale": rationale}
+
+    def _build_policy_snapshot(self, state: SimulationState) -> Dict[str, Any]:
+        signals = self._compute_policy_signals(state)
+        decision = self._build_policy_decision(state, signals=signals)
+        return {
+            "recommendation": decision["action"],
+            "rationale": decision["rationale"],
+            "brief": self._build_policy_brief(state, decision, signals),
+            "signals": signals,
+        }
 
     def _build_policy_action(self, state: SimulationState) -> Dict[str, float]:
         return self._build_policy_decision(state)["action"]
@@ -1718,6 +1733,7 @@ class Orchestrator:
         accounts = self.resources.to_serializable()
         governance = self.governance.params
         simulation_state: Optional[Dict[str, float]] = None
+        policy_snapshot: Optional[Dict[str, Any]] = None
         if self._latest_simulation_state is not None:
             simulation_state = {
                 "energy_output_gw": self._latest_simulation_state.energy_output_gw,
@@ -1739,6 +1755,7 @@ class Orchestrator:
                 "game_theory_slack": self._latest_simulation_state.game_theory_slack,
                 "equilibrium_forecast": self._build_equilibrium_forecast(self._latest_simulation_state),
             }
+            policy_snapshot = self._build_policy_snapshot(self._latest_simulation_state)
         pending_events = list(self.scheduler.pending_events())
         pending_counts = Counter(event.event_type for event in pending_events)
         next_event = self.scheduler.peek_next()
@@ -1796,6 +1813,7 @@ class Orchestrator:
                 "auto_actions_enabled": self.config.auto_policy_actions,
                 "action_interval_seconds": self.config.policy_action_interval_seconds,
                 "last_action": self._last_simulation_action,
+                "snapshot": policy_snapshot,
             },
             "scheduler": {
                 "pending_events": len(pending_events),

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_policy_brief.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_policy_brief.py
@@ -38,3 +38,29 @@ def test_insight_payload_includes_policy_brief() -> None:
     assert brief["welfare_guardrails"]["welfare_gap"] >= 0.0
     assert brief["energy_dynamics"]["gibbs_reference"] == state.gibbs_free_energy
     assert brief["game_theory_snapshot"]["nash_welfare"] == state.nash_welfare
+
+
+def test_status_snapshot_includes_policy_snapshot() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=False))
+    state = SimulationState(
+        energy_output_gw=420_000.0,
+        prosperity_index=0.62,
+        sustainability_index=0.57,
+        nash_welfare=0.58,
+        sentient_welfare_index=0.6,
+        free_energy=0.12,
+        gibbs_free_energy=-0.08,
+        entropy=0.25,
+        hamiltonian=-0.15,
+        coordination_index=0.78,
+        game_theory_slack=0.54,
+        stability_index=0.7,
+    )
+    orchestrator._latest_simulation_state = state
+
+    snapshot = orchestrator._collect_status_snapshot()
+
+    policy_snapshot = snapshot["policy"]["snapshot"]
+    assert policy_snapshot is not None
+    assert policy_snapshot["brief"]["energy_dynamics"]["gibbs_reference"] == state.gibbs_free_energy
+    assert policy_snapshot["brief"]["game_theory_snapshot"]["nash_welfare"] == state.nash_welfare


### PR DESCRIPTION
### Motivation

- Enrich operator-facing status telemetry with policy signals, rationale, and brief so decisions are auditable and actionable.
- Avoid redundant computation by reusing computed policy signals when generating insight payloads.
- Provide a compact snapshot of autonomous policy decisions alongside simulation state for monitoring and downstream tooling.

### Description

- Reused computed signals in `_build_insight_payload` by passing `signals` into `_build_policy_decision` to avoid recomputing policy signals.
- Extended `_build_policy_decision` to accept an optional `signals` argument and kept backward-compatible behavior.
- Added `_build_policy_snapshot` which returns `recommendation`, `rationale`, `brief`, and `signals`, and included this snapshot in the status payload under `policy.snapshot` in `_collect_status_snapshot`.
- Added `test_status_snapshot_includes_policy_snapshot` to `tests/test_policy_brief.py` to assert the policy snapshot appears in status outputs and contains the expected fields.

### Testing

- ✅ Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests` and all tests passed (`21 passed`).
- ⚠️ Ran the broader `python demo/run_demo_tests.py` orchestration script; it executed many suites successfully but was interrupted after 23 of 42 suites (partial run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a6a855208333bc5148b458de709e)