### PR TITLE
Add shard thermodynamic ledger to Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -851,6 +851,50 @@ function computeAllocationPolicy(shardMetrics, energyMonteCarlo) {
   };
 }
 
+function buildShardThermodynamics({
+  shardMetrics,
+  allocationPolicy,
+  energyFeeds,
+}) {
+  const allocationByShard = new Map(
+    (allocationPolicy?.allocations ?? []).map((allocation) => [
+      allocation.shardId,
+      allocation,
+    ])
+  );
+  return shardMetrics.map((metric) => {
+    const feed = resolveEnergyFeedForShard({ id: metric.shardId }, energyFeeds);
+    const nominalGw = feed ? Math.max(0, (feed.nominalMw ?? 0) / 1000) : 0;
+    const bufferGw = feed ? Math.max(0, (feed.bufferMw ?? 0) / 1000) : 0;
+    const availableGw = nominalGw + bufferGw;
+    const utilisationRatio = clamp01((metric.utilisation ?? 0) / 100);
+    const freeEnergyMarginGw = Math.max(0, availableGw * (1 - utilisationRatio));
+    const gibbsFreeEnergyGj = freeEnergyMarginGw * 3600;
+    const allocation = allocationByShard.get(metric.shardId);
+    const allocationWeight = allocation?.effectiveWeight ?? allocation?.weight ?? 0;
+    const payoff = allocation?.payoff ?? 0;
+    const resilience = clamp01(metric.resilience ?? 0);
+    const hamiltonianStability = clamp01(
+      0.5 * (1 - utilisationRatio) + 0.3 * resilience + 0.2 * allocationWeight
+    );
+    const gameTheorySlack = clamp01(0.6 * (1 - utilisationRatio) + 0.4 * payoff);
+    const entropyContribution =
+      allocationWeight > 0 ? -allocationWeight * Math.log(allocationWeight) : 0;
+    return {
+      shardId: metric.shardId,
+      region: feed?.region ?? null,
+      availableGw,
+      freeEnergyMarginGw,
+      gibbsFreeEnergyGj,
+      allocationWeight,
+      payoff,
+      hamiltonianStability,
+      gameTheorySlack,
+      entropyContribution,
+    };
+  });
+}
+
 function average(values) {
   if (!values.length) {
     return 0;
@@ -2773,6 +2817,11 @@ function main() {
     shardMetrics,
     calibratedEnergy
   );
+  const shardThermodynamics = buildShardThermodynamics({
+    shardMetrics,
+    allocationPolicy,
+    energyFeeds: calibratedEnergy.feeds,
+  });
   const generatedAt = new Date(
     Date.UTC(2125, 0, 1) + Math.floor(rng() * 86_400_000)
   ).toISOString();
@@ -3005,6 +3054,30 @@ function main() {
   );
   reportLines.push('');
 
+  reportLines.push('## Shard Thermodynamic Ledger');
+  reportLines.push('');
+  reportLines.push(
+    toTable(
+      shardThermodynamics.map((entry) => [
+        entry.shardId,
+        entry.region ?? 'unknown',
+        formatNumber(round(entry.freeEnergyMarginGw, 2)),
+        formatNumber(round(entry.gibbsFreeEnergyGj, 2)),
+        `${round(entry.hamiltonianStability * 100, 1)}%`,
+        `${round(entry.gameTheorySlack * 100, 1)}%`,
+      ]),
+      [
+        'Shard',
+        'Region',
+        'Free Energy GW',
+        'Gibbs Free Energy GJ',
+        'Hamiltonian Stability',
+        'Game-Theory Slack',
+      ]
+    )
+  );
+  reportLines.push('');
+
   reportLines.push('## Thermodynamic Allocation Policy');
   reportLines.push('');
   reportLines.push(
@@ -3097,6 +3170,7 @@ function main() {
     dominanceScore,
     dominance,
     shards: shardMetrics,
+    shardThermodynamics,
     sentinelFindings,
     dyson,
     energyMonteCarlo,

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -218,6 +218,14 @@ def test_run_demo_produces_outputs(tmp_path: Path) -> None:
     assert 0 < allocation["fairnessIndex"] <= 1
     assert allocation["gibbsPotential"] <= 0
     assert 0 <= allocation["strategyStability"] <= 1
+
+    shard_thermo = telemetry_payload["shardThermodynamics"]
+    assert len(shard_thermo) == len(telemetry_payload["shards"])
+    for entry in shard_thermo:
+        assert entry["freeEnergyMarginGw"] >= 0
+        assert entry["gibbsFreeEnergyGj"] >= 0
+        assert 0 <= entry["hamiltonianStability"] <= 1
+        assert 0 <= entry["gameTheorySlack"] <= 1
     assert 0 <= allocation["deviationIncentive"] <= 1
     assert 0 <= allocation["jainIndex"] <= 1
     assert allocation["concentrationIndex"] <= allocation["diversificationTarget"]


### PR DESCRIPTION
### Motivation
- Surface per-shard thermodynamic metrics (free energy, Gibbs free energy, Hamiltonian stability, game-theory slack) to make allocation decisions and operator reports more physically-grounded.
- Expose thermodynamic and game-theoretic observables in telemetry so downstream tooling can reason about stability and risk at shard granularity.
- Keep the Kardashev II demo self-contained and CI-friendly by computing the ledger inside the existing Node demo flow.

### Description
- Add `buildShardThermodynamics` which computes per-shard `freeEnergyMarginGw`, `gibbsFreeEnergyGj`, `hamiltonianStability`, `gameTheorySlack`, `allocationWeight`, and `entropyContribution` using shard metrics, allocation policy, and energy feeds. 
- Wire `shardThermodynamics` into the main run flow (computed after allocation) and include it in the `telemetry` payload and the generated Markdown report under a new "Shard Thermodynamic Ledger" table. 
- Add assertions in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` to validate the presence and value ranges of the new thermodynamic fields. 

### Testing
- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` and the suite completed with all tests passing (13 passed). 
- The demo wrapper `python demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py` was executed as part of earlier validation and produces the expected telemetry and report artefacts. 
- Existing demo CI test harnesses were run during development and the modified suite passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c46cef248333994b7d62f77903ff)