### PR TITLE
Validate unique energy feed identifiers in Kardashev II demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -1581,10 +1581,34 @@ function validateEnergyFeeds(energy) {
     throw new Error('Energy feeds must include at least one region with nominal + buffer MW defined.');
   }
 
+  const regionIndex = new Map();
+  const federationIndex = new Map();
+
   energy.feeds.forEach((feed, idx) => {
-    if (typeof feed.region !== 'string' || feed.region.trim() === '') {
+    const region = typeof feed.region === 'string' ? feed.region.trim() : '';
+    if (region === '') {
       throw new Error(`Energy feed #${idx} is missing a region identifier.`);
     }
+    if (regionIndex.has(region)) {
+      throw new Error(
+        `Energy feed region "${region}" is duplicated at entries ${regionIndex.get(region)} and ${idx}.`
+      );
+    }
+    regionIndex.set(region, idx);
+
+    const federationSlug =
+      typeof feed.federationSlug === 'string' ? feed.federationSlug.trim() : '';
+    if (federationSlug) {
+      if (federationIndex.has(federationSlug)) {
+        throw new Error(
+          `Energy feed federationSlug "${federationSlug}" is duplicated at entries ${federationIndex.get(
+            federationSlug
+          )} and ${idx}.`
+        );
+      }
+      federationIndex.set(federationSlug, idx);
+    }
+
     if (!Number.isFinite(feed.nominalMw) || feed.nominalMw <= 0) {
       throw new Error(`Energy feed ${feed.region} must declare positive nominalMw.`);
     }

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -473,3 +473,53 @@ def test_run_demo_requires_energy_coverage(tmp_path: Path) -> None:
     combined_output = (result.stdout + result.stderr).lower()
     assert result.returncode != 0
     assert "energy feeds missing coverage" in combined_output
+
+
+@pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
+def test_run_demo_rejects_duplicate_energy_regions(tmp_path: Path) -> None:
+    """Energy feeds must not reuse region identifiers."""
+
+    energy_config = json.loads((DEMO_ROOT / "config" / "energy-feeds.json").read_text())
+    energy_config["feeds"][1]["region"] = energy_config["feeds"][0]["region"]
+    invalid_energy = tmp_path / "energy-feeds.json"
+    invalid_energy.write_text(json.dumps(energy_config))
+
+    env = os.environ.copy()
+    env.update({"KARDASHEV_ENERGY_FEEDS_PATH": str(invalid_energy)})
+
+    result = subprocess.run(
+        [sys.executable, str(PYTHON_ENTRYPOINT), "--output-dir", str(tmp_path), "--check"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    combined_output = (result.stdout + result.stderr).lower()
+    assert result.returncode != 0
+    assert "duplicated" in combined_output
+    assert "region" in combined_output
+
+
+@pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
+def test_run_demo_rejects_duplicate_federation_slugs(tmp_path: Path) -> None:
+    """Energy feeds must not reuse federation slug identifiers."""
+
+    energy_config = json.loads((DEMO_ROOT / "config" / "energy-feeds.json").read_text())
+    energy_config["feeds"][1]["federationSlug"] = energy_config["feeds"][0]["federationSlug"]
+    invalid_energy = tmp_path / "energy-feeds.json"
+    invalid_energy.write_text(json.dumps(energy_config))
+
+    env = os.environ.copy()
+    env.update({"KARDASHEV_ENERGY_FEEDS_PATH": str(invalid_energy)})
+
+    result = subprocess.run(
+        [sys.executable, str(PYTHON_ENTRYPOINT), "--output-dir", str(tmp_path), "--check"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    combined_output = (result.stdout + result.stderr).lower()
+    assert result.returncode != 0
+    assert "duplicated" in combined_output
+    assert "federationslug" in combined_output


### PR DESCRIPTION
### Motivation
- Ensure the Kardashev-II demo fails fast on malformed energy feed configs by detecting reused identifiers that could cause ambiguous mappings at runtime.
- Prevent ambiguous routing/resolution when multiple feeds share the same `region` or `federationSlug`, which breaks coverage and telemetry assumptions.
- Improve operator diagnostics with explicit, actionable error messages when configuration collisions are present.
- Increase confidence in automation by encoding uniqueness constraints into demo validation logic used by CI and operator workflows.

### Description
- Added uniqueness checks in `validateEnergyFeeds` (demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs) that reject duplicated `region` and `federationSlug` identifiers and raise a descriptive error.
- Trim and normalise `region` and `federationSlug` values before validation to avoid false negatives from whitespace.
- Introduced two pytest cases in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` to assert failures for duplicate `region` and duplicate `federationSlug` scenarios.
- Kept existing validation rules and error semantics for `nominalMw`, `bufferMw`, `latencyMs`, `tolerancePct`, and `driftAlertPct` intact while adding uniqueness checks.

### Testing
- Ran the Kardashev-II CI validation with `npm run demo:kardashev-ii:ci` and the node check via `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs --check`, both completed successfully.
- Executed the demo unit tests `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and the new duplicate-identifier tests passed (all tests green).
- Ran the full demo test runner `python demo/run_demo_tests.py`, which completed and reported all demo suites passing.
- Verified the changed files `run-demo.cjs` and `tests/test_run_demo.py` and committed the patch with message `Validate unique energy feed identifiers`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956f27e2db48333b7e3889b6dac7545)