### PR TITLE
Add entropy production signal to Kardashev‑II demo and incorporate into policy signals

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -431,6 +431,7 @@ class Orchestrator:
                     "gibbs_free_energy": state.gibbs_free_energy,
                     "hamiltonian": state.hamiltonian,
                     "entropy": state.entropy,
+                    "entropy_production": state.entropy_production,
                     "temperature": state.temperature,
                     "enthalpy": state.enthalpy,
                     "pressure": state.pressure,
@@ -445,6 +446,7 @@ class Orchestrator:
                     "gibbs_drive": signals["gibbs_drive"],
                     "hamiltonian_pressure": signals["hamiltonian_pressure"],
                     "entropy_pressure": signals["entropy_pressure"],
+                    "entropy_production_pressure": signals["entropy_production_pressure"],
                     "stability_guard": signals["stability_guard"],
                 },
             }
@@ -751,6 +753,8 @@ class Orchestrator:
         stability_index = max(0.0, min(1.0, state.stability_index))
         entropy = max(0.0, state.entropy)
         entropy_pressure = min(1.0, entropy / math.log(2.0))
+        entropy_production = max(0.0, state.entropy_production)
+        entropy_production_pressure = min(1.0, entropy_production / (1.0 + entropy))
         exergy_balance = max(-1.0, min(1.0, state.exergy_balance))
         exergy_pressure = max(0.0, min(1.0, (1.0 - exergy_balance) / 2.0))
         pareto_efficiency = max(0.0, min(1.0, state.pareto_efficiency))
@@ -785,9 +789,13 @@ class Orchestrator:
         )
         coordination_damping = max(0.2, 1.0 - 0.3 * coordination_gap) * stability_factor
         compute_boost = 1.0 + 0.4 * compute_price_pressure
-        entropy_damping = max(0.35, 1.0 - 0.6 * entropy_pressure)
+        entropy_damping = max(
+            0.35,
+            1.0 - 0.6 * entropy_pressure - 0.2 * entropy_production_pressure,
+        )
         welfare_urgency = max(0.0, 1.0 - sentient_welfare_index)
         stability_guard = 1.0 - 0.55 * entropy_pressure - 0.35 * coordination_gap - 0.2 * hamiltonian_pressure
+        stability_guard -= 0.15 * entropy_production_pressure
         stability_guard *= 0.6 + 0.4 * stability_index
         stability_guard = min(1.0, max(0.2, stability_guard))
         return {
@@ -802,6 +810,8 @@ class Orchestrator:
             "stability_index": stability_index,
             "entropy": entropy,
             "entropy_pressure": entropy_pressure,
+            "entropy_production": entropy_production,
+            "entropy_production_pressure": entropy_production_pressure,
             "exergy_balance": exergy_balance,
             "exergy_pressure": exergy_pressure,
             "pareto_efficiency": pareto_efficiency,
@@ -1007,6 +1017,8 @@ class Orchestrator:
                 "gibbs_drive": signals["gibbs_drive"],
                 "hamiltonian_pressure": signals["hamiltonian_pressure"],
                 "entropy_pressure": signals["entropy_pressure"],
+                "entropy_production": signals["entropy_production"],
+                "entropy_production_pressure": signals["entropy_production_pressure"],
                 "stability_guard": signals["stability_guard"],
                 "exergy_balance": signals["exergy_balance"],
             },

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -17,6 +17,7 @@ class SimulationState:
     free_energy: float = 0.0
     gibbs_free_energy: Optional[float] = None
     entropy: float = 0.0
+    entropy_production: float = 0.0
     hamiltonian: float = 0.0
     stability_index: float = 0.0
     coordination_index: float = 0.0
@@ -94,6 +95,7 @@ class SyntheticEconomySim(PlanetarySimulation):
         enthalpy = internal_energy + pressure * volume
         free_energy = internal_energy - temperature * entropy
         gibbs_free_energy = enthalpy - temperature * entropy
+        entropy_production = max(0.0, entropy * temperature * (1.0 - coordination_index))
         hamiltonian = -internal_energy * order_parameter
         stability_index = math.exp(-entropy) * (1.0 / (1.0 + abs(hamiltonian)))
         stability_index *= 0.5 + 0.5 * coordination_index
@@ -114,6 +116,7 @@ class SyntheticEconomySim(PlanetarySimulation):
             "free_energy": free_energy,
             "gibbs_free_energy": gibbs_free_energy,
             "entropy": entropy,
+            "entropy_production": entropy_production,
             "hamiltonian": hamiltonian,
             "stability_index": stability_index,
             "coordination_index": coordination_index,
@@ -143,6 +146,7 @@ class SyntheticEconomySim(PlanetarySimulation):
             free_energy=metrics["free_energy"],
             gibbs_free_energy=metrics["gibbs_free_energy"],
             entropy=metrics["entropy"],
+            entropy_production=metrics["entropy_production"],
             hamiltonian=metrics["hamiltonian"],
             stability_index=metrics["stability_index"],
             coordination_index=metrics["coordination_index"],

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
@@ -61,6 +61,7 @@ def test_policy_signals_use_gibbs_deficit(tmp_path: Path) -> None:
         sustainability_index=0.6,
         free_energy=-0.5,
         entropy=0.4,
+        entropy_production=0.5,
         hamiltonian=-0.3,
         stability_index=0.8,
         coordination_index=0.9,
@@ -72,6 +73,7 @@ def test_policy_signals_use_gibbs_deficit(tmp_path: Path) -> None:
     signals = orchestrator._compute_policy_signals(state)
 
     assert signals["gibbs_drive"] == pytest.approx(0.5)
+    assert signals["entropy_production_pressure"] == pytest.approx(0.5 / 1.4)
 
 
 def test_insight_payload_surfaces_thermodynamic_strategy(tmp_path: Path) -> None:

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
@@ -22,6 +22,7 @@ def test_simulation_thermodynamic_metrics() -> None:
     free_energy = internal_energy - temperature * entropy
     hamiltonian = -internal_energy * order_parameter
     coordination_index = 1.0 - abs(state.prosperity_index - state.sustainability_index)
+    entropy_production = max(0.0, entropy * temperature * (1.0 - coordination_index))
     stability_index = math.exp(-entropy) * (1.0 / (1.0 + abs(hamiltonian)))
     stability_index *= 0.5 + 0.5 * coordination_index
     stability_index = min(1.0, max(0.0, stability_index))
@@ -31,6 +32,7 @@ def test_simulation_thermodynamic_metrics() -> None:
     game_theory_slack = min(1.0, nash_welfare * (0.5 + 0.5 * coordination_index))
 
     assert state.entropy == pytest.approx(entropy)
+    assert state.entropy_production == pytest.approx(entropy_production)
     assert state.nash_welfare == pytest.approx(nash_welfare)
     assert state.free_energy == pytest.approx(free_energy)
     assert state.hamiltonian == pytest.approx(hamiltonian)


### PR DESCRIPTION
### Motivation

- Surface an explicit entropy production metric to better represent irreversible losses in the synthetic planetary simulation.  
- Use the new metric to influence policy heuristics (damping and stability guardrails) so autonomous recommendations are more conservative when entropy is being produced.  
- Make thermodynamic reasoning (Gibbs/Hamiltonian/game‑theory signals) more expressive for downstream briefs and insights.  

### Description

- Add `entropy_production` to `SimulationState` and compute it in `SyntheticEconomySim._compute_thermodynamic_metrics()` as `max(0.0, entropy * temperature * (1.0 - coordination_index))`.  
- Propagate `entropy_production` into the state snapshot and include it in the orchestrator insight payload and policy briefs.  
- Compute `entropy_production_pressure` in `_compute_policy_signals()` and use it to adjust `entropy_damping` and reduce the `stability_guard`, making policy actions respond to ongoing entropy production.  
- Update tests to assert the new metric and signal: `tests/test_simulation_metrics.py` and `tests/test_policy_actions.py` now validate `entropy_production` and `entropy_production_pressure`.  

### Testing

- Ran the demo test runner for the modified demo with `python demo/run_demo_tests.py --demo "Kardashev-II Omega-Grade-α-AGI Business-3" --fail-fast` and all suites passed.  
- The modified demo suites (k2/omega/ultra) completed successfully with their updated assertions (tests passed).  
- Existing demo harness and orchestration smoke tests were exercised via the per-demo runner during development and completed without failures.  
- Test commands used: `python demo/run_demo_tests.py --demo "Kardashev-II Omega-Grade-α-AGI Business-3" --fail-fast` (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957181a12f88333a62706382ecb47fc)