### PR TITLE
Add coordination incentives to the Omega-grade simulation policy

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -728,6 +728,7 @@ class Orchestrator:
             "green_shift",
             "alignment_investment",
             "exergy_recovery",
+            "coordination_incentives",
         )
         normalized: Dict[str, float] = {}
         for field in allowed_fields:
@@ -794,6 +795,10 @@ class Orchestrator:
             1.0 - 0.6 * entropy_pressure - 0.2 * entropy_production_pressure,
         )
         welfare_urgency = max(0.0, 1.0 - sentient_welfare_index)
+        coordination_pressure = max(
+            0.0,
+            min(1.0, 0.5 * coordination_gap + 0.5 * (1.0 - game_theory_slack)),
+        )
         stability_guard = 1.0 - 0.55 * entropy_pressure - 0.35 * coordination_gap - 0.2 * hamiltonian_pressure
         stability_guard -= 0.15 * entropy_production_pressure
         stability_guard *= 0.6 + 0.4 * stability_index
@@ -835,6 +840,7 @@ class Orchestrator:
             "compute_boost": compute_boost,
             "entropy_damping": entropy_damping,
             "welfare_urgency": welfare_urgency,
+            "coordination_pressure": coordination_pressure,
             "stability_guard": stability_guard,
         }
 
@@ -978,6 +984,7 @@ class Orchestrator:
             ("stimulus", "Launch prosperity stimulus"),
             ("green_shift", "Accelerate green transition"),
             ("alignment_investment", "Invest in alignment"),
+            ("coordination_incentives", "Fund coordination incentives"),
             ("exergy_recovery", "Recover exergy"),
         )
         for key, label in ordered_actions:
@@ -1124,6 +1131,15 @@ class Orchestrator:
             * (0.7 + 0.3 * signals["equity_pressure"])
             * (1.0 + (1.0 - stability_guard))
         )
+        coordination_incentives = (
+            alignment_budget
+            * signals["coordination_pressure"]
+            * (0.6 + 0.4 * signals["welfare_urgency"])
+            * (0.7 + 0.3 * signals["stability_index"])
+            * (0.6 + 0.4 * signals["pareto_efficiency"])
+            * (0.6 + 0.4 * signals["equity_pressure"])
+            * signals["coordination_damping"]
+        )
         exergy_recovery = (
             action_budget
             * signals["exergy_pressure"]
@@ -1138,6 +1154,7 @@ class Orchestrator:
                 "green_shift": green_shift,
                 "alignment_investment": alignment_investment,
                 "exergy_recovery": exergy_recovery,
+                "coordination_incentives": coordination_incentives,
             }
         )
         rationale = self._build_policy_rationale(
@@ -1151,6 +1168,7 @@ class Orchestrator:
                 "green_shift": green_shift,
                 "alignment_investment": alignment_investment,
                 "exergy_recovery": exergy_recovery,
+                "coordination_incentives": coordination_incentives,
             },
         )
         return {"action": normalized_action, "rationale": rationale}

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -57,6 +57,7 @@ class SyntheticEconomySim(PlanetarySimulation):
         green_shift = max(0.0, float(action.get("green_shift", 0.0)))
         alignment_investment = max(0.0, float(action.get("alignment_investment", 0.0)))
         exergy_recovery = max(0.0, float(action.get("exergy_recovery", 0.0)))
+        coordination_incentives = max(0.0, float(action.get("coordination_incentives", 0.0)))
         self.energy_output_gw += build_dyson_nodes * 10_000
         if exergy_recovery:
             self.energy_output_gw += exergy_recovery * 4_000
@@ -73,6 +74,16 @@ class SyntheticEconomySim(PlanetarySimulation):
             elif gap < 0:
                 self.prosperity_index = min(1.0, self.prosperity_index + alignment_step)
             shared_boost = 0.003 * alignment_investment
+            self.prosperity_index = min(1.0, self.prosperity_index + shared_boost)
+            self.sustainability_index = min(1.0, self.sustainability_index + shared_boost)
+        if coordination_incentives:
+            gap = self.prosperity_index - self.sustainability_index
+            coordination_step = min(0.015 * coordination_incentives, abs(gap))
+            if gap > 0:
+                self.sustainability_index = min(1.0, self.sustainability_index + coordination_step)
+            elif gap < 0:
+                self.prosperity_index = min(1.0, self.prosperity_index + coordination_step)
+            shared_boost = 0.002 * coordination_incentives
             self.prosperity_index = min(1.0, self.prosperity_index + shared_boost)
             self.sustainability_index = min(1.0, self.sustainability_index + shared_boost)
         return self._snapshot_state()

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_simulation_actions.py
@@ -201,6 +201,43 @@ def test_policy_action_invests_in_alignment_for_coordination_gap() -> None:
     assert low_action["alignment_investment"] >= high_action["alignment_investment"]
 
 
+def test_policy_action_supports_coordination_incentives() -> None:
+    orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
+    low_coordination_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.55,
+        sustainability_index=0.35,
+        nash_welfare=0.35,
+        sentient_welfare_index=0.3,
+        free_energy=0.3,
+        entropy=0.45,
+        hamiltonian=-0.25,
+        coordination_index=0.2,
+        game_theory_slack=0.2,
+        stability_index=0.4,
+        pareto_efficiency=0.3,
+    )
+    high_coordination_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.62,
+        sustainability_index=0.6,
+        nash_welfare=0.6,
+        sentient_welfare_index=0.65,
+        free_energy=0.2,
+        entropy=0.2,
+        hamiltonian=-0.1,
+        coordination_index=0.85,
+        game_theory_slack=0.8,
+        stability_index=0.7,
+        pareto_efficiency=0.7,
+    )
+
+    low_action = orchestrator._build_policy_action(low_coordination_state)
+    high_action = orchestrator._build_policy_action(high_coordination_state)
+
+    assert low_action["coordination_incentives"] >= high_action["coordination_incentives"]
+
+
 def test_policy_action_escalates_alignment_when_entropy_high() -> None:
     orchestrator = Orchestrator(OrchestratorConfig(enable_simulation=True))
     low_entropy_state = SimulationState(


### PR DESCRIPTION
### Motivation
- Improve the demo's policy model to explicitly address coordination and game-theoretic gaps by introducing a coordination-targeted policy action.
- Surface coordination incentives as a first-class lever alongside alignment and exergy recovery to better rebalance prosperity vs sustainability.
- Reduce brittleness where low coordination states previously lacked a direct policy instrument to nudge cooperative outcomes.

### Description
- Added `coordination_incentives` to the orchestrator's normalized simulation action fields and to `_format_policy_steps` so it appears in briefs.  
- Extended `_compute_policy_signals` with a `coordination_pressure` metric used when deriving policy decisions.  
- Built `coordination_incentives` into `_build_policy_decision` so it participates in `normalized_action` and is included in the policy rationale.  
- Implemented application of `coordination_incentives` in the synthetic simulator (`SyntheticEconomySim.apply_action`) so incentives adjust the prosperity/sustainability balance.

### Testing
- Ran the modified demo test suite with `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests -q` which passed: `22 passed in 0.60s`.
- The change also preserves existing behavior of policy briefs and snapshots exercised by the demo's unit tests (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957214d4ca48333ab557f3975299fbe)