### PR TITLE
Add proxy-aware solc cache pretest to stabilize CULTURE hardhat tests

### DIFF
--- a/demo/CULTURE-v0/hardhat/package-lock.json
+++ b/demo/CULTURE-v0/hardhat/package-lock.json
@@ -12,6 +12,7 @@
         "ethers": "^6.15.0",
         "hardhat": "^2.26.1",
         "hardhat-contract-sizer": "^2.10.0",
+        "https-proxy-agent": "^7.0.6",
         "solidity-coverage": "^0.8.12",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
@@ -1398,6 +1399,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/node/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@sentry/node/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -1716,16 +1744,13 @@
       "license": "MIT"
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/aggregate-error": {
@@ -4299,17 +4324,17 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {

--- a/demo/CULTURE-v0/hardhat/package.json
+++ b/demo/CULTURE-v0/hardhat/package.json
@@ -6,13 +6,15 @@
   "packageManager": "npm@10.8.2",
   "scripts": {
     "pretest": "npm ci --ignore-scripts --no-audit --no-fund",
-    "test": "./node_modules/.bin/hardhat test --config ../hardhat.config.ts --network hardhat"
+    "pretest:solc": "node scripts/ensure-solc-cache.cjs",
+    "test": "npm run pretest:solc && ./node_modules/.bin/hardhat test --config ../hardhat.config.ts --network hardhat"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^6.1.0",
     "ethers": "^6.15.0",
     "hardhat": "^2.26.1",
     "hardhat-contract-sizer": "^2.10.0",
+    "https-proxy-agent": "^7.0.6",
     "solidity-coverage": "^0.8.12",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"

--- a/demo/CULTURE-v0/hardhat/scripts/ensure-solc-cache.cjs
+++ b/demo/CULTURE-v0/hardhat/scripts/ensure-solc-cache.cjs
@@ -1,0 +1,162 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const https = require("https");
+const { HttpsProxyAgent } = require("https-proxy-agent");
+const { keccak256 } = require("ethereum-cryptography/keccak");
+const { bytesToHex } = require("ethereum-cryptography/utils");
+const envPaths = require("env-paths");
+
+const SOLC_VERSION = "0.8.25";
+const PRIMARY_REPO = "https://binaries.soliditylang.org";
+const FALLBACK_REPO = "https://solc-bin.ethereum.org";
+
+function platformFolder() {
+  switch (os.platform()) {
+    case "win32":
+      return "windows-amd64";
+    case "darwin":
+      return "macosx-amd64";
+    case "linux":
+      return "linux-amd64";
+    default:
+      return "wasm";
+  }
+}
+
+function requestJson(url) {
+  return new Promise((resolve, reject) => {
+    const agent = proxyAgent();
+    https
+      .get(url, { agent }, (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`Failed to fetch ${url} (status ${res.statusCode})`));
+          return;
+        }
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(data));
+          } catch (error) {
+            reject(error);
+          }
+        });
+      })
+      .on("error", reject);
+  });
+}
+
+async function fetchJsonWithFallback(pathname) {
+  try {
+    return await requestJson(`${PRIMARY_REPO}/${pathname}`);
+  } catch (error) {
+    return await requestJson(`${FALLBACK_REPO}/${pathname}`);
+  }
+}
+
+function downloadFile(url, destination) {
+  return new Promise((resolve, reject) => {
+    const agent = proxyAgent();
+    https
+      .get(url, { agent }, (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`Failed to download ${url} (status ${res.statusCode})`));
+          return;
+        }
+
+        fs.mkdirSync(path.dirname(destination), { recursive: true });
+        const tempPath = `${destination}.tmp`;
+        const file = fs.createWriteStream(tempPath);
+
+        res.pipe(file);
+        file.on("finish", () => {
+          file.close(() => {
+            fs.renameSync(tempPath, destination);
+            resolve();
+          });
+        });
+        file.on("error", (err) => {
+          reject(err);
+        });
+      })
+      .on("error", reject);
+  });
+}
+
+async function downloadWithFallback(pathname, destination) {
+  try {
+    await downloadFile(`${PRIMARY_REPO}/${pathname}`, destination);
+  } catch (error) {
+    await downloadFile(`${FALLBACK_REPO}/${pathname}`, destination);
+  }
+}
+
+function compilerHashMatches(filePath, expectedHash) {
+  if (!fs.existsSync(filePath)) {
+    return false;
+  }
+  const buffer = fs.readFileSync(filePath);
+  const actual = `0x${bytesToHex(keccak256(buffer))}`;
+  return actual === expectedHash;
+}
+
+function proxyAgent() {
+  const proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
+
+  if (!proxyUrl) {
+    return undefined;
+  }
+
+  return new HttpsProxyAgent(proxyUrl);
+}
+
+async function ensureCompilerCache() {
+  const platform = platformFolder();
+  const cacheDir = envPaths("hardhat").cache;
+  const compilersDir = path.join(cacheDir, "compilers-v2", platform);
+  const listPath = path.join(compilersDir, "list.json");
+  let list;
+
+  if (fs.existsSync(listPath)) {
+    list = JSON.parse(fs.readFileSync(listPath, "utf8"));
+  }
+
+  if (!list || !list.builds.some((build) => build.version === SOLC_VERSION)) {
+    list = await fetchJsonWithFallback(`${platform}/list.json`);
+    fs.mkdirSync(compilersDir, { recursive: true });
+    fs.writeFileSync(listPath, `${JSON.stringify(list, null, 2)}\n`, "utf8");
+  }
+
+  const build = list.builds.find(
+    (entry) => entry.version === SOLC_VERSION && entry.prerelease === undefined
+  );
+
+  if (!build) {
+    throw new Error(`Unable to locate solc ${SOLC_VERSION} in compiler list`);
+  }
+
+  const compilerPath = path.join(compilersDir, build.path);
+  if (!compilerHashMatches(compilerPath, build.keccak256)) {
+    await downloadWithFallback(`${platform}/${build.path}`, compilerPath);
+    if (!compilerHashMatches(compilerPath, build.keccak256)) {
+      throw new Error(`solc ${SOLC_VERSION} download failed integrity check`);
+    }
+  }
+
+  fs.chmodSync(compilerPath, 0o755);
+}
+
+ensureCompilerCache().catch((error) => {
+  console.error("Failed to cache solc compiler:", error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- Hardhat tests for the `CULTURE-v0` demo were failing intermittently because the native `solc` binary download could be blocked or unreliable in CI/proxy environments. 
- Tests should not rely on on-demand remote compiler downloads during test runs to ensure deterministic, reproducible CI. 
- A robust pretest step that fetches, verifies and caches the correct `solc` binary reduces flakiness and speeds test setup. 
- The solution must respect corporate proxy settings and validate binary integrity before running compilation. 

### Description
- Added `demo/CULTURE-v0/hardhat/scripts/ensure-solc-cache.cjs` which prefetches the `solc` `0.8.25` binary into the Hardhat cache, supports a fallback repository, validates keccak256 integrity, and sets executable permissions. 
- The downloader is proxy-aware via `https-proxy-agent` and uses `ethereum-cryptography` utilities to compute/compare Keccak hashes. 
- Hooked the fetch/verify step into `demo/CULTURE-v0/hardhat/package.json` as a `pretest:solc` script and updated the `test` script to run the pretest before invoking Hardhat. 
- Added the `https-proxy-agent` dependency to ensure downloads succeed behind HTTP/HTTPS proxies. 

### Testing
- Ran `npm test` inside `demo/CULTURE-v0/hardhat` which executes the new `pretest:solc` and then Hardhat tests, and the suite completed with `3 passing` tests. 
- The pretest correctly downloaded (via proxy), validated, and installed the `solc` binary into the Hardhat cache and allowed compilation to succeed. 
- The modified Hardhat test flow was exercised end-to-end in CI-like conditions (proxy environment variables set) and the flake previously observed for the CULTURE hardhat suite was resolved. 
- No automated tests failed for the modified `CULTURE-v0/hardhat` project after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69573aed05b083338d63408f81c66732)