### PR TITLE
Fix AGI Alpha Node demo test imports

### DIFF
--- a/demo/AGI-Alpha-Node-v0/grand_demo/tests/test_alpha_node.py
+++ b/demo/AGI-Alpha-Node-v0/grand_demo/tests/test_alpha_node.py
@@ -8,8 +8,27 @@ import sys
 import pytest
 
 PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(PACKAGE_ROOT) not in sys.path:
-    sys.path.insert(0, str(PACKAGE_ROOT))
+PACKAGE_ROOT_STR = str(PACKAGE_ROOT)
+if PACKAGE_ROOT_STR not in sys.path:
+    sys.path.insert(0, PACKAGE_ROOT_STR)
+
+
+def _ensure_grand_demo_alpha_node() -> None:
+    module = sys.modules.get("alpha_node")
+    if not module:
+        return
+
+    module_file = getattr(module, "__file__", "") or ""
+    module_paths = [str(path) for path in getattr(module, "__path__", [])]
+    if PACKAGE_ROOT_STR in module_file or any(PACKAGE_ROOT_STR in path for path in module_paths):
+        return
+
+    for name in list(sys.modules):
+        if name == "alpha_node" or name.startswith("alpha_node."):
+            sys.modules.pop(name, None)
+
+
+_ensure_grand_demo_alpha_node()
 
 from alpha_node.ai.planner import MuZeroPlanner
 from alpha_node.compliance.scorecard import ComplianceEngine

--- a/demo/AGI-Alpha-Node-v0/grandiose_alpha_demo/test_grandiose_alpha_demo.py
+++ b/demo/AGI-Alpha-Node-v0/grandiose_alpha_demo/test_grandiose_alpha_demo.py
@@ -2,7 +2,27 @@ import sys
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent
-sys.path.insert(0, str(BASE_DIR / "src"))
+SRC_PATH = BASE_DIR / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+
+def _ensure_grandiose_demo_package() -> None:
+    module = sys.modules.get("agi_alpha_node_demo")
+    if not module:
+        return
+
+    module_file = getattr(module, "__file__", "") or ""
+    module_paths = [str(path) for path in getattr(module, "__path__", [])]
+    if str(SRC_PATH) in module_file or any(str(SRC_PATH) in path for path in module_paths):
+        return
+
+    for name in list(sys.modules):
+        if name == "agi_alpha_node_demo" or name.startswith("agi_alpha_node_demo."):
+            sys.modules.pop(name, None)
+
+
+_ensure_grandiose_demo_package()
 
 from agi_alpha_node_demo.alpha_node import AlphaNode
 from agi_alpha_node_demo.config import load_demo_config


### PR DESCRIPTION
### Motivation

- Prevent pytest import collisions between demos that cause `ModuleNotFoundError` and import-file mismatches.
- Ensure the demo-local package (grand demo) wins import resolution when multiple demo suites run in the same process.
- Make test module names unique to avoid pytest collection confusion.

### Description

- Add a guarded cache-purge helper in `demo/AGI-Alpha-Node-v0/grand_demo/tests/test_alpha_node.py` that removes any `alpha_node` modules from `sys.modules` when they do not originate from the grand demo package.  
- Rename `demo/AGI-Alpha-Node-v0/grandiose_alpha_demo/tests.py` to `test_grandiose_alpha_demo.py` and add `_ensure_grandiose_demo_package` to clear conflicting `agi_alpha_node_demo` modules from the import cache.  
- Replace ad-hoc `sys.path` inserts with explicit path string variables (`PACKAGE_ROOT_STR`, `SRC_PATH`) to make import resolution deterministic.  
- Remove the temporary `conftest.py` that attempted to force import ordering in favor of the in-test guarded purge logic.

### Testing

- Ran `pytest -q demo/AGI-Alpha-Node-v0/tests demo/AGI-Alpha-Node-v0/grand_demo/tests demo/AGI-Alpha-Node-v0/grandiose_alpha_demo/test_grandiose_alpha_demo.py` and observed `16 passed in 2.65s`.
- Verified related demo test suites in the repository also run successfully in isolation (for example, `pytest -q demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests` reported `22 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957786b0ad08333afaa4adab544fbb7)