### PR TITLE
Add risk-budget throttling to omega policy actions

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -803,6 +803,12 @@ class Orchestrator:
         stability_guard -= 0.15 * entropy_production_pressure
         stability_guard *= 0.6 + 0.4 * stability_index
         stability_guard = min(1.0, max(0.2, stability_guard))
+        risk_budget = (
+            stability_guard
+            * (0.6 + 0.4 * entropy_damping)
+            * (0.6 + 0.4 * coordination_damping)
+        )
+        risk_budget = min(1.0, max(0.1, risk_budget))
         return {
             "prosperity_gap": prosperity_gap,
             "sustainability_gap": sustainability_gap,
@@ -842,6 +848,7 @@ class Orchestrator:
             "welfare_urgency": welfare_urgency,
             "coordination_pressure": coordination_pressure,
             "stability_guard": stability_guard,
+            "risk_budget": risk_budget,
         }
 
     def _score_claimant(self, job: JobRecord, agent: str) -> Tuple[float, float, int, str]:
@@ -1018,6 +1025,7 @@ class Orchestrator:
                 "welfare_gap": signals["welfare_gap"],
                 "equity_pressure": signals["equity_pressure"],
                 "welfare_urgency": signals["welfare_urgency"],
+                "risk_budget": signals["risk_budget"],
             },
             "energy_dynamics": {
                 "gibbs_reference": gibbs_reference,
@@ -1084,6 +1092,7 @@ class Orchestrator:
         """
 
         signals = signals or self._compute_policy_signals(state)
+        risk_budget = signals["risk_budget"]
         action_budget = (
             1.5
             + 3.0 * signals["energy_price_pressure"]
@@ -1096,12 +1105,14 @@ class Orchestrator:
             * signals["entropy_damping"]
         )
         action_budget *= 0.9 + 0.6 * signals["welfare_urgency"] + 0.3 * signals["equity_pressure"]
+        action_budget *= 0.5 + 0.5 * risk_budget
         alignment_budget = (
             action_budget
             * (1.0 + 0.8 * signals["entropy_pressure"])
             / max(0.6, signals["entropy_damping"])
         )
         alignment_budget *= 1.0 + 0.6 * signals["equity_pressure"]
+        alignment_budget *= 0.5 + 0.5 * risk_budget
         stability_guard = signals["stability_guard"]
         energy_action = action_budget * (0.8 + 0.4 * signals["coordination_damping"]) * stability_guard
         stability_modifier = 0.7 + 0.6 * signals["stability_index"]

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_policy_actions.py
@@ -126,3 +126,36 @@ def test_policy_steps_include_exergy_recovery(tmp_path: Path) -> None:
     steps = orchestrator._format_policy_steps({"exergy_recovery": 2.5})
 
     assert any("Recover exergy" in step for step in steps)
+
+
+def test_policy_brief_surfaces_risk_budget(tmp_path: Path) -> None:
+    orchestrator = Orchestrator(
+        OrchestratorConfig(
+            control_channel_file=tmp_path / "control.jsonl",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            status_output_path=None,
+            audit_log_path=None,
+            energy_oracle_path=None,
+        )
+    )
+    state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.62,
+        sustainability_index=0.58,
+        free_energy=-0.4,
+        entropy=0.52,
+        entropy_production=0.4,
+        hamiltonian=-0.25,
+        stability_index=0.7,
+        coordination_index=0.55,
+        nash_welfare=0.6,
+        sentient_welfare_index=0.58,
+        game_theory_slack=0.62,
+    )
+
+    signals = orchestrator._compute_policy_signals(state)
+    decision = orchestrator._build_policy_decision(state, signals=signals)
+    brief = orchestrator._build_policy_brief(state, decision, signals)
+
+    assert 0.1 <= signals["risk_budget"] <= 1.0
+    assert brief["welfare_guardrails"]["risk_budget"] == pytest.approx(signals["risk_budget"])


### PR DESCRIPTION
### Motivation
- Prevent the autonomous policy engine from proposing overly aggressive actions when thermodynamic signals indicate high entropy or low stability. 
- Introduce an explicit, bounded risk signal to gate policy intensity so energy/compute expansion respects safety and coordination constraints. 
- Surface the risk signal in operator-facing briefs so human operators can inspect the automated risk posture. 
- Keep policy math interpretable by composing the new signal from existing stability/entropy/coordination terms.

### Description
- Added a `risk_budget` signal to the policy pipeline computed from `stability_guard`, `entropy_damping`, and `coordination_damping`, clamped to `[0.1, 1.0]` in `Orchestrator._compute_policy_signals`.
- Scaled autonomous policy budgets by the new risk budget in `Orchestrator._build_policy_decision` by adjusting `action_budget` and `alignment_budget` with `risk_budget` to throttle actions under risk.
- Included `risk_budget` inside the policy brief under `welfare_guardrails` in `Orchestrator._build_policy_brief` so it is exposed in the operator insight payloads.
- Added unit test `test_policy_brief_surfaces_risk_budget` in `tests/test_policy_actions.py` to validate the signal is computed and surfaced in briefs.

### Testing
- Ran `pytest demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/tests/test_policy_actions.py`, which completed with `5 passed` (including the new `test_policy_brief_surfaces_risk_budget`).
- The change is limited to `orchestrator.py` and test coverage was added to the demo's policy actions tests, all of which passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69579e4e2ba88333a33df38280f20f47)