### PR TITLE
Stabilize alignment investment under entropy pressure

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -1106,13 +1106,18 @@ class Orchestrator:
         )
         action_budget *= 0.9 + 0.6 * signals["welfare_urgency"] + 0.3 * signals["equity_pressure"]
         action_budget *= 0.5 + 0.5 * risk_budget
+        alignment_risk_budget = max(
+            risk_budget,
+            0.35 + 0.45 * signals["entropy_pressure"] + 0.2 * signals["entropy_production_pressure"],
+        )
+        alignment_risk_budget = min(1.0, alignment_risk_budget)
         alignment_budget = (
             action_budget
             * (1.0 + 0.8 * signals["entropy_pressure"])
             / max(0.6, signals["entropy_damping"])
         )
         alignment_budget *= 1.0 + 0.6 * signals["equity_pressure"]
-        alignment_budget *= 0.5 + 0.5 * risk_budget
+        alignment_budget *= 0.5 + 0.5 * alignment_risk_budget
         stability_guard = signals["stability_guard"]
         energy_action = action_budget * (0.8 + 0.4 * signals["coordination_damping"]) * stability_guard
         stability_modifier = 0.7 + 0.6 * signals["stability_index"]


### PR DESCRIPTION
### Motivation
- A simulation test showed alignment investment could decrease when system entropy rises, which contradicts the intended behavior of escalating alignment under disorder.
- The original alignment gating used the general `risk_budget` which may be low when entropy is high, unintentionally suppressing alignment responses.
- The goal is to ensure alignment spending grows with entropy while preserving the general action-budget risk gating.

### Description
- Introduced an entropy-aware `alignment_risk_budget` computed as the max of `risk_budget` and an entropy-driven floor derived from `entropy_pressure` and `entropy_production_pressure` inside `orchestrator.py`.
- Clamped `alignment_risk_budget` to `1.0` and substituted it where `alignment_budget` was previously scaled by `risk_budget` so alignment now scales with the entropy-aware floor.
- The change is localized to the `_build_policy_decision` / policy action calculation in `demo/Kardashev-II Omega-Grade-α-AGI Business-3/.../orchestrator.py` and preserves the rest of the action budgeting logic.

### Testing
- Ran `pytest -q` in `demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo` and observed the failing `tests/test_simulation_actions.py::test_policy_action_escalates_alignment_when_entropy_high` before the fix.
- After the change, `pytest -q` in the same demo package reports `22 passed` and the previously failing test now succeeds.
- The wider demo test runner shown in the rollout was also exercised earlier, and other demo suites ran successfully during the debugging session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957cd5c725c83338ce4dd04adf1b691)