### PR TITLE
Add phase transition risk signal to omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -432,6 +432,7 @@ class Orchestrator:
                     "hamiltonian": state.hamiltonian,
                     "entropy": state.entropy,
                     "entropy_production": state.entropy_production,
+                    "phase_transition_risk": state.phase_transition_risk,
                     "temperature": state.temperature,
                     "enthalpy": state.enthalpy,
                     "pressure": state.pressure,
@@ -447,6 +448,7 @@ class Orchestrator:
                     "hamiltonian_pressure": signals["hamiltonian_pressure"],
                     "entropy_pressure": signals["entropy_pressure"],
                     "entropy_production_pressure": signals["entropy_production_pressure"],
+                    "phase_transition_risk": signals["phase_transition_risk"],
                     "stability_guard": signals["stability_guard"],
                 },
             }
@@ -756,6 +758,7 @@ class Orchestrator:
         entropy_pressure = min(1.0, entropy / math.log(2.0))
         entropy_production = max(0.0, state.entropy_production)
         entropy_production_pressure = min(1.0, entropy_production / (1.0 + entropy))
+        phase_transition_risk = max(0.0, min(1.0, state.phase_transition_risk))
         exergy_balance = max(-1.0, min(1.0, state.exergy_balance))
         exergy_pressure = max(0.0, min(1.0, (1.0 - exergy_balance) / 2.0))
         pareto_efficiency = max(0.0, min(1.0, state.pareto_efficiency))
@@ -823,6 +826,7 @@ class Orchestrator:
             "entropy_pressure": entropy_pressure,
             "entropy_production": entropy_production,
             "entropy_production_pressure": entropy_production_pressure,
+            "phase_transition_risk": phase_transition_risk,
             "exergy_balance": exergy_balance,
             "exergy_pressure": exergy_pressure,
             "pareto_efficiency": pareto_efficiency,
@@ -1035,6 +1039,7 @@ class Orchestrator:
                 "entropy_production": signals["entropy_production"],
                 "entropy_production_pressure": signals["entropy_production_pressure"],
                 "stability_guard": signals["stability_guard"],
+                "phase_transition_risk": signals["phase_transition_risk"],
                 "exergy_balance": signals["exergy_balance"],
             },
             "game_theory_snapshot": {
@@ -1074,6 +1079,7 @@ class Orchestrator:
             "hamiltonian_load": hamiltonian_load,
             "exergy_headroom": exergy_headroom,
             "risk_budget": risk_budget,
+            "phase_transition_risk": signals["phase_transition_risk"],
         }
 
     def _build_policy_decision(
@@ -1106,6 +1112,7 @@ class Orchestrator:
         )
         action_budget *= 0.9 + 0.6 * signals["welfare_urgency"] + 0.3 * signals["equity_pressure"]
         action_budget *= 0.5 + 0.5 * risk_budget
+        action_budget *= 1.0 - 0.3 * signals["phase_transition_risk"]
         alignment_risk_budget = max(
             risk_budget,
             0.35 + 0.45 * signals["entropy_pressure"] + 0.2 * signals["entropy_production_pressure"],
@@ -1117,6 +1124,7 @@ class Orchestrator:
             / max(0.6, signals["entropy_damping"])
         )
         alignment_budget *= 1.0 + 0.6 * signals["equity_pressure"]
+        alignment_budget *= 1.0 + 0.4 * signals["phase_transition_risk"]
         alignment_budget *= 0.5 + 0.5 * alignment_risk_budget
         stability_guard = signals["stability_guard"]
         energy_action = action_budget * (0.8 + 0.4 * signals["coordination_damping"]) * stability_guard
@@ -1155,6 +1163,7 @@ class Orchestrator:
             * (0.6 + 0.4 * signals["pareto_efficiency"])
             * (0.6 + 0.4 * signals["equity_pressure"])
             * signals["coordination_damping"]
+            * (1.0 + 0.4 * signals["phase_transition_risk"])
         )
         exergy_recovery = (
             action_budget
@@ -1796,6 +1805,7 @@ class Orchestrator:
                 "pressure": self._latest_simulation_state.pressure,
                 "exergy_balance": self._latest_simulation_state.exergy_balance,
                 "pareto_efficiency": self._latest_simulation_state.pareto_efficiency,
+                "phase_transition_risk": self._latest_simulation_state.phase_transition_risk,
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,
                 "game_theory_slack": self._latest_simulation_state.game_theory_slack,
@@ -1891,6 +1901,7 @@ class Orchestrator:
                 "pressure": self._latest_simulation_state.pressure,
                 "exergy_balance": self._latest_simulation_state.exergy_balance,
                 "pareto_efficiency": self._latest_simulation_state.pareto_efficiency,
+                "phase_transition_risk": self._latest_simulation_state.phase_transition_risk,
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,
                 "game_theory_slack": self._latest_simulation_state.game_theory_slack,

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -27,6 +27,7 @@ class SimulationState:
     pressure: float = 0.0
     exergy_balance: float = 0.0
     pareto_efficiency: float = 0.0
+    phase_transition_risk: float = 0.0
 
     def __post_init__(self) -> None:
         if self.gibbs_free_energy is None:
@@ -121,6 +122,16 @@ class SyntheticEconomySim(PlanetarySimulation):
         exergy_balance = 0.0
         if enthalpy:
             exergy_balance = max(-1.0, min(1.0, gibbs_free_energy / enthalpy))
+        entropy_production_pressure = min(1.0, entropy_production / (1.0 + entropy))
+        gibbs_stress = 0.0
+        if enthalpy:
+            gibbs_stress = min(1.0, abs(gibbs_free_energy) / max(1e-6, enthalpy))
+        phase_transition_risk = (
+            0.5 * entropy_production_pressure
+            + 0.3 * (1.0 - coordination_index)
+            + 0.2 * gibbs_stress
+        )
+        phase_transition_risk = min(1.0, max(0.0, phase_transition_risk))
         return {
             "nash_welfare": nash_welfare,
             "sentient_welfare_index": sentient_welfare_index,
@@ -137,6 +148,7 @@ class SyntheticEconomySim(PlanetarySimulation):
             "pressure": pressure,
             "exergy_balance": exergy_balance,
             "pareto_efficiency": pareto_efficiency,
+            "phase_transition_risk": phase_transition_risk,
         }
 
     def tick(self, hours: float) -> SimulationState:
@@ -167,4 +179,5 @@ class SyntheticEconomySim(PlanetarySimulation):
             pressure=metrics["pressure"],
             exergy_balance=metrics["exergy_balance"],
             pareto_efficiency=metrics["pareto_efficiency"],
+            phase_transition_risk=metrics["phase_transition_risk"],
         )

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
@@ -20,8 +20,12 @@ def test_simulation_thermodynamic_metrics() -> None:
     temperature = 1.0 + (1.0 - state.sustainability_index)
     internal_energy = state.energy_output_gw / 1_000_000.0
     free_energy = internal_energy - temperature * entropy
+    pressure = 1.0 + 0.5 * (1.0 - state.prosperity_index) + 0.5 * (1.0 - state.sustainability_index)
     hamiltonian = -internal_energy * order_parameter
     coordination_index = 1.0 - abs(state.prosperity_index - state.sustainability_index)
+    volume = 1.0 + coordination_index
+    enthalpy = internal_energy + pressure * volume
+    gibbs_free_energy = enthalpy - temperature * entropy
     entropy_production = max(0.0, entropy * temperature * (1.0 - coordination_index))
     stability_index = math.exp(-entropy) * (1.0 / (1.0 + abs(hamiltonian)))
     stability_index *= 0.5 + 0.5 * coordination_index
@@ -30,6 +34,14 @@ def test_simulation_thermodynamic_metrics() -> None:
         max(1e-6, state.prosperity_index) * max(1e-6, state.sustainability_index)
     )
     game_theory_slack = min(1.0, nash_welfare * (0.5 + 0.5 * coordination_index))
+    entropy_production_pressure = min(1.0, entropy_production / (1.0 + entropy))
+    gibbs_stress = min(1.0, abs(gibbs_free_energy) / max(1e-6, enthalpy))
+    phase_transition_risk = (
+        0.5 * entropy_production_pressure
+        + 0.3 * (1.0 - coordination_index)
+        + 0.2 * gibbs_stress
+    )
+    phase_transition_risk = min(1.0, max(0.0, phase_transition_risk))
 
     assert state.entropy == pytest.approx(entropy)
     assert state.entropy_production == pytest.approx(entropy_production)
@@ -39,6 +51,7 @@ def test_simulation_thermodynamic_metrics() -> None:
     assert state.stability_index == pytest.approx(stability_index)
     assert state.coordination_index == pytest.approx(coordination_index)
     assert state.game_theory_slack == pytest.approx(game_theory_slack)
+    assert state.phase_transition_risk == pytest.approx(phase_transition_risk)
     assert 0.0 <= state.coordination_index <= 1.0
     assert 0.0 <= state.stability_index <= 1.0
     assert 0.0 <= state.game_theory_slack <= 1.0


### PR DESCRIPTION
### Motivation
- Surface a compact thermodynamic risk metric to detect dangerous phase-transition-like regimes in the synthetic planetary economy and improve policy stability. 
- Feed that signal into policy decision-making so autonomous actions trade off growth against systemic instability. 
- Reduce risky expansion when entropy production, coordination breakdown, or Gibbs stress indicate elevated transition risk. 

### Description
- Add `phase_transition_risk` to `SimulationState` and compute it in `SyntheticEconomySim` using entropy production pressure, coordination deficit, and Gibbs stress. 
- Surface the metric through orchestrator payloads: `insights` payloads, status snapshots, energy snapshots, and policy briefs via `_build_insight_payload`, `_collect_status_snapshot`, and `_collect_energy_snapshot`. 
- Expose the metric in policy signals returned by `_compute_policy_signals` and incorporate it into budgeting and incentives by scaling `action_budget`, `alignment_budget`, and `coordination_incentives`. 
- Update `test_simulation_metrics.py` to validate the new `phase_transition_risk` computation. 

### Testing
- Ran `pytest "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests"` and observed `23 passed` (all tests in that suite passed). 
- Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests` earlier and observed `22 passed` (no regressions in the wrapper suite). 
- Executed the demo runner `demo/Kardashev-II Omega-Grade-α-AGI Business-3/bin/run.sh --cycles 1 --no-resume --no-sim` for a short smoke-run and the orchestrator completed a cycle without error. 
- All modified and existing automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957e326043083339c1d3e5de41c3d90)