### PR TITLE
Auto-generate Kardashev II artefacts before serving

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/kardashev-report.md
@@ -31,6 +31,14 @@ Generated: 2125-01-01T22:58:01.595Z
 | mars    | 109,212      | 120               | 17 min         | 0.999      | 96.05%             |
 | orbital | 633,731      | 126               | 6 min          | 0.999      | 96.05%             |
 
+## Shard Thermodynamic Ledger
+
+| Shard   | Region        | Free Energy GW | Gibbs Free Energy GJ | Hamiltonian Stability | Game-Theory Slack |
+| ------- | ------------- | -------------- | -------------------- | --------------------- | ----------------- |
+| earth   | earth-grid    | 14,654.5       | 52,756,200           | 38.7%                 | 6.4%              |
+| mars    | mars-dome     | 4,305.5        | 15,499,800           | 33.9%                 | 6.4%              |
+| orbital | orbital-swarm | 103,372.62     | 372,141,431.37       | 43.2%                 | 6.4%              |
+
 ## Thermodynamic Allocation Policy
 
 | Shard   | Boltzmann Weight | Effective Weight | Recommended GW | Capacity GW | Nash Payoff |

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/serve-dashboard.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/scripts/serve-dashboard.cjs
@@ -3,9 +3,18 @@
 const http = require('http');
 const fs = require('fs/promises');
 const path = require('path');
+const { spawnSync } = require('child_process');
 const { pathToFileURL } = require('url');
 
 const DEMO_ROOT = path.resolve(__dirname, '..');
+const OUTPUT_DIR = path.join(DEMO_ROOT, 'output');
+const REQUIRED_ARTEFACTS = [
+  'index.html',
+  'kardashev-telemetry.json',
+  'kardashev-stability-ledger.json',
+  'kardashev-equilibrium-ledger.json',
+  'kardashev-owner-proof.json',
+];
 
 const MIME_TYPES = {
   '.html': 'text/html; charset=utf-8',
@@ -64,6 +73,7 @@ async function readFileOr404(targetPath, res) {
 
 async function startServer() {
   const { port } = parseArgs(process.argv.slice(2));
+  await ensureArtefacts();
 
   const server = http.createServer(async (req, res) => {
     if (!req.url) {
@@ -88,6 +98,33 @@ async function startServer() {
     console.log('   Serve this URL in a browser to load telemetry without CORS errors.');
     console.log(`   Demo root: ${pathToFileURL(DEMO_ROOT).toString()}`);
   });
+}
+
+async function ensureArtefacts() {
+  const missing = [];
+  for (const filename of REQUIRED_ARTEFACTS) {
+    const targetPath = path.join(OUTPUT_DIR, filename);
+    try {
+      await fs.stat(targetPath);
+    } catch (error) {
+      missing.push(filename);
+    }
+  }
+
+  if (missing.length === 0) {
+    return;
+  }
+
+  console.log(
+    `⚠️ Missing Kardashev II artefacts (${missing.join(', ')}). Regenerating via run-demo.cjs...`
+  );
+  const result = spawnSync(process.execPath, [path.join(DEMO_ROOT, 'run-demo.cjs')], {
+    stdio: 'inherit',
+    cwd: DEMO_ROOT,
+  });
+  if (result.status !== 0) {
+    throw new Error('Failed to regenerate Kardashev II demo artefacts.');
+  }
 }
 
 startServer().catch((error) => {


### PR DESCRIPTION
### Motivation
- Ensure the Kardashev-II dashboard can be served from a fresh checkout without requiring a manual orchestrator run. 
- Prevent local-browser fetch failures and CI/documentation drift by guaranteeing the offline output artefacts exist. 
- Make the operator quickstart simpler and more robust by auto-regenerating missing telemetry and ledger files.

### Description
- Add `OUTPUT_DIR`, `REQUIRED_ARTEFACTS` and an `ensureArtefacts()` helper to `scripts/serve-dashboard.cjs` which checks for key artefacts and runs the demo orchestrator if any are missing. 
- Invoke `ensureArtefacts()` before the server starts so the dashboard serves complete offline assets (`index.html`, telemetry, ledgers, owner-proof). 
- Use `spawnSync` to run the existing `run-demo.cjs` in-place to regenerate artefacts, and throw an error if regeneration fails. 
- Refresh the generated `output/kardashev-report.md` so report content stays in sync with the orchestrator output.

### Testing
- Ran `npm run demo:kardashev` to regenerate orchestration artefacts and observed a successful generation summary. 
- Ran `npm run demo:kardashev-ii:ci` and observed the CI validation pass (artefacts up-to-date and README verified). 
- Executed the demo test suites including `python demo/run_demo_tests.py` and `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py`, and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957f9a9c7388333bb014160d3aee741)