### PR TITLE
Add phase-transition auto-pause/resume guard to Omega demo orchestrator

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/config/default.json
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/config/default.json
@@ -34,6 +34,9 @@
   "status_output_path": "logs/omega-status.jsonl",
   "energy_oracle_path": "logs/omega-energy-oracle.jsonl",
   "energy_oracle_interval_seconds": 60.0,
+  "auto_pause_on_phase_transition": true,
+  "phase_transition_pause_threshold": 0.85,
+  "phase_transition_resume_threshold": 0.7,
   "initial_jobs": [
     {
       "title": "Planetary Dyson Swarm Expansion",

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/cli.py
@@ -35,6 +35,13 @@ def _require_positive(value: float, *, field: str, allow_zero: bool = False) -> 
             raise ValueError(f"{field} must be positive (got {value})")
 
 
+def _require_unit_interval(value: float, *, field: str) -> None:
+    """Validate that a configuration value is within [0, 1]."""
+
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{field} must be between 0 and 1 (got {value})")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run the Kardashev-II Omega-Grade α-AGI Business 3 demo")
     parser.add_argument(
@@ -118,6 +125,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Seconds between autonomous policy actions",
     )
     parser.add_argument(
+        "--auto-phase-pause",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Automatically pause the orchestrator if phase-transition risk spikes",
+    )
+    parser.add_argument(
+        "--phase-transition-pause-threshold",
+        type=float,
+        default=0.85,
+        help="Phase-transition risk level that triggers an automatic pause",
+    )
+    parser.add_argument(
+        "--phase-transition-resume-threshold",
+        type=float,
+        default=0.7,
+        help="Phase-transition risk level that clears an automatic pause",
+    )
+    parser.add_argument(
         "--config",
         type=Path,
         help=(
@@ -187,6 +212,22 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
     _require_positive(checkpoint_interval, field="checkpoint_interval_seconds")
     cycle_sleep = float(overrides.get("cycle_sleep_seconds", OrchestratorConfig.cycle_sleep_seconds))
     _require_positive(cycle_sleep, field="cycle_sleep_seconds")
+    auto_pause_value = overrides.get("auto_pause_on_phase_transition", args.auto_phase_pause)
+    phase_pause_threshold = float(
+        overrides.get("phase_transition_pause_threshold", args.phase_transition_pause_threshold)
+    )
+    phase_resume_threshold = float(
+        overrides.get("phase_transition_resume_threshold", args.phase_transition_resume_threshold)
+    )
+    _require_unit_interval(phase_pause_threshold, field="phase_transition_pause_threshold")
+    _require_unit_interval(phase_resume_threshold, field="phase_transition_resume_threshold")
+    if phase_resume_threshold > phase_pause_threshold:
+        raise ValueError(
+            "phase_transition_resume_threshold must be less than or equal to phase_transition_pause_threshold"
+        )
+    overrides["auto_pause_on_phase_transition"] = bool(auto_pause_value)
+    overrides["phase_transition_pause_threshold"] = phase_pause_threshold
+    overrides["phase_transition_resume_threshold"] = phase_resume_threshold
 
     params = {
         "max_cycles": args.cycles or None,
@@ -211,6 +252,9 @@ def build_config(args: argparse.Namespace, overrides: Optional[dict[str, Any]] =
         "heartbeat_timeout_seconds": args.heartbeat_timeout,
         "health_check_interval_seconds": args.health_check_interval,
         "integrity_check_interval_seconds": args.integrity_interval,
+        "auto_pause_on_phase_transition": overrides["auto_pause_on_phase_transition"],
+        "phase_transition_pause_threshold": overrides["phase_transition_pause_threshold"],
+        "phase_transition_resume_threshold": overrides["phase_transition_resume_threshold"],
     }
     params.update(overrides)
     params["checkpoint_interval_seconds"] = checkpoint_interval

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -68,6 +68,9 @@ class OrchestratorConfig:
     heartbeat_timeout_seconds: float = 30.0
     health_check_interval_seconds: float = 5.0
     integrity_check_interval_seconds: float = 30.0
+    auto_pause_on_phase_transition: bool = True
+    phase_transition_pause_threshold: float = 0.85
+    phase_transition_resume_threshold: float = 0.7
 
 
 class Orchestrator:
@@ -104,6 +107,7 @@ class Orchestrator:
         self._running = False
         self._paused = asyncio.Event()
         self._paused.set()
+        self._phase_transition_paused = False
         self._cycle = 0
         self._stopped = asyncio.Event()
         self._status_path = config.status_output_path
@@ -511,6 +515,30 @@ class Orchestrator:
             energy_price=self.resources.energy_price,
             compute_price=self.resources.compute_price,
         )
+        self._apply_phase_transition_guard(state)
+
+    def _apply_phase_transition_guard(self, state: SimulationState) -> None:
+        if not self.config.auto_pause_on_phase_transition:
+            return
+        risk = float(state.phase_transition_risk)
+        pause_threshold = float(self.config.phase_transition_pause_threshold)
+        resume_threshold = float(self.config.phase_transition_resume_threshold)
+        if not self._phase_transition_paused and risk >= pause_threshold:
+            self._phase_transition_paused = True
+            self._warning(
+                "phase_transition_pause",
+                risk=risk,
+                threshold=pause_threshold,
+            )
+            self.pause()
+        elif self._phase_transition_paused and risk <= resume_threshold:
+            self._phase_transition_paused = False
+            self._info(
+                "phase_transition_resume",
+                risk=risk,
+                threshold=resume_threshold,
+            )
+            self.resume()
 
     async def _simulation_loop(self) -> None:
         assert self.simulation is not None

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_phase_transition_guard.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_phase_transition_guard.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.orchestrator import (
+    Orchestrator,
+    OrchestratorConfig,
+)
+from demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo.simulation import SimulationState
+
+
+def test_phase_transition_guard_pauses_and_resumes(tmp_path: Path) -> None:
+    orchestrator = Orchestrator(
+        OrchestratorConfig(
+            control_channel_file=tmp_path / "control.jsonl",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            status_output_path=None,
+            audit_log_path=None,
+            energy_oracle_path=None,
+            auto_pause_on_phase_transition=True,
+            phase_transition_pause_threshold=0.6,
+            phase_transition_resume_threshold=0.4,
+        )
+    )
+
+    high_risk_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.7,
+        sustainability_index=0.6,
+        phase_transition_risk=0.75,
+    )
+    orchestrator._apply_simulation_state(high_risk_state, event="simulation_tick")
+
+    assert orchestrator._phase_transition_paused is True
+    assert not orchestrator._paused.is_set()
+
+    low_risk_state = SimulationState(
+        energy_output_gw=505_000.0,
+        prosperity_index=0.72,
+        sustainability_index=0.62,
+        phase_transition_risk=0.3,
+    )
+    orchestrator._apply_simulation_state(low_risk_state, event="simulation_tick")
+
+    assert orchestrator._phase_transition_paused is False
+    assert orchestrator._paused.is_set()


### PR DESCRIPTION
### Motivation
- Prevent uncontrolled phase transitions in the Kardashev-II Omega-grade demo by automatically pausing the orchestrator when the simulation reports dangerously high phase-transition risk. 
- Expose safe, configurable thresholds and CLI flags so operators can tune automated protection without modifying code. 
- Provide deterministic behaviour for automated policy loops that act on thermodynamic/game-theory signals.

### Description
- Add `auto_pause_on_phase_transition`, `phase_transition_pause_threshold`, and `phase_transition_resume_threshold` to `OrchestratorConfig` and default config to enable configurable auto-pause behaviour. 
- Implement `_apply_phase_transition_guard` and integrate it into `_apply_simulation_state`, tracking `_phase_transition_paused` and invoking `pause()`/`resume()` when thresholds are crossed. 
- Add CLI flags (`--auto-phase-pause`, `--phase-transition-pause-threshold`, `--phase-transition-resume-threshold`) with validation via a new `_require_unit_interval` helper and a sanity check ensuring resume threshold ≤ pause threshold. 
- Add unit test `tests/test_phase_transition_guard.py` that verifies the orchestrator pauses and resumes when simulated `phase_transition_risk` crosses the configured thresholds.

### Testing
- Ran the demo test-suite with `pytest -q` for `demo/Kardashev-II Omega-Grade-α-AGI Business-3` and all tests passed: `30 passed in 0.94s`.
- The new `test_phase_transition_guard.py` executed as part of that run and passed. 
- Existing demo tests were exercised during the rollout (multiple demo suites executed) and remained green. 
- No failing automated tests were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958179f789483338848204782f811b8)