### PR TITLE
Fix offline dashboard inline payload loading

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -1,6 +1,13 @@
 let mermaidModule;
 
 const DEFAULT_ASSET_BASE = "./output";
+const INLINE_PAYLOADS = [
+  { key: "__KARDASHEV_TELEMETRY__", filename: "kardashev-telemetry.inline.js" },
+  { key: "__KARDASHEV_LEDGER__", filename: "kardashev-stability-ledger.inline.js" },
+  { key: "__KARDASHEV_EQUILIBRIUM__", filename: "kardashev-equilibrium-ledger.inline.js" },
+  { key: "__KARDASHEV_OWNER_PROOF__", filename: "kardashev-owner-proof.inline.js" },
+  { key: "__KARDASHEV_DIAGRAMS__", filename: "kardashev-diagrams.inline.js" },
+];
 
 function resolveAssetBase() {
   const explicitBase = window.__KARDASHEV_ASSET_BASE__;
@@ -59,6 +66,60 @@ function loadMermaidScript(url) {
     script.onerror = () => reject(new Error(`Failed to load mermaid script from ${url}`));
     document.head.appendChild(script);
   });
+}
+
+function loadInlineScript(url) {
+  if (!url) {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[data-kardashev-inline="${url}"]`);
+    if (existing) {
+      existing.addEventListener("load", () => resolve(), { once: true });
+      existing.addEventListener(
+        "error",
+        () => reject(new Error(`Failed to load inline payload from ${url}`)),
+        { once: true }
+      );
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = url;
+    script.async = true;
+    script.dataset.kardashevInline = url;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Failed to load inline payload from ${url}`));
+    document.head.appendChild(script);
+  });
+}
+
+async function hydrateInlinePayloads() {
+  const payloads = {};
+  for (const entry of INLINE_PAYLOADS) {
+    const existing = readInlinePayload(entry.key);
+    if (existing) {
+      payloads[entry.key] = existing;
+      continue;
+    }
+
+    try {
+      await loadInlineScript(assetPath(entry.filename));
+      payloads[entry.key] = readInlinePayload(entry.key);
+    } catch (error) {
+      console.warn(`Failed to load inline payload ${entry.filename}`, error);
+      payloads[entry.key] = null;
+    }
+  }
+
+  return {
+    telemetry: payloads.__KARDASHEV_TELEMETRY__ ?? null,
+    ledger: payloads.__KARDASHEV_LEDGER__ ?? null,
+    equilibrium: payloads.__KARDASHEV_EQUILIBRIUM__ ?? null,
+    ownerProof: payloads.__KARDASHEV_OWNER_PROOF__ ?? null,
+    diagrams: payloads.__KARDASHEV_DIAGRAMS__ ?? null,
+  };
 }
 
 async function loadMermaid() {
@@ -1988,12 +2049,21 @@ function renderOwnerProof(ownerProof, telemetry) {
 }
 
 async function bootstrap() {
-  const inlineTelemetry = readInlinePayload("__KARDASHEV_TELEMETRY__");
-  const inlineLedger = readInlinePayload("__KARDASHEV_LEDGER__");
-  const inlineEquilibrium = readInlinePayload("__KARDASHEV_EQUILIBRIUM__");
-  const inlineOwnerProof = readInlinePayload("__KARDASHEV_OWNER_PROOF__");
-  const inlineDiagrams = readInlinePayload("__KARDASHEV_DIAGRAMS__");
+  let inlineTelemetry = readInlinePayload("__KARDASHEV_TELEMETRY__");
+  let inlineLedger = readInlinePayload("__KARDASHEV_LEDGER__");
+  let inlineEquilibrium = readInlinePayload("__KARDASHEV_EQUILIBRIUM__");
+  let inlineOwnerProof = readInlinePayload("__KARDASHEV_OWNER_PROOF__");
+  let inlineDiagrams = readInlinePayload("__KARDASHEV_DIAGRAMS__");
   const isFileProtocol = window.location.protocol === "file:";
+
+  if (isFileProtocol && !inlineTelemetry) {
+    const hydrated = await hydrateInlinePayloads();
+    inlineTelemetry = hydrated.telemetry ?? inlineTelemetry;
+    inlineLedger = hydrated.ledger ?? inlineLedger;
+    inlineEquilibrium = hydrated.equilibrium ?? inlineEquilibrium;
+    inlineOwnerProof = hydrated.ownerProof ?? inlineOwnerProof;
+    inlineDiagrams = hydrated.diagrams ?? inlineDiagrams;
+  }
 
   if (isFileProtocol && !inlineTelemetry) {
     renderLocalFileWarning();


### PR DESCRIPTION
### Motivation
- The Kardashev II dashboard must work when opened from a local file URL without an HTTP server by hydrating telemetry and ledger payloads already emitted into `output/`.
- The UI previously assumed either inline payloads exist or remote fetches succeed, causing the dashboard to show a hard failure when run as `file://`.
- Improve robustness for offline/CI workflows where artefacts are produced by the Node orchestrator and consumed locally by the dashboard.

### Description
- Added an `INLINE_PAYLOADS` list and a `loadInlineScript` helper to inject local inline payload scripts (e.g. `kardashev-telemetry.inline.js`) when needed.
- Implemented `hydrateInlinePayloads` to prefer any already-present inline globals and fall back to loading the corresponding `.inline.js` files via `assetPath` when running from `file:`.
- Updated `bootstrap` to attempt hydration on `file://` loads before rendering the local-file warning, preserving existing network fetch fallback for HTTP serving.
- Added console warnings when inline payload assets fail to load and preserved prior behaviour for mermaid/diagram fallbacks.

### Testing
- Ran the Kardashev II demo validation: `python demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py --check`, which completed successfully.
- Ran the demo test runner (`python demo/run_demo_tests.py`) during investigation and the repository demo suites were observed to pass in the environment used (all relevant demo suites green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958224198188333a86db955a8b876e7)