### PR TITLE
Expose primary equilibrium action in Kardashev II dashboard

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -139,6 +139,8 @@
         </div>
         <p id="equilibrium-summary" class="lede">…</p>
         <ul id="equilibrium-components" class="ledger-list"></ul>
+        <h3>Primary action</h3>
+        <ul id="equilibrium-primary-action" class="ledger-list"></ul>
         <h3>Thermodynamics</h3>
         <ul id="equilibrium-thermo" class="ledger-list"></ul>
         <h3>Game-theory posture</h3>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/index.html
@@ -139,6 +139,8 @@
         </div>
         <p id="equilibrium-summary" class="lede">…</p>
         <ul id="equilibrium-components" class="ledger-list"></ul>
+        <h3>Primary action</h3>
+        <ul id="equilibrium-primary-action" class="ledger-list"></ul>
         <h3>Thermodynamics</h3>
         <ul id="equilibrium-thermo" class="ledger-list"></ul>
         <h3>Game-theory posture</h3>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/ui/dashboard.js
@@ -358,6 +358,15 @@ function renderEquilibriumUnavailable(reason) {
     gameTheory.appendChild(li);
   }
 
+  const primaryAction = document.querySelector("#equilibrium-primary-action");
+  if (primaryAction) {
+    primaryAction.innerHTML = "";
+    const li = document.createElement("li");
+    li.textContent = "Primary action pending equilibrium ledger refresh.";
+    li.classList.add("status-warn");
+    primaryAction.appendChild(li);
+  }
+
   const pathways = document.querySelector("#equilibrium-pathways");
   if (pathways) {
     pathways.innerHTML = "";
@@ -1698,6 +1707,7 @@ function renderEquilibriumLedger(ledger) {
   const thermoList = document.querySelector("#equilibrium-thermo");
   const gameTheoryList = document.querySelector("#equilibrium-game-theory");
   const pathwaysList = document.querySelector("#equilibrium-pathways");
+  const primaryActionList = document.querySelector("#equilibrium-primary-action");
   const actionPathList = document.querySelector("#equilibrium-action-path");
   const recommendationsList = document.querySelector("#equilibrium-recommendations");
   if (
@@ -1706,6 +1716,7 @@ function renderEquilibriumLedger(ledger) {
     !thermoList ||
     !gameTheoryList ||
     !pathwaysList ||
+    !primaryActionList ||
     !actionPathList ||
     !recommendationsList
   )
@@ -1756,6 +1767,23 @@ function renderEquilibriumLedger(ledger) {
     li.classList.add(score >= 0.9 ? "status-ok" : score >= 0.8 ? "status-warn" : "status-fail");
     componentsList.appendChild(li);
   });
+
+  primaryActionList.innerHTML = "";
+  if (!ledger.primaryAction) {
+    const li = document.createElement("li");
+    li.textContent = "No primary equilibrium action required.";
+    li.classList.add("status-ok");
+    primaryActionList.appendChild(li);
+  } else {
+    const action = ledger.primaryAction;
+    const li = document.createElement("li");
+    const priorityText = Number.isFinite(action.priorityScore)
+      ? `<br /><span>Priority: ${formatPercent(action.priorityScore)}</span>`
+      : "";
+    li.innerHTML = `<strong>${action.rank}. ${action.title}</strong> — ${action.rationale}<br /><span>${action.action}</span><br /><span>Target: ${action.target}</span>${priorityText}`;
+    li.classList.add(action.status === "needs-action" ? "status-warn" : "status-ok");
+    primaryActionList.appendChild(li);
+  }
 
   const thermodynamics = ledger.thermodynamics ?? {};
   const gameTheory = ledger.gameTheory ?? {};

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -358,6 +358,15 @@ function renderEquilibriumUnavailable(reason) {
     gameTheory.appendChild(li);
   }
 
+  const primaryAction = document.querySelector("#equilibrium-primary-action");
+  if (primaryAction) {
+    primaryAction.innerHTML = "";
+    const li = document.createElement("li");
+    li.textContent = "Primary action pending equilibrium ledger refresh.";
+    li.classList.add("status-warn");
+    primaryAction.appendChild(li);
+  }
+
   const pathways = document.querySelector("#equilibrium-pathways");
   if (pathways) {
     pathways.innerHTML = "";
@@ -1698,6 +1707,7 @@ function renderEquilibriumLedger(ledger) {
   const thermoList = document.querySelector("#equilibrium-thermo");
   const gameTheoryList = document.querySelector("#equilibrium-game-theory");
   const pathwaysList = document.querySelector("#equilibrium-pathways");
+  const primaryActionList = document.querySelector("#equilibrium-primary-action");
   const actionPathList = document.querySelector("#equilibrium-action-path");
   const recommendationsList = document.querySelector("#equilibrium-recommendations");
   if (
@@ -1706,6 +1716,7 @@ function renderEquilibriumLedger(ledger) {
     !thermoList ||
     !gameTheoryList ||
     !pathwaysList ||
+    !primaryActionList ||
     !actionPathList ||
     !recommendationsList
   )
@@ -1756,6 +1767,23 @@ function renderEquilibriumLedger(ledger) {
     li.classList.add(score >= 0.9 ? "status-ok" : score >= 0.8 ? "status-warn" : "status-fail");
     componentsList.appendChild(li);
   });
+
+  primaryActionList.innerHTML = "";
+  if (!ledger.primaryAction) {
+    const li = document.createElement("li");
+    li.textContent = "No primary equilibrium action required.";
+    li.classList.add("status-ok");
+    primaryActionList.appendChild(li);
+  } else {
+    const action = ledger.primaryAction;
+    const li = document.createElement("li");
+    const priorityText = Number.isFinite(action.priorityScore)
+      ? `<br /><span>Priority: ${formatPercent(action.priorityScore)}</span>`
+      : "";
+    li.innerHTML = `<strong>${action.rank}. ${action.title}</strong> — ${action.rationale}<br /><span>${action.action}</span><br /><span>Target: ${action.target}</span>${priorityText}`;
+    li.classList.add(action.status === "needs-action" ? "status-warn" : "status-ok");
+    primaryActionList.appendChild(li);
+  }
 
   const thermodynamics = ledger.thermodynamics ?? {};
   const gameTheory = ledger.gameTheory ?? {};


### PR DESCRIPTION
### Motivation
- Make the next operator step explicit by surfacing the primary equilibrium action in the Equilibrium ledger UI so mission owners can act quickly.  
- Improve offline and online dashboard parity by keeping generated `output/` artefacts in sync with the UI layout.  
- Provide a clear fallback state when the orchestrator ledger is missing so the dashboard communicates required regeneration.  
- Reduce cognitive load for owners by rendering status styling for urgent primary actions.

### Description
- Add a new `Primary action` subsection and an `#equilibrium-primary-action` list to `index.html` and the generated `output/index.html`.  
- Render primary action details (title, rationale, action, target, priority and status) in `ui/dashboard.js` and the offline copy at `output/ui/dashboard.js`.  
- Show a friendly fallback entry when the equilibrium ledger or `primaryAction` is unavailable to guide users to run the orchestrator.  
- Keep offline dashboard copies updated by modifying the exported `output/` UI so `npm run demo:kardashev-ii:serve` loads the new section without extra steps.

### Testing
- Ran the Kardashev II CI validator with `npm run demo:kardashev-ii:ci` and it completed successfully.  
- Executed the demo generator `npm run demo:kardashev` which produced orchestration artefacts without errors.  
- Ran the full demo test runner `python demo/run_demo_tests.py` and it reported all demo test suites passed.  
- Ran the local equilibrium demo tests with `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests` which passed (`16 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585fde075883339744f5788faa2bed)