### PR TITLE
Hydrate inline dashboard payloads when any telemetry is missing (Kardashev II dashboard)

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/output/ui/dashboard.js
@@ -2084,7 +2084,15 @@ async function bootstrap() {
   let inlineDiagrams = readInlinePayload("__KARDASHEV_DIAGRAMS__");
   const isFileProtocol = window.location.protocol === "file:";
 
-  if (isFileProtocol) {
+  const shouldHydrateInline =
+    isFileProtocol ||
+    !inlineTelemetry ||
+    !inlineLedger ||
+    !inlineEquilibrium ||
+    !inlineOwnerProof ||
+    !inlineDiagrams;
+
+  if (shouldHydrateInline) {
     const hydrated = await hydrateInlinePayloads();
     inlineTelemetry = hydrated.telemetry ?? inlineTelemetry;
     inlineLedger = hydrated.ledger ?? inlineLedger;

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -2084,7 +2084,15 @@ async function bootstrap() {
   let inlineDiagrams = readInlinePayload("__KARDASHEV_DIAGRAMS__");
   const isFileProtocol = window.location.protocol === "file:";
 
-  if (isFileProtocol) {
+  const shouldHydrateInline =
+    isFileProtocol ||
+    !inlineTelemetry ||
+    !inlineLedger ||
+    !inlineEquilibrium ||
+    !inlineOwnerProof ||
+    !inlineDiagrams;
+
+  if (shouldHydrateInline) {
     const hydrated = await hydrateInlinePayloads();
     inlineTelemetry = hydrated.telemetry ?? inlineTelemetry;
     inlineLedger = hydrated.ledger ?? inlineLedger;


### PR DESCRIPTION
### Motivation
- Improve robustness of the Kardashev II dashboard so the UI can render when inline payloads are partially missing, not only under `file:` protocol loads.
- Prevent blank dashboards or confusing fetch errors when generated artefacts are present but inline payload embedding is incomplete.
- Keep generated `output/ui/dashboard.js` consistent with the source `ui/dashboard.js` to avoid divergence between shipped artefacts and the source code.

### Description
- Change the dashboard bootstrap to compute `shouldHydrateInline` and call `hydrateInlinePayloads()` whenever any of `inlineTelemetry`, `inlineLedger`, `inlineEquilibrium`, `inlineOwnerProof`, or `inlineDiagrams` is missing, not only when `window.location.protocol === 'file:'`.
- Apply the same logic to the generated output bundle at `output/ui/dashboard.js` so offline artefacts behave identically to the source UI.
- Keep existing `renderLocalFileWarning()` behaviour for true local file protocol cases where telemetry still cannot be loaded.

### Testing
- Ran `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and the suite completed successfully with `16 passed`.
- Verified the UI logic change by ensuring dashboard inline hydration path is exercised when inline payloads are absent (covered by the demo tests).
- No automated tests failed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69586709ecb08333ae1d46938af9f364)