### PR TITLE
Add cooperation potential signal to omega demo policy engine

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -442,11 +442,12 @@ class Orchestrator:
                     "pressure": state.pressure,
                 },
                 "game_theory": {
-                    "nash_welfare": state.nash_welfare,
-                    "sentient_welfare_index": state.sentient_welfare_index,
-                    "game_theory_slack": state.game_theory_slack,
-                    "coordination_index": state.coordination_index,
-                },
+                "nash_welfare": state.nash_welfare,
+                "sentient_welfare_index": state.sentient_welfare_index,
+                "game_theory_slack": state.game_theory_slack,
+                "coordination_index": state.coordination_index,
+                "cooperation_potential": state.cooperation_potential,
+            },
                 "policy_signals": {
                     "gibbs_drive": signals["gibbs_drive"],
                     "hamiltonian_pressure": signals["hamiltonian_pressure"],
@@ -778,6 +779,8 @@ class Orchestrator:
         sustainability_gap = max(0.0, 1.0 - state.sustainability_index)
         coordination_gap = max(0.0, 1.0 - state.coordination_index)
         game_theory_slack = max(0.0, min(1.0, state.game_theory_slack))
+        cooperation_potential = max(0.0, min(1.0, state.cooperation_potential))
+        cooperation_gap = max(0.0, 1.0 - cooperation_potential)
         nash_welfare = max(0.0, min(1.0, state.nash_welfare))
         sentient_welfare_index = max(0.0, min(1.0, state.sentient_welfare_index))
         welfare_floor = max(0.0, min(state.prosperity_index, state.sustainability_index))
@@ -829,7 +832,10 @@ class Orchestrator:
         welfare_urgency = max(0.0, 1.0 - sentient_welfare_index)
         coordination_pressure = max(
             0.0,
-            min(1.0, 0.5 * coordination_gap + 0.5 * (1.0 - game_theory_slack)),
+            min(
+                1.0,
+                0.4 * coordination_gap + 0.4 * (1.0 - game_theory_slack) + 0.2 * cooperation_gap,
+            ),
         )
         stability_guard = 1.0 - 0.55 * entropy_pressure - 0.35 * coordination_gap - 0.2 * hamiltonian_pressure
         stability_guard -= 0.15 * entropy_production_pressure
@@ -846,6 +852,8 @@ class Orchestrator:
             "sustainability_gap": sustainability_gap,
             "coordination_gap": coordination_gap,
             "game_theory_slack": game_theory_slack,
+            "cooperation_potential": cooperation_potential,
+            "cooperation_gap": cooperation_gap,
             "nash_welfare": nash_welfare,
             "sentient_welfare_index": sentient_welfare_index,
             "welfare_floor": welfare_floor,
@@ -1077,6 +1085,7 @@ class Orchestrator:
                 "sentient_welfare_index": state.sentient_welfare_index,
                 "coordination_index": state.coordination_index,
                 "game_theory_slack": state.game_theory_slack,
+                "cooperation_potential": state.cooperation_potential,
                 "pareto_efficiency": state.pareto_efficiency,
             },
         }
@@ -1179,6 +1188,7 @@ class Orchestrator:
         alignment_investment = (
             alignment_budget
             * signals["coordination_gap"]
+            * (0.8 + 0.4 * signals["cooperation_gap"])
             * (0.6 + 0.4 * signals["welfare_urgency"])
             * (0.7 + 0.3 * signals["stability_index"])
             * (0.7 + 0.6 * signals["pareto_gap"])
@@ -1195,6 +1205,7 @@ class Orchestrator:
         coordination_incentives = (
             alignment_budget
             * signals["coordination_pressure"]
+            * (0.7 + 0.6 * signals["cooperation_gap"])
             * (0.6 + 0.4 * signals["welfare_urgency"])
             * (0.7 + 0.3 * signals["stability_index"])
             * (0.6 + 0.4 * signals["pareto_efficiency"])
@@ -1848,6 +1859,7 @@ class Orchestrator:
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,
                 "game_theory_slack": self._latest_simulation_state.game_theory_slack,
+                "cooperation_potential": self._latest_simulation_state.cooperation_potential,
                 "equilibrium_forecast": self._build_equilibrium_forecast(self._latest_simulation_state),
             }
             policy_snapshot = self._build_policy_snapshot(self._latest_simulation_state)
@@ -1944,6 +1956,7 @@ class Orchestrator:
                 "stability_index": self._latest_simulation_state.stability_index,
                 "coordination_index": self._latest_simulation_state.coordination_index,
                 "game_theory_slack": self._latest_simulation_state.game_theory_slack,
+                "cooperation_potential": self._latest_simulation_state.cooperation_potential,
                 "equilibrium_forecast": self._build_equilibrium_forecast(self._latest_simulation_state),
             }
         return {

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/simulation.py
@@ -22,6 +22,7 @@ class SimulationState:
     stability_index: float = 0.0
     coordination_index: float = 0.0
     game_theory_slack: float = 0.0
+    cooperation_potential: float = 0.0
     temperature: float = 0.0
     enthalpy: float = 0.0
     pressure: float = 0.0
@@ -139,6 +140,17 @@ class SyntheticEconomySim(PlanetarySimulation):
         gibbs_stress = 0.0
         if enthalpy:
             gibbs_stress = min(1.0, abs(gibbs_free_energy) / max(1e-6, enthalpy))
+        entropy_pressure = min(1.0, entropy / math.log(2.0))
+        cooperation_potential = (
+            0.5 * nash_welfare
+            + 0.3 * coordination_index
+            + 0.2 * sentient_welfare_index
+        )
+        cooperation_potential *= (1.0 - 0.4 * entropy_pressure) * (
+            1.0 - 0.3 * entropy_production_pressure
+        )
+        cooperation_potential *= 1.0 - 0.3 * gibbs_stress
+        cooperation_potential = min(1.0, max(0.0, cooperation_potential))
         phase_transition_risk = (
             0.5 * entropy_production_pressure
             + 0.3 * (1.0 - coordination_index)
@@ -156,6 +168,7 @@ class SyntheticEconomySim(PlanetarySimulation):
             "stability_index": stability_index,
             "coordination_index": coordination_index,
             "game_theory_slack": game_theory_slack,
+            "cooperation_potential": cooperation_potential,
             "temperature": temperature,
             "enthalpy": enthalpy,
             "pressure": pressure,
@@ -187,6 +200,7 @@ class SyntheticEconomySim(PlanetarySimulation):
             stability_index=metrics["stability_index"],
             coordination_index=metrics["coordination_index"],
             game_theory_slack=metrics["game_theory_slack"],
+            cooperation_potential=metrics["cooperation_potential"],
             temperature=metrics["temperature"],
             enthalpy=metrics["enthalpy"],
             pressure=metrics["pressure"],

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_simulation_metrics.py
@@ -36,6 +36,16 @@ def test_simulation_thermodynamic_metrics() -> None:
     game_theory_slack = min(1.0, nash_welfare * (0.5 + 0.5 * coordination_index))
     entropy_production_pressure = min(1.0, entropy_production / (1.0 + entropy))
     gibbs_stress = min(1.0, abs(gibbs_free_energy) / max(1e-6, enthalpy))
+    entropy_pressure = min(1.0, entropy / math.log(2.0))
+    sentient_welfare_index = 0.55 * nash_welfare + 0.45 * min(
+        state.prosperity_index, state.sustainability_index
+    )
+    cooperation_potential = 0.5 * nash_welfare + 0.3 * coordination_index + 0.2 * sentient_welfare_index
+    cooperation_potential *= (1.0 - 0.4 * entropy_pressure) * (
+        1.0 - 0.3 * entropy_production_pressure
+    )
+    cooperation_potential *= 1.0 - 0.3 * gibbs_stress
+    cooperation_potential = min(1.0, max(0.0, cooperation_potential))
     phase_transition_risk = (
         0.5 * entropy_production_pressure
         + 0.3 * (1.0 - coordination_index)
@@ -51,6 +61,7 @@ def test_simulation_thermodynamic_metrics() -> None:
     assert state.stability_index == pytest.approx(stability_index)
     assert state.coordination_index == pytest.approx(coordination_index)
     assert state.game_theory_slack == pytest.approx(game_theory_slack)
+    assert state.cooperation_potential == pytest.approx(cooperation_potential)
     assert state.phase_transition_risk == pytest.approx(phase_transition_risk)
     assert 0.0 <= state.coordination_index <= 1.0
     assert 0.0 <= state.stability_index <= 1.0


### PR DESCRIPTION
### Motivation
- Introduce a compact cooperation metric that captures collective readiness for cooperative policy (blending game-theoretic and thermodynamic signals). 
- Surface that metric to the orchestrator so policy generation and coordination incentives can respond to emergent cooperation signals. 
- Improve alignment of the demo policy engine with statistical-physics and game-theory inspired signals (Nash welfare, Gibbs drive, entropy, coordination). 

### Description
- Add `cooperation_potential: float` to `SimulationState` and compute it in `SyntheticEconomySim._compute_thermodynamic_metrics()` as a bounded function of `nash_welfare`, `coordination_index`, `sentient_welfare_index`, and entropy/enthalpy-derived pressures. 
- Return the new `cooperation_potential` in the simulation metrics and include it in snapshots created by `_snapshot_state()`. 
- Feed `cooperation_potential` into the orchestrator by exposing it in `_compute_policy_signals()` and adjust `coordination_pressure`, `alignment_investment`, and `coordination_incentives` weighting to account for cooperation gaps. 
- Surface `cooperation_potential` in the `game_theory` and status/energy snapshots emitted by the orchestrator and add tests to validate the new metric.

### Testing
- Ran `python -m pytest demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/tests/test_simulation_metrics.py demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/tests/test_policy_actions.py`, and all tests passed (6 passed). 
- Existing demo test runner previously completes successfully in CI; focused unit tests covering the change were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587a24648c83339e1d3314667e7574)