### PR TITLE
Make Phase-8 Playwright e2e optional in demo runner

### DIFF
--- a/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts
@@ -304,6 +304,14 @@ describe('isOptionalE2E', () => {
     expect(isOptionalE2E()).toBe(false);
   });
 
+  test('defaults to optional under demo runner even in CI', () => {
+    process.env.CI = '1';
+    process.env.DEMO_RUNTIME_ROOT = '/tmp/demo-runtime';
+    const { isOptionalE2E } = require('../run-tests.js');
+
+    expect(isOptionalE2E()).toBe(true);
+  });
+
   test('defaults to optional outside CI', () => {
     delete process.env.CI;
     const { isOptionalE2E } = require('../run-tests.js');

--- a/demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js
+++ b/demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js
@@ -22,6 +22,9 @@ function isOptionalE2E(env = process.env) {
   if (flag !== undefined) {
     return flag !== '0' && flag.toString().toLowerCase() !== 'false';
   }
+  if (env.DEMO_RUNTIME_ROOT) {
+    return true;
+  }
   // Default: enforce e2e in CI so demo regressions are caught, but allow
   // developers to skip locally without extra configuration.
   return !isCi(env);


### PR DESCRIPTION
### Motivation

- Prevent the Phase-8 demo from failing or hanging demo orchestration when Playwright/Chromium is unavailable or expensive to install in constrained/demo-runner environments. 
- Allow the demo-runner sandbox (`DEMO_RUNTIME_ROOT`) to skip heavyweight browser e2e installs while preserving the ability to opt in explicitly. 
- Reduce CI noise and runtime latency for the full demo gallery by treating Phase-8 e2e as optional under orchestrated runs. 
- Provide explicit test coverage for the new demo-runner default behavior.

### Description

- Update `demo/Phase-8-Universal-Value-Dominance/scripts/run-tests.js` so `isOptionalE2E` returns `true` when `env.DEMO_RUNTIME_ROOT` is present, making Playwright e2e optional under the demo runner. 
- Add a unit test `demo/Phase-8-Universal-Value-Dominance/scripts/__tests__/run-tests.unit.test.ts` that asserts the CI+`DEMO_RUNTIME_ROOT` case defaults to optional. 
- Keep previous opt-in/out flags (`PLAYWRIGHT_OPTIONAL_E2E`, `PLAYWRIGHT_INSTALL_WITH_DEPS`) and CI semantics intact so explicit behavior remains configurable. 

### Testing

- Executed `npm test` in `demo/Phase-8-Universal-Value-Dominance`, which ran the unit suite and reported all tests passing (`52 passed`). 
- Verified the modified `isOptionalE2E` behavior via the newly added unit test which asserts demo-runner defaulting to optional e2e in CI. 
- Existing demo test harness was exercised during development to ensure the change does not break overall demo orchestration (no regressions observed in local runs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695895388fc0833380b080996f28611a)