### PR TITLE
Respect manual pauses during phase transition recovery

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/orchestrator.py
@@ -108,6 +108,7 @@ class Orchestrator:
         self._paused = asyncio.Event()
         self._paused.set()
         self._phase_transition_paused = False
+        self._manual_pause = False
         self._cycle = 0
         self._stopped = asyncio.Event()
         self._status_path = config.status_output_path
@@ -531,15 +532,22 @@ class Orchestrator:
                 risk=risk,
                 threshold=pause_threshold,
             )
-            self.pause()
+            self.pause(reason="phase_transition")
         elif self._phase_transition_paused and risk <= resume_threshold:
             self._phase_transition_paused = False
+            if self._manual_pause:
+                self._info(
+                    "phase_transition_resume_deferred",
+                    risk=risk,
+                    threshold=resume_threshold,
+                )
+                return
             self._info(
                 "phase_transition_resume",
                 risk=risk,
                 threshold=resume_threshold,
             )
-            self.resume()
+            self.resume(reason="phase_transition")
 
     async def _simulation_loop(self) -> None:
         assert self.simulation is not None
@@ -738,9 +746,9 @@ class Orchestrator:
                 message = await receiver()
                 action = message.payload.get("action")
                 if action == "pause" and self.governance.params.pause_enabled:
-                    self.pause()
+                    self.pause(reason="operator")
                 elif action == "resume":
-                    self.resume()
+                    self.resume(reason="operator")
                 elif action == "stop":
                     await self.shutdown()
                 elif action == "update_parameters":
@@ -1630,13 +1638,34 @@ class Orchestrator:
             self.resources.release_stake(validator, self.governance.params.validator_stake)
         job.validators_with_stake.clear()
 
-    def pause(self) -> None:
+    def pause(self, *, reason: str = "operator") -> None:
+        if reason == "operator":
+            self._manual_pause = True
         self._paused.clear()
-        self._info("orchestrator_paused")
+        self._info(
+            "orchestrator_paused",
+            reason=reason,
+            manual_pause=self._manual_pause,
+            phase_transition_paused=self._phase_transition_paused,
+        )
 
-    def resume(self) -> None:
+    def resume(self, *, reason: str = "operator") -> None:
+        if reason == "operator":
+            self._manual_pause = False
+        if reason == "phase_transition" and self._manual_pause:
+            self._info(
+                "orchestrator_resume_deferred",
+                reason=reason,
+                manual_pause=self._manual_pause,
+            )
+            return
         self._paused.set()
-        self._info("orchestrator_resumed")
+        self._info(
+            "orchestrator_resumed",
+            reason=reason,
+            manual_pause=self._manual_pause,
+            phase_transition_paused=self._phase_transition_paused,
+        )
 
     async def shutdown(self) -> None:
         if not self._running and self._stopped.is_set():
@@ -1884,6 +1913,11 @@ class Orchestrator:
             "cycle": self._cycle,
             "running": self._running,
             "paused": not self._paused.is_set(),
+            "pause_state": {
+                "manual": self._manual_pause,
+                "phase_transition": self._phase_transition_paused,
+                "auto_pause_enabled": self.config.auto_pause_on_phase_transition,
+            },
             "jobs": {
                 "total": len(jobs),
                 "status_counts": dict(status_counts),

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_phase_transition_guard.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_phase_transition_guard.py
@@ -44,3 +44,44 @@ def test_phase_transition_guard_pauses_and_resumes(tmp_path: Path) -> None:
 
     assert orchestrator._phase_transition_paused is False
     assert orchestrator._paused.is_set()
+
+
+def test_phase_transition_guard_respects_manual_pause(tmp_path: Path) -> None:
+    orchestrator = Orchestrator(
+        OrchestratorConfig(
+            control_channel_file=tmp_path / "control.jsonl",
+            checkpoint_path=tmp_path / "checkpoint.json",
+            status_output_path=None,
+            audit_log_path=None,
+            energy_oracle_path=None,
+            auto_pause_on_phase_transition=True,
+            phase_transition_pause_threshold=0.6,
+            phase_transition_resume_threshold=0.4,
+        )
+    )
+
+    orchestrator.pause(reason="operator")
+
+    high_risk_state = SimulationState(
+        energy_output_gw=500_000.0,
+        prosperity_index=0.7,
+        sustainability_index=0.6,
+        phase_transition_risk=0.8,
+    )
+    orchestrator._apply_simulation_state(high_risk_state, event="simulation_tick")
+
+    assert orchestrator._phase_transition_paused is True
+    assert orchestrator._manual_pause is True
+    assert not orchestrator._paused.is_set()
+
+    low_risk_state = SimulationState(
+        energy_output_gw=505_000.0,
+        prosperity_index=0.72,
+        sustainability_index=0.62,
+        phase_transition_risk=0.2,
+    )
+    orchestrator._apply_simulation_state(low_risk_state, event="simulation_tick")
+
+    assert orchestrator._phase_transition_paused is False
+    assert orchestrator._manual_pause is True
+    assert not orchestrator._paused.is_set()


### PR DESCRIPTION
### Motivation

- Prevent the orchestrator's automatic phase-transition unpause from overriding an operator-initiated manual pause. 
- Improve operational observability by exposing pause state in status snapshots. 
- Make pause/resume actions explicit about their origin so logic can treat operator and auto pauses differently. 
- Add test coverage to ensure manual pauses are respected during phase-transition recovery.

### Description

- Track manual operator pauses with a new `_manual_pause` flag and propagate it in status snapshots under `pause_state`.
- Update pause/resume APIs to accept a `reason` parameter (`"operator"` or `"phase_transition"`) and to set/clear `_manual_pause` accordingly via `pause(reason=...)` and `resume(reason=...)`.
- Change the phase-transition guard to call `pause(reason="phase_transition")` and to defer auto-resume when `_manual_pause` is set, emitting distinct log events when a deferred resume occurs.
- Pass `reason="operator"` from the control listener when the operator triggers pause/resume and add a unit test `test_phase_transition_guard_respects_manual_pause` to validate behavior.

### Testing

- Ran `pytest -q "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests/test_phase_transition_guard.py"` and it passed (`2 passed`).
- Ran `pytest -q "demo/Kardashev-II Omega-Grade-α-AGI Business-3/tests"` and the suite passed (`25 passed`).
- Verified the orchestrator CLI runs a single cycle with `python -m demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo --cycles 1` producing expected simulation and policy logs. 
- All modified demo unit tests completed successfully within the demo test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69590527ca308333bf15f8482bc0faf7)