### PR TITLE
Add equilibrium action path to Kardashev II demo and dashboard

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/index.html
@@ -155,6 +155,14 @@
 
       <section class="card">
         <div class="section-title">
+          <h2>Equilibrium action path</h2>
+        </div>
+        <p id="equilibrium-path-summary" class="lede">…</p>
+        <ul id="equilibrium-path" class="ledger-list"></ul>
+      </section>
+
+      <section class="card">
+        <div class="section-title">
           <h2>Mission lattice</h2>
         </div>
         <p id="mission-summary" class="lede">…</p>

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -2261,6 +2261,121 @@ function formatFixedValue(value, digits = 2) {
   return value.toFixed(digits);
 }
 
+function buildEquilibriumPath({
+  energyMonteCarlo,
+  allocationPolicy,
+  sentientWelfare,
+  logistics,
+  missionThermodynamics,
+}) {
+  const steps = [];
+  const addStep = ({ title, status, metric, target, recommendation }) => {
+    steps.push({
+      title,
+      status,
+      metric,
+      target,
+      recommendation,
+    });
+  };
+
+  const freeEnergyMarginGw = Number.isFinite(energyMonteCarlo.freeEnergyMarginGw)
+    ? energyMonteCarlo.freeEnergyMarginGw
+    : 0;
+  const freeEnergyOk = Boolean(energyMonteCarlo.maintainsBuffer);
+  addStep({
+    title: 'Thermodynamic reserve buffer',
+    status: freeEnergyOk ? 'on-track' : 'needs-action',
+    metric: `Free energy margin ${formatNumber(round(freeEnergyMarginGw, 2))} GW`,
+    target: `Maintain ≥ ${formatNumber(round(energyMonteCarlo.marginGw ?? 0, 2))} GW buffer`,
+    recommendation: freeEnergyOk
+      ? 'Maintain reserve buffers and monitor drift variance.'
+      : 'Increase reserve buffers or tighten demand variance until buffer recovers.',
+  });
+
+  const hamiltonianOk = (energyMonteCarlo.hamiltonianStability ?? 0) >= HAMILTONIAN_TARGET_STABILITY;
+  addStep({
+    title: 'Hamiltonian stability band',
+    status: hamiltonianOk ? 'on-track' : 'needs-action',
+    metric: `Hamiltonian ${formatPercentValue(energyMonteCarlo.hamiltonianStability)}`,
+    target: `≥ ${formatPercentValue(HAMILTONIAN_TARGET_STABILITY)}`,
+    recommendation: hamiltonianOk
+      ? 'Maintain current stability envelope.'
+      : 'Raise reserve buffers and smooth demand phase variance to lift stability.',
+  });
+
+  const gameTheoryOk = (energyMonteCarlo.gameTheorySlack ?? 0) >= 0.85;
+  addStep({
+    title: 'Game-theory slack',
+    status: gameTheoryOk ? 'on-track' : 'needs-action',
+    metric: `Slack ${formatPercentValue(energyMonteCarlo.gameTheorySlack)}`,
+    target: '≥ 85%',
+    recommendation: gameTheoryOk
+      ? 'Maintain cooperation incentives across shards.'
+      : 'Rebalance incentives to improve cooperation slack above 85%.',
+  });
+
+  const allocationEntropy = allocationPolicy.fairnessIndex ?? 0;
+  const concentrationIndex = allocationPolicy.concentrationIndex ?? 0;
+  const diversificationTarget =
+    allocationPolicy.diversificationTarget ?? DIVERSIFICATION_TARGET_HHI;
+  const allocationOk = allocationEntropy >= 0.9 && concentrationIndex <= diversificationTarget;
+  addStep({
+    title: 'Allocation entropy balance',
+    status: allocationOk ? 'on-track' : 'needs-action',
+    metric: `Fairness ${(allocationEntropy * 100).toFixed(1)}% · HHI ${concentrationIndex.toFixed(2)}`,
+    target: `Fairness ≥ 90% · HHI ≤ ${diversificationTarget.toFixed(2)}`,
+    recommendation: allocationOk
+      ? 'Maintain entropy-balanced allocations.'
+      : 'Spread allocations to reduce concentration and lift entropy.',
+  });
+
+  const welfareOk =
+    (sentientWelfare.equilibriumScore ?? 0) >= 0.85 &&
+    (sentientWelfare.coalitionStability ?? 0) >= 0.85;
+  addStep({
+    title: 'Sentient welfare equilibrium',
+    status: welfareOk ? 'on-track' : 'needs-action',
+    metric: `Equilibrium ${formatPercentValue(sentientWelfare.equilibriumScore)} · coalition ${formatPercentValue(
+      sentientWelfare.coalitionStability
+    )}`,
+    target: '≥ 85% equilibrium + coalition',
+    recommendation: welfareOk
+      ? 'Maintain coalition reinforcement and fairness guarantees.'
+      : 'Boost coalition stability and reduce inequality to restore equilibrium.',
+  });
+
+  const logisticsEquilibrium = logistics?.equilibrium ?? {};
+  const logisticsOk =
+    (logisticsEquilibrium.gameTheorySlack ?? 0) >= 0.85 &&
+    (logisticsEquilibrium.entropyRatio ?? 0) >= 0.9;
+  addStep({
+    title: 'Logistics entropy smoothing',
+    status: logisticsOk ? 'on-track' : 'needs-action',
+    metric: `Entropy ${formatFixedValue(logisticsEquilibrium.entropyRatio, 2)} · slack ${formatPercentValue(
+      logisticsEquilibrium.gameTheorySlack
+    )}`,
+    target: 'Entropy ≥ 0.90 · slack ≥ 85%',
+    recommendation: logisticsOk
+      ? 'Maintain corridor utilization within the 65–85% band.'
+      : 'Shift corridor utilization to lift entropy and reduce deviation incentives.',
+  });
+
+  const missionHamiltonian = missionThermodynamics?.hamiltonianStability ?? 0;
+  const missionOk = missionHamiltonian >= HAMILTONIAN_TARGET_STABILITY;
+  addStep({
+    title: 'Mission Hamiltonian load-balance',
+    status: missionOk ? 'on-track' : 'needs-action',
+    metric: `Mission stability ${formatPercentValue(missionHamiltonian)}`,
+    target: `≥ ${formatPercentValue(HAMILTONIAN_TARGET_STABILITY)}`,
+    recommendation: missionOk
+      ? 'Maintain mission load balance.'
+      : 'Rebalance mission timelines to restore thermodynamic headroom.',
+  });
+
+  return steps;
+}
+
 function buildActionPathBriefing(equilibriumLedger) {
   const thermodynamics = equilibriumLedger?.thermodynamics ?? {};
   const gameTheory = equilibriumLedger?.gameTheory ?? {};
@@ -3227,6 +3342,14 @@ function main() {
   governanceLines.push('');
   governanceLines.push('All actions are auditable; copy/paste-ready commands are available via `npm run demo:kardashev -- --print-commands`.');
 
+  const equilibriumPath = buildEquilibriumPath({
+    energyMonteCarlo,
+    allocationPolicy,
+    sentientWelfare,
+    logistics,
+    missionThermodynamics,
+  });
+
   const telemetry = {
     generatedAt,
     dominanceScore,
@@ -3265,6 +3388,7 @@ function main() {
       corridors: logistics.corridors,
       equilibrium: logistics.equilibrium,
     },
+    equilibriumPath,
     settlement: {
       protocols: settlement.protocols,
       watchers: settlement.watchers,

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/ui/dashboard.js
@@ -1902,6 +1902,46 @@ function renderEquilibriumLedger(ledger) {
   }
 }
 
+function renderEquilibriumPath(path) {
+  const summary = document.querySelector("#equilibrium-path-summary");
+  const list = document.querySelector("#equilibrium-path");
+  if (!summary || !list) return;
+
+  list.innerHTML = "";
+  if (!Array.isArray(path) || path.length === 0) {
+    summary.textContent = "Equilibrium action path unavailable.";
+    applyStatus(summary, "status-warn");
+    return;
+  }
+
+  const needsActionCount = path.filter((entry) => entry.status === "needs-action").length;
+  if (needsActionCount === 0) {
+    summary.textContent = "All equilibrium checkpoints are on track.";
+    applyStatus(summary, "status-ok");
+  } else {
+    summary.textContent = `${needsActionCount} checkpoint${needsActionCount === 1 ? "" : "s"} need intervention.`;
+    applyStatus(summary, "status-warn");
+  }
+
+  path.forEach((entry) => {
+    const li = document.createElement("li");
+    li.innerHTML = `<strong>${entry.title}</strong> — ${entry.metric} · target ${entry.target}`;
+    const recommendation = document.createElement("div");
+    recommendation.textContent = entry.recommendation;
+    recommendation.classList.add("lede");
+    li.appendChild(recommendation);
+
+    const statusClass =
+      entry.status === "on-track"
+        ? "status-ok"
+        : entry.status === "needs-action"
+          ? "status-fail"
+          : "status-warn";
+    li.classList.add(statusClass);
+    list.appendChild(li);
+  });
+}
+
 function renderLedger(ledger) {
   document.querySelector("#ledger-summary").textContent = ledger.confidence.summary;
   const composite = `${(ledger.confidence.compositeScore * 100).toFixed(2)}%`;
@@ -2142,6 +2182,7 @@ async function bootstrap() {
       console.warn("Equilibrium ledger unavailable", equilibriumResult.reason);
       renderEquilibriumUnavailable(equilibriumResult.reason);
     }
+    renderEquilibriumPath(null);
 
     renderOwnerProofUnavailable("Owner proof requires full orchestrator output.");
 
@@ -2194,6 +2235,7 @@ async function bootstrap() {
     console.warn("Equilibrium ledger unavailable", equilibriumResult.reason);
     renderEquilibriumUnavailable(equilibriumResult.reason);
   }
+  renderEquilibriumPath(telemetry.equilibriumPath);
   renderMissionLattice(telemetry.missionLattice);
   renderMissionThermodynamics(telemetry.missionThermodynamics);
   renderLogistics(telemetry.logistics, telemetry.verification.logistics);


### PR DESCRIPTION
### Motivation

- Surface a concise, operator-friendly action path that translates thermodynamic, game-theory, and welfare signals into prioritized, actionable checkpoints.  
- Make it simple for mission owners to see which equilibrium checkpoints require intervention (thermodynamics, Hamiltonian stability, game-theory slack, allocation fairness, sentient welfare, logistics, mission stability).  
- Keep the UI resilient when running the lightweight Node demo (legacy telemetry) by showing a clear unavailable state where appropriate.  
- Improve observability and handoff between the orchestrator telemetry and the dashboard.

### Description

- Implemented `buildEquilibriumPath(...)` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` to synthesize a small list of equilibrium checkpoints (thermodynamic reserve, Hamiltonian band, game-theory slack, allocation entropy, sentient welfare, logistics entropy, mission Hamiltonian) with status, metric, target, and recommendation.  
- Embedded the computed `equilibriumPath` into the generated `telemetry` payload so it is exported with the usual artefacts (`kardashev-telemetry.json` and inline JS).  
- Added a new UI section to `index.html` for “Equilibrium action path” and implemented `renderEquilibriumPath(path)` in `ui/dashboard.js` to render the checkpoints, status badges, and recommendations and to integrate it into the dashboard bootstrap flow.  
- The dashboard gracefully handles absent or legacy telemetry by rendering an unavailable summary when `equilibriumPath` is missing, and no existing equilibrium or ledger flows were modified.

### Testing

- Ran the demo unit/integration suite: `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and all tests passed (`16 passed`).  
- Executed the Node orchestrator to generate artefacts: `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs --output-dir /tmp/k2-output` and confirmed artefacts were emitted and `telemetry` includes `equilibriumPath`.  
- Served the generated output locally and captured a UI rendering snapshot to validate the new section renders without errors (`python -m http.server` + headless browser screenshot).  
- No automated tests were broken by these changes and the demo CI tests remain green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695921a495b08333b6dcbf319205791a)