### PR TITLE
Avoid repo output writes in Kardashev demo wrapper

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
@@ -21,7 +21,7 @@ from urllib.parse import unquote, urlparse
 
 ROOT = Path(__file__).resolve().parent
 NODE_SCRIPT = ROOT / "run-demo.cjs"
-DEFAULT_OUTPUT_DIR = ROOT / "output"
+DEFAULT_OUTPUT_DIR = Path.home() / ".cache" / "agi-jobs-v0" / "kardashev-ii"
 
 
 def _ensure_node_available() -> str:


### PR DESCRIPTION
### Motivation

- The Kardashev-II Python wrapper previously defaulted to writing generated artefacts into the demo `output/` directory inside the repository, which caused CI drift and untracked file noise.  
- Redirecting default outputs to a per-user cache avoids dirtying the repo during validation and local check-mode runs.  
- Keep CLI behaviour unchanged while making safe defaults for contributor workflows and CI.  

### Description

- Change the wrapper default `DEFAULT_OUTPUT_DIR` from the repo `output` to a user cache at `~/.cache/agi-jobs-v0/kardashev-ii` by updating `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py`.  
- The wrapper still exposes `--output-dir`, `--check`, `--print-commands`, and `--config-root` so callers can explicitly control where artefacts are written.  
- No other behavioural changes were made to argument parsing or delegation to the Node demo.  

### Testing

- Ran `python demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py --check` and it completed successfully with validation output.  
- Executed `pytest demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` and the full test suite passed (`16 passed`).  
- Verified `npm run demo:kardashev` / orchestrator generation and subsequent `npm run demo:kardashev-ii:ci` checks in the demo workflow to ensure artefacts remain up-to-date (local orchestration produced artefacts as expected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594e567bfc833393699f859ee09ffb)