### PR TITLE
Use FastAPI lifespan for analytics scheduler in meta API

### DIFF
--- a/services/meta_api/app/main.py
+++ b/services/meta_api/app/main.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Final
+from contextlib import asynccontextmanager
+from typing import Final, AsyncIterator
 
 from fastapi import FastAPI
 
@@ -24,11 +25,26 @@ def _configure_logging() -> None:
     LOGGER.info("Meta API logging configured", extra={"level": level})
 
 
+@asynccontextmanager
+async def _lifespan(_: FastAPI) -> AsyncIterator[None]:
+    scheduler = AnalyticsScheduler(AnalyticsEngine(), get_cache())
+    scheduler.start()
+    if not get_cache().snapshot().get("reports"):
+        try:
+            run_once()
+        except Exception:  # pragma: no cover - best-effort warm cache
+            LOGGER.warning("analytics warmup failed", exc_info=True)
+    try:
+        yield
+    finally:
+        scheduler.stop()
+
+
 def create_app() -> FastAPI:
     """Instantiate the FastAPI application with all orchestrator routers."""
 
     _configure_logging()
-    app = FastAPI(title="AGI Jobs Meta API", version="0.1.0", docs_url="/docs")
+    app = FastAPI(title="AGI Jobs Meta API", version="0.1.0", docs_url="/docs", lifespan=_lifespan)
 
     app.include_router(health_router)
     app.include_router(onebox_router)
@@ -36,21 +52,6 @@ def create_app() -> FastAPI:
     app.include_router(analytics_router)
     app.include_router(agents_router)
     app.include_router(hgm_router)
-
-    scheduler = AnalyticsScheduler(AnalyticsEngine(), get_cache())
-
-    @app.on_event("startup")
-    async def _start_scheduler() -> None:  # pragma: no cover - FastAPI lifecycle wiring
-        scheduler.start()
-        if not get_cache().snapshot().get("reports"):
-            try:
-                run_once()
-            except Exception:  # pragma: no cover - best-effort warm cache
-                LOGGER.warning("analytics warmup failed", exc_info=True)
-
-    @app.on_event("shutdown")
-    async def _stop_scheduler() -> None:  # pragma: no cover - FastAPI lifecycle wiring
-        scheduler.stop()
 
     @app.get("/healthz", tags=["health"])
     def root_health() -> dict[str, bool]:


### PR DESCRIPTION
### Motivation
- FastAPI deprecated the `@app.on_event("startup")` and `@app.on_event("shutdown")` handlers and recommends lifespan context managers.
- The analytics scheduler must be started on application startup and stopped on shutdown while avoiding deprecation warnings.
- Keep existing analytics warmup (`run_once`) and graceful shutdown behavior unchanged.

### Description
- Replace `@app.on_event("startup")`/`@app.on_event("shutdown")` with an `@asynccontextmanager` lifespan function named `_lifespan`.
- Move analytics scheduler instantiation, `scheduler.start()`, and `scheduler.stop()` into the `_lifespan` context and wire it into `FastAPI(..., lifespan=_lifespan)`.
- Preserve the existing warm-cache call to `run_once()` with the same defensive `try/except` behavior.

### Testing
- Ran `pytest -q tests/routes/test_hgm_routes.py` after the change and it completed successfully with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959682c191083338683f1ad926af2cf)