### PR TITLE
Normalize Onebox orchestrator base URLs

### DIFF
--- a/apps/onebox/src/lib/environment.ts
+++ b/apps/onebox/src/lib/environment.ts
@@ -194,10 +194,14 @@ export const resolveOrchestratorBase = (
   if (!orchestratorUrl) {
     return undefined;
   }
-  if (orchestratorUrl.endsWith('/onebox')) {
-    return orchestratorUrl;
+  const trimmed = orchestratorUrl.trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return undefined;
   }
-  return `${orchestratorUrl}/onebox`;
+  if (trimmed.endsWith('/onebox')) {
+    return trimmed;
+  }
+  return `${trimmed}/onebox`;
 };
 
 export const createExplorerUrl = (
@@ -222,4 +226,3 @@ export const createIpfsGatewayUrl = (
   }
   return joinUrl(ipfsGatewayBase, cid);
 };
-

--- a/apps/onebox/test/onebox-config.test.ts
+++ b/apps/onebox/test/onebox-config.test.ts
@@ -65,6 +65,14 @@ test('resolveOrchestratorBase normalises URLs', () => {
     resolveOrchestratorBase('https://example.com/onebox'),
     'https://example.com/onebox'
   );
+  assert.equal(
+    resolveOrchestratorBase('https://example.com/onebox/'),
+    'https://example.com/onebox'
+  );
+  assert.equal(
+    resolveOrchestratorBase('  https://example.com/edge/  '),
+    'https://example.com/edge/onebox'
+  );
   assert.equal(resolveOrchestratorBase(undefined), undefined);
 });
 


### PR DESCRIPTION
### Motivation

- Fix edge cases where orchestrator URLs with trailing slashes or surrounding whitespace produced malformed `/onebox` endpoints.
- Ensure downstream UI components and helpers receive a stable, predictable orchestrator base URL.

### Description

- Trim whitespace and remove trailing slashes from the input `orchestratorUrl` before decision logic in `resolveOrchestratorBase` within `apps/onebox/src/lib/environment.ts`.
- Return `undefined` for empty/whitespace-only inputs after trimming to avoid producing invalid endpoints.
- Update tests in `apps/onebox/test/onebox-config.test.ts` to cover trailing-slash and whitespace inputs when resolving the orchestrator base.

### Testing

- Ran the onebox config test bundle with `npx esbuild apps/onebox/test/onebox-config.test.ts --bundle --platform=node --format=esm --target=es2022 --outfile=apps/onebox/test/dist/onebox-config.test.mjs && node apps/onebox/test/dist/onebox-config.test.mjs` and the suite completed with all assertions passing.
- The modified tests exercised `resolveOrchestratorBase` for normal, trailing-slash, and whitespace-padded inputs and validated expected outputs (all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596c7cc95c8333860b7d0f88a48daa)