### PR TITLE
Allow owner plan script to forward Hardhat CLI arguments

### DIFF
--- a/scripts/v2/run-owner-plan.js
+++ b/scripts/v2/run-owner-plan.js
@@ -3,6 +3,7 @@ const { spawn } = require('child_process');
 
 const userArgs = process.argv.slice(2);
 const hardhatArgs = ['hardhat', 'run', '--no-compile', 'scripts/v2/ownerControlPlan.ts'];
+const passthroughArgs = [];
 
 const forwardedEnv = { ...process.env };
 
@@ -58,8 +59,13 @@ for (let i = 0; i < userArgs.length; i += 1) {
       break;
     }
     default:
-      throw new Error(`Unknown owner:plan argument ${arg}`);
+      passthroughArgs.push(arg);
+      break;
   }
+}
+
+if (passthroughArgs.length > 0) {
+  hardhatArgs.push(...passthroughArgs);
 }
 
 const child = spawn('npx', hardhatArgs, {


### PR DESCRIPTION
### Motivation
- The owner plan wrapper script errored when passed standard Hardhat CLI flags (e.g. `--network`), preventing callers from controlling the Hardhat environment.
- Unknown arguments should be forwarded to Hardhat instead of aborting, while preserving owner-plan-specific options that set environment variables.

### Description
- Added a `passthroughArgs` array and collect unknown CLI tokens instead of throwing an error for them.
- Append collected passthrough arguments to the Hardhat invocation (`hardhatArgs`) so flags like `--network` are forwarded.
- Kept existing owner-plan flags mapped to environment variables via `forwardedEnv` to preserve current behavior.
- Modified file: `scripts/v2/run-owner-plan.js`.

### Testing
- Ran `node scripts/v2/run-owner-plan.js --network sepolia --help` and observed the Hardhat usage output indicating the flags were forwarded successfully (test succeeded).
- Verified the script now exits normally when forwarding CLI args and that owner-plan env flags still set via examples during local runs (manual automated invocation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598186df3483338e631891ba7a6fe6)