### PR TITLE
Harden thermostat Prometheus ingestion and fix demo import/test isolation

### DIFF
--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -1,1 +1,6 @@
-"""Demo packages for AGI Jobs v0 (v2)."""
+"""Demo package entrypoint for shared test utilities."""
+from __future__ import annotations
+
+from . import run_demo_tests
+
+__all__ = ["run_demo_tests"]

--- a/scripts/thermostat.py
+++ b/scripts/thermostat.py
@@ -53,29 +53,41 @@ async def stream_prometheus(
     count = 0
     while iterations <= 0 or count < iterations:
         count += 1
-        payload = await loop.run_in_executor(None, _prometheus_query, base_url, query)
+        try:
+            payload = await loop.run_in_executor(None, _prometheus_query, base_url, query)
+        except Exception:
+            LOGGER.exception("Prometheus query failed for %s", query)
+            await asyncio.sleep(interval)
+            continue
         result = payload.get("data", {}).get("result", [])
         if not result:
             LOGGER.warning("Prometheus query returned no data: %s", query)
         for vector in result:
             values = vector.get("value")
-            if isinstance(values, (list, tuple)) and len(values) == 2:
-                ts_raw, roi_raw = values
+            if not (isinstance(values, (list, tuple)) and len(values) == 2):
+                LOGGER.warning("Prometheus vector missing value pair: %s", vector)
+                continue
+            ts_raw, roi_raw = values
+            try:
                 timestamp = datetime.fromtimestamp(float(ts_raw), tz=timezone.utc)
-                sample = MetricSample(
-                    timestamp=timestamp,
-                    roi=float(roi_raw),
-                    gmv=0.0,
-                    cost=0.0,
-                )
-                yield sample
+                roi = float(roi_raw)
+            except (TypeError, ValueError):
+                LOGGER.warning("Skipping Prometheus sample with invalid values: %s", values)
+                continue
+            sample = MetricSample(
+                timestamp=timestamp,
+                roi=roi,
+                gmv=0.0,
+                cost=0.0,
+            )
+            yield sample
         await asyncio.sleep(interval)
 
 
 def _prometheus_query(base_url: str, query: str) -> dict[str, object]:
     params = parse.urlencode({"query": query})
     url = f"{base_url.rstrip('/')}/api/v1/query?{params}"
-    req = request.Request(url)
+    req = request.Request(url, headers={"User-Agent": "agi-jobs-thermostat/1.0"})
     with request.urlopen(req, timeout=5) as resp:
         data = resp.read()
         payload = json.loads(data.decode("utf-8"))

--- a/tests/demo/test_absolute_zero_reasoner_v0.py
+++ b/tests/demo/test_absolute_zero_reasoner_v0.py
@@ -6,13 +6,20 @@ import sys
 from pathlib import Path
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2] / "demo" / "Absolute-Zero-Reasoner-v0"
-if str(PACKAGE_ROOT) not in sys.path:
-    sys.path.insert(0, str(PACKAGE_ROOT))
+_PACKAGE_ROOT_STR = str(PACKAGE_ROOT)
+_added_to_path = False
+if _PACKAGE_ROOT_STR not in sys.path:
+    sys.path.insert(0, _PACKAGE_ROOT_STR)
+    _added_to_path = True
 
-from azr_demo.__main__ import AbsoluteZeroReasonerDemo, DEFAULT_CONFIG  # type: ignore  # noqa: E402
-from azr_demo.executor import SafeExecutor, SandboxViolation  # type: ignore  # noqa: E402
-from azr_demo.reward import RewardEngine  # type: ignore  # noqa: E402
-from azr_demo.tasks import TaskType  # type: ignore  # noqa: E402
+try:
+    from azr_demo.__main__ import AbsoluteZeroReasonerDemo, DEFAULT_CONFIG  # type: ignore  # noqa: E402
+    from azr_demo.executor import SafeExecutor, SandboxViolation  # type: ignore  # noqa: E402
+    from azr_demo.reward import RewardEngine  # type: ignore  # noqa: E402
+    from azr_demo.tasks import TaskType  # type: ignore  # noqa: E402
+finally:
+    if _added_to_path and sys.path[0] == _PACKAGE_ROOT_STR:
+        sys.path.pop(0)
 
 
 def test_executor_blocks_forbidden_code() -> None:


### PR DESCRIPTION
### Motivation
- Make the thermostat Prometheus ingestion resilient to transient network errors and malformed Prometheus responses to avoid operator-facing crashes.
- Prevent demo test import collisions caused by demos sharing flat module names on the top-level `demo` path.
- Avoid permanently mutating `sys.path` during demo tests so test isolation is preserved.

### Description
- Wrap Prometheus queries in `stream_prometheus` with a try/except to handle transient failures, log the error, and retry after a sleep interval.
- Validate Prometheus vector payloads before converting values and skip malformed samples with logged warnings.
- Add a `User-Agent` header to `_prometheus_query` requests to be a well-behaved HTTP client.
- Add `demo/__init__.py` exporting `run_demo_tests` and update `tests/demo/test_absolute_zero_reasoner_v0.py` to push `PACKAGE_ROOT` onto `sys.path` only temporarily and remove it after imports.

### Testing
- Ran `python -m pytest -k thermostat -q` which collected no thermostat tests (235 deselected) indicating the thermostat CLI changes do not break test discovery.
- Ran `python -m pytest tests/test_run_demo_tests.py -q` and received `8 passed` indicating demo runner discovery and isolation behavior is working as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598e37c4d08333be73fe88d762093c)