### PR TITLE
Lazy-load CLI entrypoints for Supreme demo to avoid import-time side effects

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/__init__.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/__init__.py
@@ -1,8 +1,6 @@
 """Supreme Omega-grade Kardashev-II business orchestrator demo package."""
 
-from .config import SupremeDemoConfig
-from .orchestrator import SupremeOrchestrator
-from .cli import build_arg_parser, run_from_cli
+from __future__ import annotations
 
 __all__ = [
     "SupremeDemoConfig",
@@ -10,3 +8,27 @@ __all__ = [
     "build_arg_parser",
     "run_from_cli",
 ]
+
+
+def __getattr__(name: str):
+    if name == "SupremeDemoConfig":
+        from .config import SupremeDemoConfig
+
+        return SupremeDemoConfig
+    if name == "SupremeOrchestrator":
+        from .orchestrator import SupremeOrchestrator
+
+        return SupremeOrchestrator
+    if name == "build_arg_parser":
+        from .cli import build_arg_parser
+
+        return build_arg_parser
+    if name == "run_from_cli":
+        from .cli import run_from_cli
+
+        return run_from_cli
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/__init__.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/__init__.py
@@ -32,13 +32,9 @@ _spec.loader.exec_module(_module)
 # consumers such as ``run_demo.py``. The upstream package intentionally keeps
 # its public surface minimal; wiring ``main`` to ``run_from_cli`` here provides
 # an ergonomic, ASCII-safe entrypoint without mutating the source package.
-_main = getattr(_module, "run_from_cli", None)
-if _main is not None and not hasattr(_module, "main"):
-    setattr(_module, "main", _main)
-    if hasattr(_module, "__all__"):
-        upstream_all = list(getattr(_module, "__all__", ()))
-        if "main" not in upstream_all:
-            setattr(_module, "__all__", upstream_all + ["main"])
+_upstream_all = list(_module.__dict__.get("__all__", ()))
+if "main" not in _upstream_all:
+    _upstream_all.append("main")
 
 # Keep local helper modules (such as ``run_demo.py``) importable alongside the
 # canonical package contents.
@@ -47,7 +43,23 @@ if hasattr(_module, "__path__"):
     if package_path not in _module.__path__:
         _module.__path__.append(package_path)
 
-__all__ = getattr(_module, "__all__", [])
-run_from_cli = getattr(_module, "run_from_cli", None)
-build_arg_parser = getattr(_module, "build_arg_parser", None)
-main = getattr(_module, "main", getattr(_module, "run_from_cli", None))
+__all__ = _upstream_all
+
+
+def __getattr__(name: str):
+    if name == "main":
+        return main
+    return getattr(_module, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__) | set(dir(_module)))
+
+
+def main(*args, **kwargs):
+    """Defer CLI binding until runtime to avoid import-time side effects."""
+
+    run_from_cli = getattr(_module, "run_from_cli", None)
+    if run_from_cli is None:
+        raise AttributeError("run_from_cli is not available in the upstream module")
+    return run_from_cli(*args, **kwargs)


### PR DESCRIPTION
### Motivation
- Importing the Supreme demo package caused the CLI module to be imported at package-import time which emitted a runtime warning and created unpredictable import-time side effects. 
- The package should expose CLI helpers (`build_arg_parser`, `run_from_cli`, `main`) without forcing the CLI module to execute during import. 
- Keep the public API stable while aligning with best practices for lazy imports in library entrypoints. 
- Maintain compatibility between the repository-level compatibility wrapper and the canonical source package.

### Description
- Added lazy attribute resolution to `demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/__init__.py` via `__getattr__` and `__dir__` so `SupremeDemoConfig`, `SupremeOrchestrator`, `build_arg_parser`, and `run_from_cli` are only loaded on access. 
- Updated the compatibility wrapper `demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/__init__.py` to compute a stable `__all__`, defer binding of `main` to a runtime proxy that calls `run_from_cli`, and expose attributes lazily via `__getattr__` and `__dir__`. 
- Ensured local helper modules remain importable by appending the wrapper package path to the upstream module `__path__` without importing the CLI at module import time. 
- Preserved upstream public API names and added runtime guards that raise clear `AttributeError` if CLI helpers are unavailable.

### Testing
- Ran the demo unit tests: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest demo/Kardashev-II\ Omega-Grade-α-AGI\ Business-3/tests -q` which passed (`25 passed`).
- Invoked the CLI entrypoint: `python -m demo.kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme.cli --cycles 1` and observed the invocation complete without the prior import-time warning. 
- Verified import-time behaviour with a simple import that now does not pre-import the CLI module (import-time checks show `cli` is not loaded at package import).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ac3249ec83338a978fb9bf3f9b6a)