### PR TITLE
Fix demo import isolation and expose CLI main alias

### DIFF
--- a/demo/AGI-Alpha-Node-v0/tests/conftest.py
+++ b/demo/AGI-Alpha-Node-v0/tests/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
 
 for name in list(sys.modules):
-    if name.startswith("alpha_node"):
+    if name.startswith(("agi_alpha_node_demo", "alpha_node")):
         sys.modules.pop(name, None)
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/__init__.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "SupremeDemoConfig",
     "SupremeOrchestrator",
     "build_arg_parser",
+    "main",
     "run_from_cli",
 ]
 
@@ -27,6 +28,10 @@ def __getattr__(name: str):
         from .cli import run_from_cli
 
         return run_from_cli
+    if name == "main":
+        from .cli import main
+
+        return main
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/cli.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo_supreme/cli.py
@@ -115,5 +115,7 @@ def run_from_cli(args: Optional[argparse.Namespace] = None) -> None:
     config = _build_config_from_args(parsed)
     asyncio.run(_run_and_report(config))
 
+main = run_from_cli
 
-__all__ = ["build_arg_parser", "run_from_cli"]
+
+__all__ = ["build_arg_parser", "main", "run_from_cli"]


### PR DESCRIPTION
### Motivation
- Prevent cross-demo import collisions by ensuring demo test suites clear cached demo modules before importing local packages.
- Satisfy wrapper and test expectations by providing a canonical `main` alias for the supreme Kardashev-II demo CLI.
- Keep demo package exports deterministic and compatible with existing test harnesses.

### Description
- Update `demo/AGI-Alpha-Node-v0/tests/conftest.py` to also clear any cached modules starting with `agi_alpha_node_demo` in `sys.modules` during test setup.
- Add a `main` alias for the supreme demo CLI by setting `main = run_from_cli` in `demo/.../cli.py` so `main` is identical to `run_from_cli`.
- Export `main` from the supreme demo package by adding it to `__all__` and handling it in `__getattr__` in `demo/.../__init__.py`.

### Testing
- Ran `pytest demo -q` which completed successfully with `346 passed, 4 warnings`.
- Ran `DEMO_SYS_PATH_DEBUG=1 pytest demo/AGI-Alpha-Node-v0/tests/test_demo.py -q` which completed successfully with `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b161f18c833382c90653d5dae90a)