### PR TITLE
Harden Hardhat test runner timeouts and signal handling

### DIFF
--- a/scripts/run-hardhat-tests.cjs
+++ b/scripts/run-hardhat-tests.cjs
@@ -152,7 +152,10 @@ const env = { ...process.env };
 // several minutes on shared CI hosts; giving Hardhat 15 minutes by default
 // avoids spurious ETIMEDOUT failures on slower builders while still protecting
 // against runaway jobs.
-const hardhatTimeoutMs = Number.parseInt(env.HARDHAT_TEST_TIMEOUT_MS ?? '900000', 10);
+const parsedHardhatTimeout = Number.parseInt(env.HARDHAT_TEST_TIMEOUT_MS ?? '900000', 10);
+const hardhatTimeoutMs = Number.isFinite(parsedHardhatTimeout) && parsedHardhatTimeout > 0
+  ? parsedHardhatTimeout
+  : 900000;
 
 // Speed up test-time compilation by allowing the Solidity optimizer and viaIR
 // settings to be relaxed when HARDHAT_FAST_COMPILE is set. Default to the
@@ -253,7 +256,10 @@ function runHardhatWithHeartbeat(timeoutMs) {
       env,
     });
 
-    const heartbeatIntervalMs = Number.parseInt(process.env.HARDHAT_HEARTBEAT_MS ?? '60000', 10);
+    const parsedHeartbeat = Number.parseInt(process.env.HARDHAT_HEARTBEAT_MS ?? '60000', 10);
+    const heartbeatIntervalMs = Number.isFinite(parsedHeartbeat) && parsedHeartbeat > 0
+      ? parsedHeartbeat
+      : 60000;
     let elapsed = 0;
     const heartbeat = setInterval(() => {
       elapsed += heartbeatIntervalMs;
@@ -268,13 +274,31 @@ function runHardhatWithHeartbeat(timeoutMs) {
       child.kill('SIGTERM');
     }, timeoutMs);
 
+    const signalHandlers = new Map();
+    const forwardSignal = (signal) => {
+      if (!child.killed) {
+        child.kill(signal);
+      }
+    };
+    ['SIGINT', 'SIGTERM', 'SIGHUP'].forEach((signal) => {
+      const handler = () => forwardSignal(signal);
+      signalHandlers.set(signal, handler);
+      process.on(signal, handler);
+    });
+
     child.on('exit', (code, signal) => {
+      signalHandlers.forEach((handler, signalName) => {
+        process.off(signalName, handler);
+      });
       clearInterval(heartbeat);
       clearTimeout(killTimer);
       resolve({ status: code, signal });
     });
 
     child.on('error', (error) => {
+      signalHandlers.forEach((handler, signalName) => {
+        process.off(signalName, handler);
+      });
       clearInterval(heartbeat);
       clearTimeout(killTimer);
       console.error(error.message);


### PR DESCRIPTION
### Motivation
- Prevent invalid or malicious environment variable values from producing NaN/invalid timeouts or heartbeat intervals in the Hardhat test runner.
- Ensure the spawned Hardhat child process reliably receives termination signals so runs don't leave orphaned processes.
- Improve robustness of the test harness for CI and local runs where timeouts and signals vary across environments.
- Keep behavior conservative with sensible defaults to avoid surprising test failures on slower machines.

### Description
- Validate and normalise `HARDHAT_TEST_TIMEOUT_MS` into `hardhatTimeoutMs` with a safe default of `900000` (15 minutes) instead of trusting raw parsing. 
- Validate and normalise `HARDHAT_HEARTBEAT_MS` into `heartbeatIntervalMs` with a safe default of `60000` (60s).
- Add signal forwarding for `SIGINT`, `SIGTERM`, and `SIGHUP` so parent signals are forwarded to the spawned `npx hardhat test` child process.
- Remove registered signal handlers when the child process exits or errors to avoid leaking listeners, and tidy up heartbeat/kill timers on exit; changes are in `scripts/run-hardhat-tests.cjs`.

### Testing
- Ran `HARDHAT_TEST_TIMEOUT_MS=bogus HARDHAT_HEARTBEAT_MS=bogus node scripts/run-hardhat-tests.cjs --listTests` which completed successfully and exercised environment parsing/error-resilience. (Succeeded)
- Executed the repository's `pretest` and partial `npm test` earlier in the workflow to observe existing test flow, but the full Hardhat suite is long-running and was intentionally not re-run in full here; the updated runner behaves correctly under the smoke invocation above. (Partial)
- The changes were lint-free and the modified script was committed after validation via local invocation of the helper command. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959b8e787a4833381b2ceb61f8d760d)