### PR TITLE
Fix gRPC error mapping in alpha-bridge

### DIFF
--- a/services/alpha-bridge/src/server.js
+++ b/services/alpha-bridge/src/server.js
@@ -141,23 +141,28 @@ function buildHeaders({
 }
 
 function mapError(error) {
+  const fallbackMessage = "Unexpected error";
   if (!error) {
-    return { code: grpc.status.UNKNOWN, message: "Unknown error" };
+    const unknown = new Error("Unknown error");
+    unknown.code = grpc.status.UNKNOWN;
+    return unknown;
   }
+
+  let code = grpc.status.UNKNOWN;
+  let message = error.message || fallbackMessage;
   if (typeof error.code === "number") {
-    return {
-      code: error.code,
-      message: error.message || grpc.status[error.code] || "Error",
-      details: error.details,
-    };
+    code = error.code;
+    message = message || grpc.status[error.code] || fallbackMessage;
+  } else if (error.httpStatus) {
+    code = HTTP_TO_GRPC.get(error.httpStatus) ?? grpc.status.UNKNOWN;
   }
-  const httpStatus = error.httpStatus;
-  const mapped = httpStatus ? HTTP_TO_GRPC.get(httpStatus) : null;
-  return {
-    code: mapped ?? grpc.status.UNKNOWN,
-    message: error.message || "Unexpected error",
-    details: error.details,
-  };
+
+  const grpcError = new Error(message);
+  grpcError.code = code;
+  if (error.details !== undefined) {
+    grpcError.details = error.details;
+  }
+  return grpcError;
 }
 
 function unary(handler) {


### PR DESCRIPTION
### Motivation
- The previous error mapping returned plain objects instead of real `Error`/ServiceError instances which can confuse gRPC callbacks expecting an `Error` with a numeric `code` property.  
- HTTP error translations to gRPC codes were not consistently wrapped into proper `Error` objects with preserved details.  
- Ensuring consistent ServiceError shapes improves interoperability and clearer error propagation for clients and tests.  

### Description
- Replace the previous plain-object return path in `mapError` with construction of real `Error` instances that include a numeric `code` and optional `details`.  
- Preserve the existing HTTP-to-gRPC mapping via `HTTP_TO_GRPC` while using it to set the returned `Error.code` when `error.httpStatus` is present.  
- Add a clear fallback message and ensure existing `error.code` numeric values are respected when present.  

### Testing
- Ran the alpha-bridge unit test suite with `npm run alpha-bridge:test` and the canonical gRPC proxy test passed.  
- The modified server was exercised by the existing test which verifies plan/execute request/response flows and header/body propagation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959caffefe083338c7dfd1a9bfefcba)