### PR TITLE
Make onebox serialization Pydantic v2-compatible (plan hash & attachments)

### DIFF
--- a/routes/onebox.py
+++ b/routes/onebox.py
@@ -1191,7 +1191,7 @@ def _calculate_deadline_timestamp(days: int) -> int:
     return base + max(0, days_int) * 86400
 
 def _compute_plan_hash(intent: JobIntent) -> str:
-    intent_data = intent.dict(exclude={"userContext"}, by_alias=True)
+    intent_data = _model_dump_with_options(intent, exclude={"userContext"}, by_alias=True)
     encoded = json.dumps(intent_data, sort_keys=True).encode("utf-8")
     h = hashlib.sha256()
     h.update(encoded)
@@ -1254,6 +1254,22 @@ def _maybe_model_dump(value: Any) -> Any:
             return value.dict()
         except Exception:
             pass
+    return value
+
+
+def _model_dump_with_options(value: Any, **kwargs: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        try:
+            return value.model_dump(**kwargs)
+        except TypeError:
+            pass
+        except Exception:
+            return value
+    if hasattr(value, "dict"):
+        try:
+            return value.dict(**kwargs)
+        except Exception:
+            return value
     return value
 
 
@@ -2736,7 +2752,7 @@ async def execute(request: Request, req: ExecuteRequest):
             job_payload = {
                 "title": payload.title or "New Job",
                 "description": payload.description or "",
-                "attachments": [a.dict() for a in payload.attachments],
+                "attachments": [_maybe_model_dump(a) for a in payload.attachments],
                 "rewardToken": payload.rewardToken or AGIALPHA_SYMBOL,
                 "reward": str(payload.reward),
                 "deadlineDays": deadline_days,

--- a/test/routes/test_onebox.py
+++ b/test/routes/test_onebox.py
@@ -1008,7 +1008,7 @@ class ExecuteEndpointRegressionTests(unittest.TestCase):
         app = FastAPI()
         app.include_router(router)
 
-        intent_payload = intent.dict() if hasattr(intent, "dict") else intent.model_dump()
+        intent_payload = intent.model_dump() if hasattr(intent, "model_dump") else intent.dict()
         with mock.patch("routes.onebox._API_TOKEN", ""):
             response = TestClient(app).post(
                 "/onebox/execute",


### PR DESCRIPTION
### Motivation
- Avoid deprecated `dict()` usage and ensure robust serialization across Pydantic v1/v2 for plan hashing and payload attachments.
- Ensure deterministic hashing of job intents for plan identities used in specification and receipt generation.
- Normalize model dumping to reduce runtime errors when calling `.model_dump()` or `.dict()` with options.
- Maintain backward compatibility with code that may still provide Pydantic v1 models.

### Description
- Added a helper `
_model_dump_with_options
` to apply Pydantic v2-style options when available and fall back to `
.dict()
` when appropriate.
- Replaced direct `
.dict(...)
` use in `
_compute_plan_hash
` with `
_model_dump_with_options
` for safe, option-aware serialization.
- Switched attachment serialization to use `
_maybe_model_dump
` so attachments are consistently converted to primitives before pinning.
- Updated the regression test in `test/routes/test_onebox.py` to prefer `
model_dump()
` when present to match runtime behavior.

### Testing
- Ran `pytest` in the repository root as the primary verification command.
- All automated tests completed successfully with `235 passed`.
- No new failing tests were introduced by these changes.
- Existing warnings remained unrelated to the changes and were not treated as failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959d5fb36dc8333bc6bf38ab3373863)