### PR TITLE
Handle numeric and bigint tx receipt status in ownerControlPlan

### DIFF
--- a/scripts/v2/ownerControlPlan.ts
+++ b/scripts/v2/ownerControlPlan.ts
@@ -398,7 +398,9 @@ async function executeModulePlan(plan: ModulePlan) {
     const tx = await (plan.contract as any)[action.method](...action.args);
     console.log(`   Tx hash: ${tx.hash}`);
     const receipt = await tx.wait();
-    if (receipt?.status !== 1n) {
+    const receiptStatus = receipt?.status;
+    const isSuccess = receiptStatus === 1 || receiptStatus === 1n;
+    if (!isSuccess) {
       throw new Error(`Transaction for ${action.method} failed`);
     }
     txHashes.push(tx.hash);


### PR DESCRIPTION
### Motivation
- The owner control plan executes on-chain transactions and previously assumed `receipt.status` would be a `bigint`, which can fail with providers that return a numeric `status` instead.
- Ensuring compatibility with both numeric and `bigint` receipt values prevents false-negative transaction failure reports when running governance updates.
- This small change follows robust input-handling best practices for provider variability.
- Keep behavior minimal and non-destructive by only normalising the receipt success check.

### Description
- Update `executeModulePlan` in `scripts/v2/ownerControlPlan.ts` to read `receipt?.status` into `receiptStatus` and treat success as `receiptStatus === 1 || receiptStatus === 1n`.
- Replace the previous strict `1n` comparison with a cross-type-safe `isSuccess` boolean and throw only when it is false.
- No other functional changes or removals were made; change is limited to `scripts/v2/ownerControlPlan.ts`.
- Code remains compatible with existing `Safe` bundle and plan generation flows.

### Testing
- Ran `node --test apps/onebox/test/error-catalog.test.mjs` and the suite passed successfully.
- No other automated tests were modified or executed as part of this change.
- Manual inspection and a smoke run of the updated `executeModulePlan` logic were performed during development.
- The change is minimal and focused, reducing the risk of regressions in unrelated subsystems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959dd6761d08333babb865a966c7fa0)