### PR TITLE
Validate resource usage inputs in Omega demo

### DIFF
--- a/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/resources.py
+++ b/demo/Kardashev-II Omega-Grade-α-AGI Business-3/kardashev_ii_omega_grade_alpha_agi_business_3_demo/resources.py
@@ -148,6 +148,8 @@ class ResourceManager:
 
     def record_usage(self, name: str, energy: float, compute: float) -> None:
         account = self.ensure_account(name)
+        if energy < 0 or compute < 0:
+            raise ValueError("Usage values must be non-negative")
         if energy > self.energy_available or compute > self.compute_available:
             raise ValueError("Insufficient planetary resources for request")
         self.energy_available -= energy

--- a/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_resources.py
+++ b/demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_resources.py
@@ -22,6 +22,16 @@ def test_lock_stake_mints_when_underfunded():
     assert manager.token_supply == 0
 
 
+def test_record_usage_rejects_negative_values():
+    manager = ResourceManager(energy_capacity=1_000, compute_capacity=1_000, base_token_supply=0)
+    manager.ensure_account("worker", 100)
+
+    with pytest.raises(ValueError):
+        manager.record_usage("worker", energy=-5, compute=10)
+    with pytest.raises(ValueError):
+        manager.record_usage("worker", energy=10, compute=-1)
+
+
 def test_restore_state_rehydrates_reservations_and_clamps_availability():
     manager = ResourceManager(energy_capacity=1_000, compute_capacity=2_000, base_token_supply=100)
     manager.reserve_budget("job-1", energy=200, compute=500)


### PR DESCRIPTION
### Motivation
- Ensure the planetary `ResourceManager` fails fast on invalid input to protect resource and token accounting invariants.
- Harden the demo against accidental or malicious negative usage values by enforcing simple input validation as a best practice.

### Description
- Added a guard in `ResourceManager.record_usage` to raise `ValueError` when `energy` or `compute` is negative.
- Added the unit test `test_record_usage_rejects_negative_values` to verify negative usage is rejected.
- The change is minimal and preserves existing semantics for valid, non-negative usage flows.

### Testing
- Ran `pytest demo/kardashev_ii_omega_grade_alpha_agi_business_3_demo/tests/test_resources.py -q` and the targeted tests passed (`6 passed`).
- The repository-level test run used earlier (`pytest -q`) completed successfully (`235 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959e8f6cc1883338ef45b261eee84ac)