### PR TITLE
Fix background runner failure handling

### DIFF
--- a/orchestrator/runner.py
+++ b/orchestrator/runner.py
@@ -315,19 +315,19 @@ def start_run(plan: OrchestrationPlan, approvals: List[str]) -> RunInfo:
             _RUNS[status.run.id] = current_status
             _persist(current_status)
 
-        final_state: str | None = "succeeded"
+        final_state: str | None = None
         try:
             _resume_run(plan, current_status, status.run.id)
+            final_state = current_status.run.state
         except Exception:  # pragma: no cover - defensive guard for background failures
             logger.exception("Run %s failed during resume", status.run.id)
-            final_state = None
+            final_state = "failed"
         finally:
             with _LOCK:
                 latest_status = _RUNS.get(status.run.id, current_status)
                 if final_state:
                     latest_status.run.state = final_state  # type: ignore[assignment]
-                    if hasattr(latest_status.run, "finished_at"):
-                        latest_status.run.finished_at = time.time()
+                    latest_status.run.completed_at = time.time()
                 _RUNS[status.run.id] = latest_status
                 _persist(latest_status)
 

--- a/tests/orchestrator/test_runner_background.py
+++ b/tests/orchestrator/test_runner_background.py
@@ -1,0 +1,42 @@
+import time
+
+import pytest
+
+from orchestrator import runner
+from orchestrator.models import Budget, OrchestrationPlan, Policies, Step
+
+
+def test_background_run_preserves_failed_state(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setenv("ORCHESTRATOR_SYNC_RUNS", "0")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "")
+    monkeypatch.setenv("ONEBOX_TEST_FORCE_STUB_WEB3", "0")
+    monkeypatch.setenv("ORCHESTRATOR_MODERATION_AUDIT", str(tmp_path / "moderation.log"))
+
+    step = Step(
+        id="moderation-block",
+        name="Moderation Block",
+        kind="validate",
+        tool="safety.moderation",
+        params={
+            "description": (
+                "malware exploit ddos ransomware botnet phishing weapon propaganda "
+                "malware exploit ddos ransomware botnet phishing weapon propaganda"
+            )
+        },
+    )
+    plan = OrchestrationPlan(
+        plan_id="plan-background-fail",
+        steps=[step],
+        budget=Budget(max="0"),
+        policies=Policies(),
+    )
+
+    run_info = runner.start_run(plan, approvals=[])
+
+    deadline = time.time() + 5
+    status = runner.get_status(run_info.id)
+    while status.run.state in {"pending", "running"} and time.time() < deadline:
+        time.sleep(0.05)
+        status = runner.get_status(run_info.id)
+
+    assert status.run.state == "failed"


### PR DESCRIPTION
### Motivation
- Background worker could overwrite a run marked as failed with a success state during finalization, losing the failure signal. 
- The completion timestamp was inconsistently written to a non-existent `finished_at` attribute instead of the canonical `completed_at`. 
- Add a deterministic test to ensure background runs that fail (e.g. moderation blocks) remain `failed` after the worker finishes. 

### Description
- Update `orchestrator/runner.py` worker finalization to capture the actual run state after `_resume_run` and only override when appropriate, using `final_state = current_status.run.state` on success and `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a671a9b3c833383b9dca997de957e)