### PR TITLE
Fix agent depth updates when ensuring agents

### DIFF
--- a/backend/models/hgm.py
+++ b/backend/models/hgm.py
@@ -200,21 +200,27 @@ class HgmRepository:
         now = _now()
         placeholder = self._db.placeholder()
         with self._db.transaction() as cur:
-            depth = 0
-            if parent_key:
-                cur.execute(
-                    f"SELECT depth FROM hgm_agents WHERE run_id = {placeholder} AND agent_key = {placeholder}",
-                    (run_id, parent_key),
-                )
-                parent_row = cur.fetchone()
-                if parent_row is not None:
-                    depth = int(parent_row[0]) + 1
             cur.execute(
                 f"SELECT run_id, agent_key, parent_key, depth, metadata, expansion_count, clade_success, clade_failure, created_at, updated_at "
                 f"FROM hgm_agents WHERE run_id = {placeholder} AND agent_key = {placeholder}",
                 (run_id, agent_key),
             )
             existing = cur.fetchone()
+            if parent_key is not None:
+                depth = 0
+                if parent_key:
+                    cur.execute(
+                        f"SELECT depth FROM hgm_agents WHERE run_id = {placeholder} AND agent_key = {placeholder}",
+                        (run_id, parent_key),
+                    )
+                    parent_row = cur.fetchone()
+                    if parent_row is not None:
+                        depth = int(parent_row[0]) + 1
+            elif existing is not None:
+                parent_key = existing[2]
+                depth = int(existing[3])
+            else:
+                depth = 0
             payload = _serialize(metadata)
             if existing is None:
                 cur.execute(
@@ -232,7 +238,7 @@ class HgmRepository:
                 if parent_key is not None and parent_key != existing[2]:
                     updates.append(f"parent_key = {placeholder}")
                     params.append(parent_key)
-                if depth != existing[3]:
+                if parent_key is not None and depth != existing[3]:
                     updates.append(f"depth = {placeholder}")
                     params.append(depth)
                 if metadata is not None:


### PR DESCRIPTION
### Motivation

- The prior `ensure_agent` logic could reset an agent's `parent_key`/`depth` when called without an explicit `parent_key`, corrupting lineage information.
- Ensure metadata-only updates do not unintentionally change hierarchical relationships.
- Only recalculate depth when a parent is explicitly provided to avoid surprising behavior.

### Description

- Updated `backend/models/hgm.py` (`ensure_agent`) to read the existing row before deciding how to set `parent_key` and `depth` so existing values are preserved when no parent is supplied.
- Depth lookup now only occurs when `parent_key is not None`, and the `UPDATE` statement updates `depth` only when a parent was explicitly provided.
- Kept insertion behavior unchanged and ensured metadata updates still write `metadata` and `updated_at` as before.

### Testing

- Ran `pytest -q tests/backend/test_hgm_repository.py::test_repository_persists_lineage` which passed.
- Ran `pytest -q tests/backend/test_hgm_repository.py tests/routes/test_hgm_routes.py -q` which passed all tests.
- Verified that `seed_demo_run` and lineage traversal still return expected structures via the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a85b0934c8333a342c923f9c67b92)