### PR TITLE
Fix sqlite URL parsing for relative and absolute paths

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -37,14 +37,15 @@ class Database:
             raise DatabaseError("Empty database URL")
         if url.startswith("sqlite://"):
             dsn = url[len("sqlite://"):]
-            if dsn.startswith("/"):
+            if dsn.startswith("//"):
                 # Handle sqlite:////absolute/path.db -> //absolute/path.db
                 while dsn.startswith("//"):
                     dsn = dsn[1:]
-                if dsn.startswith("/"):
-                    # Absolute path
-                    return "sqlite", dsn
-                return "sqlite", dsn
+                return "sqlite", dsn or ":memory:"
+            if dsn.startswith("/"):
+                # sqlite:///relative/path.db should be treated as relative to CWD.
+                dsn = dsn.lstrip("/")
+                return "sqlite", dsn or ":memory:"
             if not dsn:
                 return "sqlite", ":memory:"
             return "sqlite", dsn


### PR DESCRIPTION
### Motivation

- `sqlite://` URL handling produced ambiguous DSNs for three- and four-slash forms and empty paths, causing unexpected file locations or failures.
- `sqlite:////absolute/path.db` semantics need to preserve absolute paths while `sqlite:///relative/path.db` should be treated as relative to the working directory.
- When no path is supplied the parser should default to an in-memory database for robustness.

### Description

- Update `Database._parse_url` to distinguish `//` (absolute) vs single leading `/` (treat as relative) and strip leading slashes appropriately.
- Ensure empty DSNs resolved to `:memory:` to avoid creating unexpected files and make behavior explicit.
- Keep existing behavior for `sqlite:` without slashes and for PostgreSQL URLs; no other APIs were changed.

### Testing

- Ran a small automated check that constructs `Database(url)` and asserts the parsed `_dsn` for representative cases: `sqlite:///storage/hgm.db`, `sqlite:////tmp/test.db`, and `sqlite://`.
- The snippet asserted expected DSNs and printed `ok`, indicating the parsing logic behaves as intended.
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a8ae897f8833394092fbeac5a5300)