### PR TITLE
Fix checkpoint store reconfiguration for updated environment paths

### DIFF
--- a/orchestrator/checkpoint.py
+++ b/orchestrator/checkpoint.py
@@ -389,6 +389,7 @@ class CheckpointManager:
 
 
 _CHECKPOINT_STORE_SINGLETON: Optional[CheckpointStore] = None
+_CHECKPOINT_STORE_CONFIG: Optional[tuple[object, ...]] = None
 
 
 def load_governance_settings(path: Path | None = None) -> GovernanceSettings:
@@ -405,23 +406,38 @@ def load_governance_settings(path: Path | None = None) -> GovernanceSettings:
     return GovernanceSettings.from_metadata(payload, source=str(resolved))
 
 
-def get_checkpoint_store() -> CheckpointStore:
-    global _CHECKPOINT_STORE_SINGLETON
-    if _CHECKPOINT_STORE_SINGLETON is not None:
-        return _CHECKPOINT_STORE_SINGLETON
+def _checkpoint_store_config() -> tuple[object, ...]:
     backend = os.environ.get("ORCHESTRATOR_CHECKPOINT_BACKEND", "file").lower()
     if backend == "leveldb":
-        store = LevelDBCheckpointStore()
+        path = Path(os.environ.get("ORCHESTRATOR_CHECKPOINT_LEVELDB", "storage/orchestrator/checkpoint.db")).resolve()
+        return (backend, path)
+    if backend == "s3":
+        bucket = os.environ.get("ORCHESTRATOR_CHECKPOINT_BUCKET", "")
+        prefix = os.environ.get("ORCHESTRATOR_CHECKPOINT_PREFIX", _DEFAULT_S3_PREFIX)
+        return (backend, bucket, prefix)
+    path = Path(os.environ.get("ORCHESTRATOR_CHECKPOINT_PATH", "storage/orchestrator/checkpoint.json")).resolve()
+    return (backend, path)
+
+
+def get_checkpoint_store() -> CheckpointStore:
+    global _CHECKPOINT_STORE_SINGLETON, _CHECKPOINT_STORE_CONFIG
+    config = _checkpoint_store_config()
+    if _CHECKPOINT_STORE_SINGLETON is not None and _CHECKPOINT_STORE_CONFIG == config:
+        return _CHECKPOINT_STORE_SINGLETON
+    backend = config[0]
+    if backend == "leveldb":
+        store = LevelDBCheckpointStore(Path(config[1]))
     elif backend == "s3":
-        bucket = os.environ.get("ORCHESTRATOR_CHECKPOINT_BUCKET")
+        bucket = config[1]
         if not bucket:
             raise CheckpointStoreError("ORCHESTRATOR_CHECKPOINT_BUCKET is required for S3 checkpoint store")
-        prefix = os.environ.get("ORCHESTRATOR_CHECKPOINT_PREFIX", _DEFAULT_S3_PREFIX)
+        prefix = config[2]
         store = S3CheckpointStore(bucket, prefix)
     else:
-        path = Path(os.environ.get("ORCHESTRATOR_CHECKPOINT_PATH", str(_DEFAULT_FILE_PATH)))
+        path = Path(config[1])
         store = FileCheckpointStore(path)
     _CHECKPOINT_STORE_SINGLETON = store
+    _CHECKPOINT_STORE_CONFIG = config
     return store
 
 


### PR DESCRIPTION
### Motivation

- The checkpoint store singleton could remain bound to an old path when environment variables changed, causing restores to miss updated checkpoint files and lost in-flight runs.
- This produced flaky behavior when the orchestrator module was reloaded with different `ORCHESTRATOR_CHECKPOINT_*` settings.
- The change ensures the checkpoint backend reflects current environment configuration so resumed runs are persisted and restored from the expected location.

### Description

- Add `_CHECKPOINT_STORE_CONFIG` to track the active checkpoint store configuration and compare it on each `get_checkpoint_store()` call.
- Introduce `_checkpoint_store_config()` to derive a canonical config tuple from environment variables and resolve file paths, including support for `file`, `leveldb`, and `s3` backends.
- Recreate the checkpoint store singleton when the environment-derived config changes and pass resolved `Path`/parameters into the backend constructors.
- Keep behavior for `FileCheckpointStore`, `LevelDBCheckpointStore`, and `S3CheckpointStore` while making store selection deterministic across reloads.

### Testing

- A prior `pytest -q` run reported `1 failed, 235 passed` with the failing test `test_restart_workflow_resumes_mid_run` before the fix. 
- Ran the targeted test with `pytest test/orchestrator/test_checkpoint.py::test_restart_workflow_resumes_mid_run -q` after the change and it passed. 
- The modified `orchestrator/checkpoint.py` was exercised by the checkpoint unit tests validating snapshot/restore and integrity. 
- No other automated test failures were observed for the targeted tests executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a912060508333ac855b2854f161c6)