### PR TITLE
Sync thermostat snapshot with applied engine config

### DIFF
--- a/services/thermostat/controller.py
+++ b/services/thermostat/controller.py
@@ -125,6 +125,8 @@ class ThermostatController:
 
         await self.initialize()
         adjustment: Optional[ThermostatAdjustment] = None
+        current: EngineConfig | None = None
+        updates: Dict[str, float] = {}
 
         async with self._lock:
             self._roi_history.append(sample.roi)
@@ -155,7 +157,6 @@ class ThermostatController:
 
             assert self._config_snapshot is not None
             current = self._config_snapshot
-            updates: Dict[str, float] = {}
 
             if direction == "roi_dip":
                 widened = min(
@@ -202,7 +203,17 @@ class ThermostatController:
 
         if adjustment is not None:
             if self._apply_updates:
-                await self._workflow.update_engine_parameters(**{k: v[1] for k, v in adjustment.parameters.items()})
+                applied = await self._workflow.update_engine_parameters(
+                    **{k: v[1] for k, v in adjustment.parameters.items()}
+                )
+                if current is not None:
+                    async with self._lock:
+                        self._config_snapshot = replace(applied)
+                    applied_parameters = {
+                        key: (getattr(current, key), getattr(applied, key))
+                        for key in updates
+                    }
+                    adjustment = replace(adjustment, parameters=applied_parameters)
             self._logger.info(
                 "Thermostat adjustment %s avg_roi=%.4f parameters=%s",
                 adjustment.reason,


### PR DESCRIPTION
### Motivation
- Ensure the thermostat controller internal snapshot stays aligned with the actual engine configuration returned by the engine after parameter updates to avoid state drift.
- Ensure reported adjustment parameters reflect the values actually applied (including any clamping/normalisation performed by the engine) rather than the requested targets.

### Description
- Update `services/thermostat/controller.py` to capture the `current` snapshot and `updates` before invoking `update_engine_parameters` and to hold the `applied` `EngineConfig` returned by the engine.
- After applying updates, refresh the controller `_config_snapshot` with the `applied` configuration under the controller lock and rebuild the `parameters` mapping to show the actual `from`/`to` values returned by the engine.
- Preserve existing cooldown and logging behaviour while improving correctness of the controller state and adjustment reporting.

### Testing
- Ran the full Python test suite with `pytest -q` as part of CI validation.
- All automated tests passed: `236 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aa1cb60f48333a3dc74d6e0f76969)