### PR TITLE
Validate stake amounts in AGI Alpha Node demos

### DIFF
--- a/demo/AGI-Alpha-Node-v0/alpha_node/stake.py
+++ b/demo/AGI-Alpha-Node-v0/alpha_node/stake.py
@@ -1,6 +1,7 @@
 """Stake, reward, and slashing simulators for the demo."""
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -35,19 +36,29 @@ class StakeManager:
         self.store.append_audit(f"[{timestamp}] stake-event {event} {amount}")
         return StakeEvent(event=event, amount=amount, total_locked=total_locked, timestamp=timestamp)
 
+    @staticmethod
+    def _validate_amount(amount: float, *, label: str) -> None:
+        if not math.isfinite(amount):
+            raise ValueError(f"{label} amount must be a finite number")
+        if amount <= 0:
+            raise ValueError(f"{label} amount must be greater than zero")
+
     def deposit(self, amount: float) -> StakeEvent:
+        self._validate_amount(amount, label="Deposit")
         state = self.store.read()
         new_total = state.stake_locked + amount
         self.store.update(stake_locked=new_total)
         return self._record("deposit", amount, new_total)
 
     def slash(self, amount: float) -> StakeEvent:
+        self._validate_amount(amount, label="Slash")
         state = self.store.read()
         new_total = max(0.0, state.stake_locked - amount)
         self.store.update(stake_locked=new_total)
         return self._record("slash", -amount, new_total)
 
     def accrue_rewards(self, amount: float) -> StakeEvent:
+        self._validate_amount(amount, label="Reward")
         state = self.store.read()
         new_total = state.total_rewards + amount
         self.store.update(total_rewards=new_total)

--- a/demo/AGI-Alpha-Node-v0/src/agi_alpha_node_demo/blockchain/contracts.py
+++ b/demo/AGI-Alpha-Node-v0/src/agi_alpha_node_demo/blockchain/contracts.py
@@ -33,6 +33,8 @@ class StakeManagerClient:
         self.ledger = ledger or MockLedger()
 
     def deposit(self, address: str, amount: int) -> str:
+        if amount <= 0:
+            raise ValueError("Deposit amount must be greater than zero")
         logger.info("Depositing stake", extra={"context": {"address": address, "amount": amount}})
         self.ledger.stakes[address] = self.ledger.stakes.get(address, 0) + amount
         tx_hash = f"0x{abs(hash((address, amount))) % (10**64):064x}"

--- a/demo/AGI-Alpha-Node-v0/tests/test_stake_validation.py
+++ b/demo/AGI-Alpha-Node-v0/tests/test_stake_validation.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agi_alpha_node_demo.blockchain.contracts import MockLedger, StakeManagerClient
+from alpha_node.config import StakeSettings
+from alpha_node.state import StateStore
+from alpha_node.stake import StakeManager
+
+
+def test_stake_manager_rejects_invalid_amounts(tmp_path: Path) -> None:
+    store = StateStore(tmp_path / "state.json")
+    settings = StakeSettings(
+        asset_symbol="AGI",
+        minimum_stake=1.0,
+        restake_threshold=0.5,
+        reward_address="0xdead",
+    )
+    manager = StakeManager(settings, store, tmp_path / "ledger.csv")
+
+    with pytest.raises(ValueError):
+        manager.deposit(0)
+    with pytest.raises(ValueError):
+        manager.deposit(-1)
+    with pytest.raises(ValueError):
+        manager.slash(0)
+    with pytest.raises(ValueError):
+        manager.accrue_rewards(float("inf"))
+
+
+def test_stake_manager_client_rejects_invalid_amounts() -> None:
+    client = StakeManagerClient(MockLedger())
+
+    with pytest.raises(ValueError):
+        client.deposit("0xabc", 0)
+    with pytest.raises(ValueError):
+        client.deposit("0xabc", -5)


### PR DESCRIPTION
### Motivation
- Prevent invalid stake operations (zero, negative, or non-finite values) from corrupting demo state or ledger files.  
- Improve defensive checks for demo-only blockchain client to match runtime validation in the Python demo.  
- Increase robustness and clarity of failure modes for operators exercising stake flows.  
- Add automated tests to document and lock-in the intended behavior.

### Description
- Added `_validate_amount` to `alpha_node.stake.StakeManager` and applied it to `deposit`, `slash`, and `accrue_rewards` to reject non-finite or non-positive inputs.  
- Added an input check to `src/agi_alpha_node_demo/blockchain/contracts.py` `StakeManagerClient.deposit` to raise `ValueError` for non-positive `amount`.  
- Introduced new unit tests in `demo/AGI-Alpha-Node-v0/tests/test_stake_validation.py` that assert invalid amounts are rejected by both the demo `StakeManager` and the mock blockchain client.  
- Minor import reordering (`math`) to support numeric validation.

### Testing
- Ran the demo test suite with `pytest demo/AGI-Alpha-Node-v0/tests -q`.  
- All tests passed: `11 passed` (including the new validation tests).  
- Existing demo unit tests were exercised and remained green after changes.  
- New tests specifically cover `StakeManager.deposit`, `StakeManager.slash`, `StakeManager.accrue_rewards`, and `StakeManagerClient.deposit` failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695abb7a111483339ca4f1336441d5ea)