### PR TITLE
Normalize psycopg-style Postgres URLs in database config

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -55,6 +55,10 @@ class Database:
             if psycopg is None:
                 raise DatabaseError("psycopg is required for PostgreSQL connections")
             return "postgres", url
+        if url.startswith("postgresql+psycopg"):
+            if psycopg is None:
+                raise DatabaseError("psycopg is required for PostgreSQL connections")
+            return "postgres", f"postgresql://{url.split('://', 1)[1]}"
         if ":" not in url and url.endswith(".db"):
             return "sqlite", url
         raise DatabaseError(f"Unsupported database URL: {url}")

--- a/tests/backend/test_database_url_parsing.py
+++ b/tests/backend/test_database_url_parsing.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from backend import database as db_module
+from backend.database import DatabaseError
+
+
+def test_parse_postgres_psycopg_url_requires_driver() -> None:
+    if db_module.psycopg is not None:
+        pytest.skip("psycopg installed; requirement test not applicable")
+    with pytest.raises(DatabaseError, match="psycopg is required"):
+        db_module.Database._parse_url("postgresql+psycopg://user@localhost/db")
+
+
+def test_parse_postgres_psycopg_url_normalizes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db_module, "psycopg", object())
+    driver, dsn = db_module.Database._parse_url("postgresql+psycopg://user@localhost/db")
+    assert driver == "postgres"
+    assert dsn == "postgresql://user@localhost/db"


### PR DESCRIPTION
### Motivation

- The database URL parser should accept SQLAlchemy/psycopg-style schemes like `postgresql+psycopg://` commonly used in configuration. 
- Without normalization these URLs were treated as unsupported and caused confusing errors in deployments that specify `+psycopg` in the scheme. 
- The code must also enforce that the optional `psycopg` dependency is present before attempting Postgres connections. 

### Description

- Update `backend/database.py` to recognize `postgresql+psycopg://` prefixes and normalize them to a standard `postgresql://` DSN. 
- Keep the existing presence check and raise `DatabaseError` when `psycopg` is not installed. 
- Preserve existing behavior for other schemes including `sqlite://` and `postgresql://`. 
- Add `tests/backend/test_database_url_parsing.py` with tests for missing-driver behavior and normalization of `postgresql+psycopg` URLs. 

### Testing

- Ran the full test suite with `pytest -q`. 
- Automated tests completed successfully with `237 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ac296ad248333a506d4608c41c7bb)