### PR TITLE
Guard database singleton against conflicting URLs

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -86,6 +86,10 @@ class Database:
     def driver(self) -> str:
         return self._driver
 
+    @property
+    def url(self) -> str:
+        return self._url
+
     def close(self) -> None:
         with self._lock:
             if self._closed:
@@ -177,6 +181,11 @@ def get_database(url: str | None = None) -> Database:
     global _DATABASE_SINGLETON
     with _DATABASE_LOCK:
         if _DATABASE_SINGLETON is not None:
+            if url is not None and url != _DATABASE_SINGLETON.url:
+                raise DatabaseError(
+                    "Database already initialised with a different URL. "
+                    "Call set_database() to reset the singleton before reconfiguring."
+                )
             return _DATABASE_SINGLETON
         db = Database(url)
         from backend.migrations import MIGRATIONS

--- a/tests/backend/test_database_url_parsing.py
+++ b/tests/backend/test_database_url_parsing.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import pytest
 
+from pathlib import Path
+
 from backend import database as db_module
-from backend.database import DatabaseError
+from backend.database import DatabaseError, get_database, set_database
 
 
 def test_parse_postgres_psycopg_url_requires_driver() -> None:
@@ -18,3 +20,15 @@ def test_parse_postgres_psycopg_url_normalizes(monkeypatch: pytest.MonkeyPatch) 
     driver, dsn = db_module.Database._parse_url("postgresql+psycopg://user@localhost/db")
     assert driver == "postgres"
     assert dsn == "postgresql://user@localhost/db"
+
+
+def test_get_database_rejects_conflicting_urls(tmp_path: Path) -> None:
+    set_database(None)
+    first_url = f"sqlite:///{tmp_path / 'first.db'}"
+    second_url = f"sqlite:///{tmp_path / 'second.db'}"
+    try:
+        get_database(first_url)
+        with pytest.raises(DatabaseError, match="already initialised"):
+            get_database(second_url)
+    finally:
+        set_database(None)


### PR DESCRIPTION
### Motivation
- Prevent accidental reuse of the process-global database singleton when callers pass a different `url`, which could lead to confusing or incorrect behavior at runtime.  
- Provide a simple, safe way to inspect the configured URL for the existing singleton via a property.  
- Make tests deterministic by ensuring tests can reset the singleton before reconfiguration.  

### Description
- Added a `url` property to `Database` to expose the originally configured database URL as `Database.url`.  
- Updated `get_database` to raise `DatabaseError` if it is called with a `url` that differs from the already-initialised singleton, with guidance to call `set_database()` to reset.  
- Added `test_get_database_rejects_conflicting_urls` to `tests/backend/test_database_url_parsing.py` to cover the new conflict check and adjusted imports and `tmp_path` usage.  

### Testing
- Ran the full test suite with `pytest -q --disable-warnings --maxfail=1`.  
- All automated tests passed: `238 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695acd9bef288333ba4ef0ab92731486)