### PR TITLE
Fix percentile calculation for latency P95

### DIFF
--- a/demo/AGIJobs-Day-One-Utility-Benchmark/demo_runner.py
+++ b/demo/AGIJobs-Day-One-Utility-Benchmark/demo_runner.py
@@ -420,12 +420,7 @@ class DayOneUtilityOrchestrator:
         utility_uplift = self._safe_relative_change(candidate_utility, baseline_utility)
         latency_delta = self._safe_relative_change(avg_candidate_latency, avg_baseline_latency)
 
-        sorted_latencies = sorted(candidate_latencies)
-        if sorted_latencies:
-            p95_index = min(len(sorted_latencies) - 1, max(0, math.ceil(0.95 * (len(sorted_latencies) - 1))))
-            latency_p95 = sorted_latencies[p95_index]
-        else:
-            latency_p95 = 0.0
+        latency_p95 = self._percentile(candidate_latencies, 0.95)
 
         owner_snapshot = {
             **snapshot,
@@ -539,6 +534,24 @@ class DayOneUtilityOrchestrator:
                 return 0.0
             return math.copysign(1.0, candidate)
         return (candidate - baseline) / abs(baseline)
+
+    @staticmethod
+    def _percentile(values: Sequence[float], quantile: float) -> float:
+        """Return a percentile using linear interpolation for small samples."""
+        if not values:
+            return 0.0
+        if quantile <= 0.0:
+            return min(values)
+        if quantile >= 1.0:
+            return max(values)
+        ordered = sorted(values)
+        rank = quantile * (len(ordered) - 1)
+        lower = math.floor(rank)
+        upper = math.ceil(rank)
+        if lower == upper:
+            return ordered[int(rank)]
+        weight = rank - lower
+        return (1 - weight) * ordered[int(lower)] + weight * ordered[int(upper)]
 
     def _build_action_path(
         self,


### PR DESCRIPTION
### Motivation
- The P95 latency calculation used an index-based approach that could produce off-by-one errors and behaved poorly with small samples.  
- A stable, well-defined quantile implementation is needed to ensure consistent telemetry and guardrail decisions.  
- Improve numerical robustness and make the demo's statistical primitives follow best-practice percentile interpolation.

### Description
- Add a new static helper ` _percentile(values, quantile)` that computes quantiles with linear interpolation for small samples.  
- Replace the ad-hoc P95 index logic in `simulate` with a call to `self._percentile(candidate_latencies, 0.95)` so latency P95 is computed correctly.  
- Keep behavioral semantics of the orchestrator unchanged while improving statistical correctness for latency metrics.

### Testing
- Ran the repository test suite with `pytest -q` which previously completed successfully (`238 passed, 1 skipped`).  
- Executed the demo unit tests with `pytest demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py -q` and all demo tests passed (`19 passed`).  
- Verified the `run_demo.py simulate` flow produces the expected JSON and HTML artifacts and includes the corrected `latency_p95` value.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af562383483338009c43c58bef524)