### PR TITLE
Fix IPFS pin auth handling

### DIFF
--- a/apps/onebox-static/lib.mjs
+++ b/apps/onebox-static/lib.mjs
@@ -435,10 +435,11 @@ export function formatEvent(event) {
 }
 
 export async function pinBlob(endpoint, token, file) {
+  const authHeaders = buildAuthHeaders(token);
   const response = await fetch(endpoint, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`,
+      ...authHeaders,
       ...(file?.type ? { "Content-Type": file.type } : {}),
     },
     body: file,
@@ -454,10 +455,11 @@ export async function pinBlob(endpoint, token, file) {
 }
 
 export async function pinJSON(endpoint, token, json) {
+  const authHeaders = buildAuthHeaders(token);
   const response = await fetch(endpoint, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${token}`,
+      ...authHeaders,
       "Content-Type": "application/json",
     },
     body: JSON.stringify(json),
@@ -483,6 +485,18 @@ const ERROR_FIELDS_TO_FOLLOW = [
   "info",
   "reason",
 ];
+
+const AUTH_TOKEN_PATTERN = /^[A-Za-z0-9._~+/=:-]{1,512}$/;
+
+function buildAuthHeaders(token) {
+  if (typeof token !== "string") return {};
+  const trimmed = token.trim();
+  if (!trimmed) return {};
+  if (!AUTH_TOKEN_PATTERN.test(trimmed)) {
+    throw new Error("Invalid IPFS token");
+  }
+  return { Authorization: `Bearer ${trimmed}` };
+}
 
 function pushUnique(array, value) {
   if (!value && value !== 0) return;

--- a/apps/onebox-static/test/pinning.test.mjs
+++ b/apps/onebox-static/test/pinning.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { needsAttachmentPin, prepareJobPayload } from '../lib.mjs';
+import { needsAttachmentPin, pinJSON, prepareJobPayload } from '../lib.mjs';
 
 const IPFS_GATEWAY = 'https://w3s.link/ipfs/';
 
@@ -332,4 +332,55 @@ test('prepareJobPayload applies multiple attachments without repinning payload',
       size: 512,
     },
   ]);
+});
+
+test('pinJSON omits authorization header when token is blank', async () => {
+  const originalFetch = global.fetch;
+  const captured = [];
+  global.fetch = async (url, options) => {
+    captured.push({ url, options });
+    return {
+      ok: true,
+      json: async () => ({ cid: CID }),
+    };
+  };
+
+  try {
+    await pinJSON('https://ipfs.example.test/pins', '', { hello: 'world' });
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  assert.equal(captured.length, 1);
+  const headers = captured[0].options?.headers ?? {};
+  assert.equal(Object.prototype.hasOwnProperty.call(headers, 'Authorization'), false);
+});
+
+test('pinJSON includes authorization header when token is provided', async () => {
+  const originalFetch = global.fetch;
+  const captured = [];
+  global.fetch = async (url, options) => {
+    captured.push({ url, options });
+    return {
+      ok: true,
+      json: async () => ({ cid: CID }),
+    };
+  };
+
+  try {
+    await pinJSON('https://ipfs.example.test/pins', 'demo-token', { hello: 'world' });
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  assert.equal(captured.length, 1);
+  const headers = captured[0].options?.headers ?? {};
+  assert.equal(headers.Authorization, 'Bearer demo-token');
+});
+
+test('pinJSON rejects invalid tokens early', async () => {
+  await assert.rejects(
+    () => pinJSON('https://ipfs.example.test/pins', 'bad token!', { hello: 'world' }),
+    /Invalid IPFS token/,
+  );
 });


### PR DESCRIPTION
### Motivation

- Avoid sending an `Authorization` header to IPFS endpoints when the token is empty to prevent accidental leakage and unexpected behavior.  
- Validate IPFS token format early to reject malformed tokens and prevent header injection.  
- Harden the onebox static pinning utilities for more predictable client behavior when interacting with pinning services.  

### Description

- Add `AUTH_TOKEN_PATTERN` and `buildAuthHeaders` to validate and normalize an IPFS token before using it.  
- Update `pinBlob` and `pinJSON` to use `buildAuthHeaders` and only include an `Authorization` header when a valid token is present.  
- Add unit tests in `apps/onebox-static/test/pinning.test.mjs` that assert header omission for blank tokens, header inclusion for valid tokens, and early rejection for invalid tokens.  
- Adjust test imports to include `pinJSON` and exercise the new behavior.  

### Testing

- Ran the onebox static unit tests with `node --test apps/onebox-static/test/*.test.mjs`.  
- All tests passed: 46 tests ran with 0 failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b03d3b47083339c50afc53922b3d5)