### PR TITLE
Restrict demo test roots to demo scope

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -392,7 +392,7 @@ def _node_package_root(tests_dir: Path, demo_dir: Path) -> Path | None:
     for ancestor in [tests_dir, *tests_dir.parents]:
         if (ancestor / "package.json").is_file():
             return ancestor
-        if ancestor == demo_dir.parent:
+        if ancestor == demo_dir:
             break
 
     return None
@@ -404,7 +404,7 @@ def _foundry_project_root(tests_dir: Path, demo_dir: Path) -> Path | None:
     for ancestor in [tests_dir, *tests_dir.parents]:
         if (ancestor / "foundry.toml").is_file():
             return ancestor
-        if ancestor == demo_dir.parent:
+        if ancestor == demo_dir:
             break
 
     return None

--- a/tests/test_run_demo_tests.py
+++ b/tests/test_run_demo_tests.py
@@ -190,3 +190,31 @@ def test_run_suite_only_adds_timeout_when_requested(
 
     run_demo_tests._run_suite(suite, {}, timeout=5.0)
     assert captured_kwargs.get("timeout") == 5.0
+
+
+def test_node_package_root_does_not_escape_demo_root(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    demo_root = workspace / "demo"
+    tests_dir = demo_root / "tests"
+    tests_dir.mkdir(parents=True)
+
+    (workspace / "package.json").write_text("{}")
+    (demo_root / "package.json").write_text("{}")
+
+    package_root = run_demo_tests._node_package_root(tests_dir, demo_root)
+
+    assert package_root == demo_root
+
+
+def test_foundry_project_root_does_not_escape_demo_root(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    demo_root = workspace / "demo"
+    tests_dir = demo_root / "tests"
+    tests_dir.mkdir(parents=True)
+
+    (workspace / "foundry.toml").write_text("profile = \"default\"")
+    (demo_root / "foundry.toml").write_text("profile = \"demo\"")
+
+    project_root = run_demo_tests._foundry_project_root(tests_dir, demo_root)
+
+    assert project_root == demo_root


### PR DESCRIPTION
### Motivation
- Demo test discovery could walk above the demo directory when locating Node or Foundry projects, causing incorrect package/foundry roots to be used.
- Keeping package and project root detection scoped to the demo tree prevents cross-demo interference and leaking state between sandboxes. 
- Ensures the per-suite isolation model remains hermetic so overlapping demo names do not collide.

### Description
- Stop climbing above the provided demo root in `_node_package_root` by breaking when `ancestor == demo_dir` instead of `demo_dir.parent`.
- Apply the same stop condition fix to `_foundry_project_root` so foundry project resolution is bounded to the demo tree. 
- Add two regression tests `test_node_package_root_does_not_escape_demo_root` and `test_foundry_project_root_does_not_escape_demo_root` in `tests/test_run_demo_tests.py` to assert roots stay scoped to the demo. 

### Testing
- Ran `pytest -q tests/test_run_demo_tests.py`, which passed: `10 passed`.
- The repository test suite was previously exercised and reported `51 passed, 1 skipped` when run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b1bd85bb08333a4d201382e12a77d)