### PR TITLE
Sanitize alpha-bridge metadata headers

### DIFF
--- a/services/alpha-bridge/src/server.js
+++ b/services/alpha-bridge/src/server.js
@@ -47,6 +47,18 @@ function normalizeMetadata(metadata) {
   return output;
 }
 
+function sanitizeHeaderKey(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 function parseJsonOrThrow(label, value, { allowEmptyArray = false } = {}) {
   if (typeof value !== "string" || !value.trim()) {
     if (allowEmptyArray) {
@@ -134,7 +146,11 @@ function buildHeaders({
   }
   if (metadata) {
     for (const [key, value] of Object.entries(metadata)) {
-      headers[`x-agi-meta-${key.toLowerCase()}`] = value;
+      const sanitizedKey = sanitizeHeaderKey(key);
+      if (!sanitizedKey) {
+        continue;
+      }
+      headers[`x-agi-meta-${sanitizedKey}`] = value;
     }
   }
   return headers;

--- a/services/alpha-bridge/test/alpha-bridge.test.js
+++ b/services/alpha-bridge/test/alpha-bridge.test.js
@@ -245,7 +245,11 @@ test("alpha-bridge proxies canonical flows via gRPC", async (t) => {
           trace_id: flow.traceId,
           require_consent: flow.requiresConsent,
           consent_token: flow.consentToken,
-          metadata: { flow: flow.name, stage: "plan" },
+          metadata: {
+            flow: flow.name,
+            stage: "plan",
+            "Region Zone": "US-East/1",
+          },
         },
         (error, response) => {
           if (error) {
@@ -271,7 +275,11 @@ test("alpha-bridge proxies canonical flows via gRPC", async (t) => {
           trace_id: planResponse.trace_id,
           consent_granted: flow.expectedConsent,
           consent_token: planResponse.consent_token,
-          metadata: { flow: flow.name, stage: "execute" },
+          metadata: {
+            flow: flow.name,
+            stage: "execute",
+            "Region Zone": "US-East/1",
+          },
         },
         (error, response) => {
           if (error) {
@@ -304,6 +312,7 @@ test("alpha-bridge proxies canonical flows via gRPC", async (t) => {
     }
     assert.equal(planHeaders["x-agi-meta-flow"], flow.name);
     assert.equal(planHeaders["x-agi-meta-stage"], "plan");
+    assert.equal(planHeaders["x-agi-meta-region-zone"], "US-East/1");
 
     const executeHeaders = receivedExecuteHeaders[index];
     assert.equal(executeHeaders["x-agi-trace-id"], flow.traceId);
@@ -316,5 +325,6 @@ test("alpha-bridge proxies canonical flows via gRPC", async (t) => {
     }
     assert.equal(executeHeaders["x-agi-meta-flow"], flow.name);
     assert.equal(executeHeaders["x-agi-meta-stage"], "execute");
+    assert.equal(executeHeaders["x-agi-meta-region-zone"], "US-East/1");
   }
 });


### PR DESCRIPTION
### Motivation
- Prevent invalid HTTP header names when arbitrary metadata keys (e.g. containing spaces or punctuation) are mapped into headers in the alpha-bridge.
- Normalize metadata keys to a safe, predictable form so downstream HTTP servers and proxies receive valid header names.

### Description
- Added a `sanitizeHeaderKey` helper that trims, lowercases, replaces non-alphanumeric characters with `-`, collapses repeated dashes, and trims leading/trailing dashes.
- Updated `buildHeaders` to use `sanitizeHeaderKey` and skip metadata entries that sanitize to an empty key.
- Extended the bridge unit test to include a metadata key with spaces (`"Region Zone"`) and assert the emitted header `x-agi-meta-region-zone` is present.
- Files changed: `services/alpha-bridge/src/server.js` and `services/alpha-bridge/test/alpha-bridge.test.js`.

### Testing
- Ran the alpha-bridge unit test with `npm run alpha-bridge:test` and it passed successfully.
- The updated test validates header key sanitization and the bridge behavior (all assertions passed).
- No other automated test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b1bd85bb08333a4d201382e12a77d)