### PR TITLE
Default onebox Web3 stub to tests only

### DIFF
--- a/routes/onebox.py
+++ b/routes/onebox.py
@@ -125,7 +125,9 @@ except Exception:  # pragma: no cover - exercised in test shims
 # Flag that forces the module to fall back to the lightweight Web3 stub. This must be
 # defined before the guarded import below to avoid NameError short-circuiting the
 # check and forcing the stub unintentionally.
-_FORCE_STUB_WEB3 = os.getenv("ONEBOX_TEST_FORCE_STUB_WEB3", "1") == "1"
+# Default to the real Web3 implementation unless explicitly overridden for tests.
+# Test suites set ONEBOX_TEST_FORCE_STUB_WEB3=1 in their fixtures.
+_FORCE_STUB_WEB3 = os.getenv("ONEBOX_TEST_FORCE_STUB_WEB3", "0") == "1"
 
 try:
     if _FORCE_STUB_WEB3 or (


### PR DESCRIPTION
### Motivation

- Prevent the lightweight Web3 stub from being used by default in non-test environments to avoid masking production issues.
- Ensure tests opt-in to the stub via environment so test fixtures control test isolation explicitly.
- Improve clarity and follow best practices by making runtime behavior explicit.
- Preserve existing shim behavior for environments that deliberately enable it.

### Description

- Change default `ONEBOX_TEST_FORCE_STUB_WEB3` handling in `routes/onebox.py` to default to off by using `os.getenv(..., "0")`.
- Add an inline comment explaining that tests should set `ONEBOX_TEST_FORCE_STUB_WEB3=1` when they require the stub.
- Leave the existing fallback shim implementation intact so test and lightweight environments still work when explicitly enabled.

### Testing

- Ran `make pytest` which invokes `PYTHONPATH=".:/workspace/AGIJobsv0/packages/hgm-core/src" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test`.
- The test run collected and executed the full suite of tests (187 items).
- All tests passed: `187 passed` (run completed successfully).
- No automated tests failed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bc4fe5b148333b631cb9a87ced723)