### PR TITLE
Handle clear-sentinel values when normalizing thermostat config

### DIFF
--- a/scripts/config/index.js
+++ b/scripts/config/index.js
@@ -1499,7 +1499,19 @@ function normaliseRewardEngineConfig(config = {}) {
   return reward;
 }
 
-const CLEAR_ROLE_TEMP_VALUES = new Set(['unset', 'remove', 'clear', 'none']);
+const CLEAR_SENTINEL_VALUES = new Set([
+  'unset',
+  'remove',
+  'clear',
+  'none',
+  'null',
+]);
+
+function isClearSentinel(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim().toLowerCase();
+  return CLEAR_SENTINEL_VALUES.has(trimmed);
+}
 
 function normaliseThermostatConfig(config = {}) {
   if (!config || typeof config !== 'object' || Array.isArray(config)) {
@@ -1509,12 +1521,22 @@ function normaliseThermostatConfig(config = {}) {
   const thermo = { ...config };
 
   if (thermo.address !== undefined) {
-    const allowZero = thermo.address === null || thermo.address === '';
-    thermo.address = allowZero
-      ? ethers.ZeroAddress
-      : ensureAddress(thermo.address, 'Thermostat address', {
-          allowZero: true,
-        });
+    const allowZero =
+      thermo.address === null ||
+      thermo.address === '' ||
+      isClearSentinel(thermo.address);
+    if (allowZero) {
+      delete thermo.address;
+    } else {
+      const address = ensureAddress(thermo.address, 'Thermostat address', {
+        allowZero: true,
+      });
+      if (address !== ethers.ZeroAddress) {
+        thermo.address = address;
+      } else {
+        delete thermo.address;
+      }
+    }
   }
 
   if (thermo.roleTemperatures && typeof thermo.roleTemperatures === 'object') {
@@ -1528,7 +1550,7 @@ function normaliseThermostatConfig(config = {}) {
       if (typeof value === 'string') {
         const trimmed = value.trim();
         if (!trimmed) continue;
-        if (CLEAR_ROLE_TEMP_VALUES.has(trimmed.toLowerCase())) {
+        if (isClearSentinel(trimmed)) {
           mapped[key] = null;
           continue;
         }
@@ -1666,7 +1688,8 @@ function loadThermostatConfig(options = {}) {
       typeof raw.rewardEngine === 'object' &&
       raw.rewardEngine.thermostat !== undefined &&
       raw.rewardEngine.thermostat !== null &&
-      raw.rewardEngine.thermostat !== ''
+      raw.rewardEngine.thermostat !== '' &&
+      !isClearSentinel(raw.rewardEngine.thermostat)
     ) {
       rewardEngineThermostat = ensureAddress(
         raw.rewardEngine.thermostat,


### PR DESCRIPTION
### Motivation
- Thermostat configuration files may use human-friendly sentinel strings (e.g. `none`, `null`, `clear`) to indicate a value should be cleared, but the normaliser only handled a limited set and sometimes left zero-addresses or threw errors. 
- This caused surprising failures when CI or operator scripts attempted to read or merge thermostat/reward-engine configs that intentionally clear addresses. 
- The goal is to make config normalization robust and follow best-practice: accept common clear sentinels and remove optional addresses rather than forcing a zero-address or raising an error. 

### Description
- Add `CLEAR_SENTINEL_VALUES` and helper `isClearSentinel()` to centralise sentinel detection for config parsing. 
- Update `normaliseThermostatConfig()` so `thermo.address` is deleted when a clear sentinel is provided, and to remove entries that resolve to the zero address instead of leaving `ethers.ZeroAddress`. 
- Reuse the sentinel helper for `roleTemperatures` so strings like `none`/`null`/`clear` map to `null` consistently. 
- Ignore explicit clear sentinels coming from the `rewardEngine.thermostat` override when resolving `rewardEngineThermostat`. 

### Testing
- Ran local Node sanity checks calling `loadThermostatConfig()` with sentinel values to verify `rewardEngineThermostat` becomes `undefined` and cleared addresses are omitted (example: `node -e "const { loadThermostatConfig } = require('./scripts/config'); ..."`). — succeeded. 
- Verified `loadThermostatConfig()` with a thermostat file containing `address: 'none'` alongside other fields returns a valid config when non-empty parameters exist. — succeeded. 
- Existing Python unit tests for the thermostat controller were executed: `pytest services/thermostat/tests/test_controller.py` (4 tests) — all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be5a7a7e08333975245716047d464)