### PR TITLE
Fix operator banner uplift formatting and add regression tests

### DIFF
--- a/tests/test_operator_banner.py
+++ b/tests/test_operator_banner.py
@@ -1,0 +1,33 @@
+import json
+import sys
+from pathlib import Path
+
+from tools import operator_banner
+
+
+def _write_report(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_operator_banner_formats_ratio_uplift(capsys, tmp_path, monkeypatch):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    _write_report(out_dir / "report.json", {"utility_uplift": 1.25})
+
+    monkeypatch.setattr(sys, "argv", ["operator_banner.py", str(out_dir)])
+    operator_banner.main()
+
+    captured = capsys.readouterr().out.strip()
+    assert captured == "✅ Day-One Utility +125.00%"
+
+
+def test_operator_banner_formats_percent_uplift(capsys, tmp_path, monkeypatch):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    _write_report(out_dir / "report.json", {"uplift_pct": 12.5})
+
+    monkeypatch.setattr(sys, "argv", ["operator_banner.py", str(out_dir)])
+    operator_banner.main()
+
+    captured = capsys.readouterr().out.strip()
+    assert captured == "✅ Day-One Utility +12.50%"

--- a/tools/operator_banner.py
+++ b/tools/operator_banner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, Tuple
 
 
 def _load_latest_report(out_dir: Path) -> Optional[dict[str, Any]]:
@@ -19,11 +19,17 @@ def _load_latest_report(out_dir: Path) -> Optional[dict[str, Any]]:
     return None
 
 
-def _extract_uplift(report: dict[str, Any]) -> Optional[float]:
-    for key in ("uplift_pct", "utility_uplift", "utility_uplift_pct"):
+def _extract_uplift(report: dict[str, Any]) -> Optional[Tuple[float, str]]:
+    percent_keys = ("uplift_pct", "utility_uplift_pct")
+    ratio_keys = ("utility_uplift",)
+    for key in percent_keys:
         value = report.get(key)
         if isinstance(value, (int, float)):
-            return float(value)
+            return float(value), "percent"
+    for key in ratio_keys:
+        value = report.get(key)
+        if isinstance(value, (int, float)):
+            return float(value), "ratio"
     metrics = report.get("metrics")
     if isinstance(metrics, dict):
         baseline = metrics.get("baseline", {})
@@ -31,7 +37,7 @@ def _extract_uplift(report: dict[str, Any]) -> Optional[float]:
         base_val = baseline.get("utility") if isinstance(baseline, dict) else None
         cand_val = candidate.get("utility") if isinstance(candidate, dict) else None
         if isinstance(base_val, (int, float)) and isinstance(cand_val, (int, float)) and base_val != 0:
-            return (cand_val - base_val) / base_val
+            return (cand_val - base_val) / base_val, "ratio"
     return None
 
 
@@ -42,11 +48,11 @@ def main() -> None:
         print("✅ Day-One run complete")
         return
     uplift = _extract_uplift(report)
-    if isinstance(uplift, (int, float)):
-        value = float(uplift)
-        if abs(value) <= 1:
+    if uplift is not None:
+        value, unit = uplift
+        if unit == "ratio":
             value *= 100.0
-        print(f"✅ Day-One Utility +{value:.2f}%")
+        print(f"✅ Day-One Utility {value:+.2f}%")
     else:
         print("✅ Day-One run complete")
 


### PR DESCRIPTION
### Motivation
- The operator banner printed uplift values inconsistently and could misinterpret ratio vs percent inputs, causing misleading operator output.
- The goal is to reliably detect percent-style and ratio-style uplift values and render a signed percentage for clear operator consumption.

### Description
- Updated `tools/operator_banner.py` to return uplift as a `(value, unit)` tuple distinguishing `percent` and `ratio` sources and to derive uplift from `metrics` when present.
- Normalized output to always render a signed percentage string (e.g. `+12.34%` or `-3.21%`).
- Added `tests/test_operator_banner.py` with regression tests for both ratio-based and percent-based uplift payloads.

### Testing
- Ran `pytest tests/test_operator_banner.py -q` and it succeeded (`2 passed`).
- Ran `pytest demo/AGIJobs-Day-One-Utility-Benchmark/tests/test_demo_runner.py -q` and it succeeded (`19 passed`).
- Verified the operator banner CLI by invoking the demo in check mode and inspecting the generated JSON uplift fields.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c059f8348833383890c684b19f716)