### PR TITLE
Add forced kill grace period for Hardhat test runner

### DIFF
--- a/scripts/run-hardhat-tests.cjs
+++ b/scripts/run-hardhat-tests.cjs
@@ -269,15 +269,37 @@ function runHardhatWithHeartbeat(timeoutMs) {
       );
     }, heartbeatIntervalMs);
 
+    const killGraceMs = Number.parseInt(process.env.HARDHAT_TEST_KILL_GRACE_MS ?? '30000', 10);
+    const killGraceTimeoutMs = Number.isFinite(killGraceMs) && killGraceMs > 0
+      ? killGraceMs
+      : 30000;
+    let forcedKillTimer;
+    const startForcedKillTimer = () => {
+      if (forcedKillTimer) {
+        return;
+      }
+      forcedKillTimer = setTimeout(() => {
+        if (!child.killed) {
+          console.error(
+            `Hardhat test run did not exit after ${killGraceTimeoutMs}ms grace period. Sending SIGKILL...`,
+          );
+          child.kill('SIGKILL');
+        }
+      }, killGraceTimeoutMs);
+    };
     const killTimer = setTimeout(() => {
       console.error(`Hardhat test run exceeded ${timeoutMs}ms. Sending SIGTERM...`);
       child.kill('SIGTERM');
+      startForcedKillTimer();
     }, timeoutMs);
 
     const signalHandlers = new Map();
     const forwardSignal = (signal) => {
       if (!child.killed) {
         child.kill(signal);
+        if (signal === 'SIGTERM') {
+          startForcedKillTimer();
+        }
       }
     };
     ['SIGINT', 'SIGTERM', 'SIGHUP'].forEach((signal) => {
@@ -292,6 +314,9 @@ function runHardhatWithHeartbeat(timeoutMs) {
       });
       clearInterval(heartbeat);
       clearTimeout(killTimer);
+      if (forcedKillTimer) {
+        clearTimeout(forcedKillTimer);
+      }
       resolve({ status: code, signal });
     });
 
@@ -301,6 +326,9 @@ function runHardhatWithHeartbeat(timeoutMs) {
       });
       clearInterval(heartbeat);
       clearTimeout(killTimer);
+      if (forcedKillTimer) {
+        clearTimeout(forcedKillTimer);
+      }
       console.error(error.message);
       resolve({ status: 1, signal: null });
     });


### PR DESCRIPTION
### Motivation
- Hardhat child processes can ignore `SIGTERM`, causing hung test runs and blocked CI jobs. 
- A deterministic forced-kill ensures runaway or unresponsive test runner processes are cleaned up reliably. 
- The grace period should be configurable to accommodate slow CI hosts or environments that need extra shutdown time. 

### Description
- Parse `HARDHAT_TEST_KILL_GRACE_MS` (default `30000`) and add a `startForcedKillTimer` that sends `SIGKILL` after the grace window. 
- Trigger the forced-kill timer when the hard timeout elapses or when the script forwards `SIGTERM` to the Hardhat child process. 
- Clear the forced-kill timer on child `exit` and `error` to avoid leaking timers. 

### Testing
- Ran `node scripts/run-hardhat-tests.cjs --listTests` which exited successfully with the expected Jest-only skip message. 
- A prior `npm test` run reproduced the long-running Hardhat behavior that motivated this change; the new forced-kill path is intended to address that failure mode but the full Solidity test run was not re-executed end-to-end in this environment due to its duration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c0efac47c833383f8419a18862f08)