### PR TITLE
Improve demo test suite detection

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -386,13 +386,20 @@ def _iter_node_test_files(tests_dir: Path) -> Iterable[Path]:
                 yield file
 
 
-def _node_package_root(tests_dir: Path, demo_dir: Path) -> Path | None:
-    """Return the nearest ancestor with a package.json, stopping at ``demo_dir``."""
+def _node_package_root(
+    tests_dir: Path, demo_dir: Path, *, root_boundary: Path | None = None
+) -> Path | None:
+    """Return the nearest ancestor with a package.json, stopping at ``demo_dir``.
 
+    ``root_boundary`` can be provided to allow discovery to climb above the
+    immediate demo directory when a demo root contains nested test folders.
+    """
+
+    stop_at = root_boundary or demo_dir
     for ancestor in [tests_dir, *tests_dir.parents]:
         if (ancestor / "package.json").is_file():
             return ancestor
-        if ancestor == demo_dir:
+        if ancestor == stop_at:
             break
 
     return None
@@ -697,11 +704,23 @@ def _playwright_system_deps_ready() -> bool:
     for lib in _PLAYWRIGHT_LIB_PATHS:
         if lib.exists():
             continue
-        resolved = ctypes.util.find_library(lib.stem.replace(".so", ""))
+        library_name = _normalize_ctypes_library_name(lib)
+        resolved = ctypes.util.find_library(library_name)
         if not resolved:
             return False
 
     return True
+
+
+def _normalize_ctypes_library_name(lib_path: Path) -> str:
+    """Normalize a library path into a name suitable for ``find_library``."""
+
+    name = lib_path.name
+    if name.startswith("lib"):
+        name = name[3:]
+    if ".so" in name:
+        name = name.split(".so", 1)[0]
+    return name
 
 
 def _maybe_extend_timeout_for_playwright(
@@ -961,13 +980,16 @@ def _has_node_tests(
     demo_dir: Path,
     *,
     generate_prisma: bool = True,
+    root_boundary: Path | None = None,
     prisma_cache: dict[Path, bool] | None = None,
 ) -> tuple[Path, str] | bool | None:
     has_node_tests = any(_iter_node_test_files(tests_dir))
     if not has_node_tests:
         return None
 
-    package_root = _node_package_root(tests_dir, demo_dir)
+    package_root = _node_package_root(
+        tests_dir, demo_dir, root_boundary=root_boundary
+    )
     if not package_root:
         return None
 
@@ -1065,6 +1087,7 @@ def _discover_tests(
                 tests_dir,
                 demo_dir,
                 generate_prisma=generate_prisma,
+                root_boundary=demo_root,
                 prisma_cache=prisma_cache,
             )
 

--- a/demo/tests/test_run_demo_tests_runner.py
+++ b/demo/tests/test_run_demo_tests_runner.py
@@ -241,6 +241,28 @@ def test_playwright_dep_readiness_detects_installed_libs(
     assert run_demo_tests._playwright_system_deps_ready() is True
 
 
+def test_playwright_dep_readiness_accepts_ctypes_resolved_libs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    libs = [
+        tmp_path / "libnss3.so",
+        tmp_path / "libasound.so.2",
+        tmp_path / "libgtk-3.so.0",
+    ]
+
+    def fake_find_library(name: str) -> str | None:
+        if name in {"nss3", "asound", "gtk-3"}:
+            return f"lib{name}.so"
+        return None
+
+    monkeypatch.setattr(run_demo_tests, "_PLAYWRIGHT_LIB_PATHS", tuple(libs))
+    monkeypatch.setattr(run_demo_tests.shutil, "which", lambda name: "/usr/bin/xvfb")
+    monkeypatch.setattr(run_demo_tests.sys, "platform", "linux")
+    monkeypatch.setattr(run_demo_tests.ctypes.util, "find_library", fake_find_library)
+
+    assert run_demo_tests._playwright_system_deps_ready() is True
+
+
 def test_playwright_dep_readiness_requires_xvfb(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation
- Make Playwright system dependency detection more robust when library files are missing but resolvable via `ctypes.util.find_library`.
- Ensure Node test suites anchored under demos discover the correct `package.json` when tests live in nested folders.
- Add targeted coverage to prevent regressions in the Playwright readiness probe.

### Description
- Add `_normalize_ctypes_library_name` and use it from `_playwright_system_deps_ready` to normalize filesystem library names before calling `ctypes.util.find_library`.
- Extend `_node_package_root` to accept an optional `root_boundary` and pass `demo_root` from `_discover_tests` so package resolution climbs no higher than the demo root.
- Add `test_playwright_dep_readiness_accepts_ctypes_resolved_libs` to `demo/tests/test_run_demo_tests_runner.py` to validate ctypes-based fallback behaviour.

### Testing
- Ran `pytest demo/tests/test_run_demo_tests_runner.py -q` after the changes and the suite passed: `45 passed in 3.16s`.
- Verified the updated demo test discovery logic with the repository test cases that exercise nested Node/Python suite layouts and observed no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c50112e148333b7897492a85ca839)