### PR TITLE
Sanitize Authorization headers in onebox-static helpers

### DIFF
--- a/apps/onebox-static/app.mjs
+++ b/apps/onebox-static/app.mjs
@@ -398,6 +398,16 @@ function clearStoredOrchestrator() {
 
 export function computeAuthHeaders(base, token) {
   const sanitizedToken = sanitizeAuthToken(token);
+  const stripAuthorization = (headers) => {
+    if (!headers || typeof headers !== "object") return {};
+    const cleaned = { ...headers };
+    for (const key of Object.keys(cleaned)) {
+      if (key.toLowerCase() === "authorization") {
+        delete cleaned[key];
+      }
+    }
+    return cleaned;
+  };
   if (base instanceof Headers) {
     const headers = new Headers(base);
     if (sanitizedToken) {
@@ -420,11 +430,11 @@ export function computeAuthHeaders(base, token) {
   }
   if (!sanitizedToken) {
     if (base && typeof base === "object") {
-      return { ...base };
+      return stripAuthorization(base);
     }
     return base;
   }
-  const headers = base && typeof base === "object" ? { ...base } : {};
+  const headers = base && typeof base === "object" ? stripAuthorization(base) : {};
   headers.Authorization = `Bearer ${sanitizedToken}`;
   return headers;
 }

--- a/apps/onebox-static/test/auth-helpers.test.mjs
+++ b/apps/onebox-static/test/auth-helpers.test.mjs
@@ -39,6 +39,16 @@ test('computeAuthHeaders replaces existing Authorization entries in arrays', () 
   );
 });
 
+test('computeAuthHeaders removes stale Authorization keys from plain objects', () => {
+  const base = {
+    authorization: 'Bearer stale',
+    Accept: 'application/json',
+  };
+  const result = computeAuthHeaders(base, 'fresh-token');
+  assert.equal(result.authorization, undefined);
+  assert.equal(result.Authorization, 'Bearer fresh-token');
+});
+
 test('computeAuthHeaders rejects tokens containing control characters', () => {
   const headers = computeAuthHeaders({ Accept: 'application/json' }, 'abc\r\nInjected: yep');
   assert.deepEqual(headers, { Accept: 'application/json' });


### PR DESCRIPTION
### Motivation
- Prevent stale or duplicate `Authorization` entries when callers pass plain object headers to `computeAuthHeaders`.
- Avoid case-insensitive collisions between `authorization` and `Authorization` keys that can lead to unexpected behavior or leaking stale tokens.
- Keep header handling consistent with array/`Headers` branches which already replace existing Authorization values.

### Description
- Add an internal `stripAuthorization` helper inside `computeAuthHeaders` to remove any existing authorization keys (case-insensitive) from plain-object headers.
- Ensure object-based header paths return a cleaned copy rather than preserving stale `authorization` entries before applying a new bearer token.
- Preserve existing behavior for `Headers` and array header formats while pushing `Authorization: Bearer ...` when a sanitized token is present.
- Add a new unit test `computeAuthHeaders removes stale Authorization keys from plain objects` to cover the object-path behavior.

### Testing
- Ran `node --test apps/onebox-static/test/auth-helpers.test.mjs` and all tests passed (9 passing tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c590a81648333b2d227e5e07a885e)