### PR TITLE
Improve HGM GraphQL lineage parsing

### DIFF
--- a/routes/hgm.py
+++ b/routes/hgm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any, Dict, List, Optional
 
@@ -63,23 +64,52 @@ def seed_demo(repo: HgmRepository = Depends(_repository)) -> Dict[str, Any]:
     return run.to_dict()
 
 
-_LINEAGE_PATTERN = re.compile(
-    r"lineage\s*\(\s*runId\s*:\s*\"(?P<run>[^\"]+)\"(?:\s*,\s*root\s*:\s*\"(?P<root>[^\"]+)\")?\s*\)"
+_LINEAGE_CALL_PATTERN = re.compile(r"\blineage\s*\((?P<args>[^)]*)\)", re.DOTALL)
+_LINEAGE_ARG_PATTERN = re.compile(
+    r"(?P<key>runId|root)\s*:\s*(?P<value>\"(?:\\\"|[^\"])*\"|\$[A-Za-z_][A-Za-z0-9_]*)"
 )
+
+
+def _parse_argument_value(value: str, variables: Dict[str, Any]) -> Optional[str]:
+    if value.startswith("$"):
+        var_name = value[1:]
+        var_value = variables.get(var_name)
+        return var_value if isinstance(var_value, str) else None
+    try:
+        return json.loads(value)
+    except Exception:
+        return None
+
+
+def _extract_lineage_args(payload: Dict[str, Any]) -> tuple[str, Optional[str]]:
+    query = payload.get("query")
+    if not isinstance(query, str):
+        raise HTTPException(status_code=400, detail="INVALID_QUERY")
+    match = _LINEAGE_CALL_PATTERN.search(query)
+    if not match:
+        raise HTTPException(status_code=400, detail="UNSUPPORTED_QUERY")
+    args_raw = match.group("args")
+    variables = payload.get("variables")
+    variables = variables if isinstance(variables, dict) else {}
+    parsed: Dict[str, Optional[str]] = {"runId": None, "root": None}
+    for arg_match in _LINEAGE_ARG_PATTERN.finditer(args_raw):
+        key = arg_match.group("key")
+        value = _parse_argument_value(arg_match.group("value"), variables)
+        parsed[key] = value
+    run_id = parsed.get("runId")
+    root = parsed.get("root")
+    if not isinstance(run_id, str) or not run_id:
+        raise HTTPException(status_code=400, detail="INVALID_QUERY")
+    if root is not None and not isinstance(root, str):
+        raise HTTPException(status_code=400, detail="INVALID_QUERY")
+    return run_id, root
 
 
 @router.post("/graphql")
 def graphql(payload: Dict[str, Any], repo: HgmRepository = Depends(_repository)) -> Dict[str, Any]:
     """Minimal GraphQL endpoint supporting ``lineage`` queries."""
 
-    query = payload.get("query")
-    if not isinstance(query, str):
-        raise HTTPException(status_code=400, detail="INVALID_QUERY")
-    match = _LINEAGE_PATTERN.search(query)
-    if not match:
-        raise HTTPException(status_code=400, detail="UNSUPPORTED_QUERY")
-    run_id = match.group("run")
-    root = match.group("root")
+    run_id, root = _extract_lineage_args(payload)
     data = repo.fetch_lineage(run_id, root_key=root)
     return {"data": {"lineage": [node.to_dict() for node in data]}}
 

--- a/tests/routes/test_hgm_routes.py
+++ b/tests/routes/test_hgm_routes.py
@@ -42,3 +42,21 @@ def test_graphql_lineage_endpoint() -> None:
     payload = response.json()
     assert "data" in payload
     assert payload["data"]["lineage"][0]["agentKey"] == "root"
+
+
+def test_graphql_lineage_endpoint_with_variables() -> None:
+    repo = HgmRepository(get_database())
+    seed_demo_run(repo, run_id="demo-graphql-vars")
+    app = create_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/hgm/graphql",
+        json={
+            "query": "query Lineage($runId: String!, $root: String) { lineage(runId: $runId, root: $root) { agentKey } }",
+            "variables": {"runId": "demo-graphql-vars", "root": "root"},
+        },
+    )
+    payload = response.json()
+    assert "data" in payload
+    assert payload["data"]["lineage"][0]["agentKey"] == "root"


### PR DESCRIPTION
### Motivation

- The minimal GraphQL endpoint for HGM lineage needed more robust parsing to handle operations that declare variables and variable-driven argument values.
- The previous regex matched operation-level declarations and failed when queries used variables instead of inline string literals.
- Supporting variable substitution and JSON string parsing makes the endpoint resilient to common GraphQL client usage patterns.
- Add a test to prevent regressions for variable-driven lineage queries.

### Description

- Replace the brittle `_LINEAGE_PATTERN` with a call-level matcher `_LINEAGE_CALL_PATTERN` and an argument matcher `_LINEAGE_ARG_PATTERN` in `routes/hgm.py` to reliably locate `lineage(...)` call arguments.
- Introduce `_parse_argument_value` to resolve `$`-prefixed GraphQL variables from the request `variables` map and to JSON-decode quoted literal values.
- Add `_extract_lineage_args` to centralise validation and extraction of `runId` and optional `root` arguments and wire it into the `/hgm/graphql` route.
- Add `test_graphql_lineage_endpoint_with_variables` in `tests/routes/test_hgm_routes.py` to cover queries using GraphQL variables.

### Testing

- Ran `pytest tests/routes/test_hgm_routes.py -q` and observed `3 passed` (all route-level GraphQL lineage tests succeeded).
- Ran the full test suite via `pytest -q` earlier in the run and observed `57 passed, 1 skipped` (no failures related to these changes).
- The new and existing HGM route tests exercise both literal and variable-driven query forms and passed.
- No automated tests failed as a result of these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c767bacd88333963c9dff68a8d44e)