### PR TITLE
Fix checkpoint resume after executor crash

### DIFF
--- a/orchestrator/runner.py
+++ b/orchestrator/runner.py
@@ -181,7 +181,7 @@ def _resume_pending_steps(plan: OrchestrationPlan, status: StatusOut) -> Iterabl
         yield idx
 
 
-def _execute_step(step: Step, status: StatusOut, step_status: StepStatus) -> bool:
+def _execute_step(step: Step, status: StatusOut, step_status: StepStatus) -> bool | None:
     _apply_transition(status, step_status, "running", f"Starting {step.name}")
     _persist(status)
     try:
@@ -189,9 +189,9 @@ def _execute_step(step: Step, status: StatusOut, step_status: StepStatus) -> boo
     except Exception as exc:  # pragma: no cover - defensive guard for executor failures
         logger.exception("Step executor crashed for %s", step.name)
         _log(status, f"{step.name}: executor error: {exc}")
-        _apply_transition(status, step_status, "failed", f"Failed {step.name}")
+        _log(status, f"{step.name}: marked for resume after crash")
         _persist(status)
-        return False
+        return None
     for line in result.logs:
         _log(status, f"{step.name}: {line}")
     if result.success:
@@ -268,6 +268,8 @@ def _resume_run(plan: OrchestrationPlan, status: StatusOut, run_id: str) -> None
         success = _execute_step(step, current_status, step_status)
         with _LOCK:
             _RUNS[run_id] = current_status
+        if success is None:
+            return
         if not success:
             with _LOCK:
                 _mark_run(current_status, "failed")


### PR DESCRIPTION
### Motivation
- Prevent transient executor crashes from permanently failing runs so checkpointed workflows can be resumed.
- Ensure step states and checkpoints reflect recoverable crashes instead of marking steps/runs as failed.
- Improve resilience of the orchestrator to intermittent executor errors during long-running plans.

### Description
- Change `_execute_step` signature to return `bool | None` and treat exceptions as a recoverable condition by returning `None` instead of marking the step failed.
- When the executor raises, log the crash, mark the step for resume in logs, persist a checkpoint, and keep step state so the run can be resumed later.
- Update `_resume_run` to treat a `None` result from `_execute_step` as a recoverable stop (allowing checkpoint restore to resume) instead of immediately marking the run failed.
- Added log message refinements to make resume semantics explicit in the checkpoint.

### Testing
- Ran the full Python test suite with `pytest -q` and it succeeded without failures.
- Test output: `pytest -q` completed with all tests passing (previous failing checkpoint test now passes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c85412cd08333a90ab312351ab9d9)