### PR TITLE
Harden thermostat metric parsing

### DIFF
--- a/services/thermostat/metrics.py
+++ b/services/thermostat/metrics.py
@@ -6,6 +6,20 @@ from datetime import datetime, timezone
 from typing import Any, Mapping
 
 
+def _coerce_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 @dataclass(slots=True)
 class MetricSample:
     """Single observation emitted by the monitoring pipeline."""
@@ -41,11 +55,11 @@ class MetricSample:
         else:
             timestamp = datetime.now(tz=timezone.utc)
 
-        roi = float(payload.get("roi", 0.0))
-        gmv = float(payload.get("gmv", payload.get("revenue", 0.0)))
-        cost = float(payload.get("cost", payload.get("spend", 0.0)))
-        successes = int(payload.get("successes", 0))
-        failures = int(payload.get("failures", 0))
+        roi = _coerce_float(payload.get("roi", 0.0))
+        gmv = _coerce_float(payload.get("gmv", payload.get("revenue", 0.0)))
+        cost = _coerce_float(payload.get("cost", payload.get("spend", 0.0)))
+        successes = _coerce_int(payload.get("successes", 0))
+        failures = _coerce_int(payload.get("failures", 0))
         return cls(
             timestamp=timestamp,
             roi=roi,

--- a/services/thermostat/tests/test_metrics.py
+++ b/services/thermostat/tests/test_metrics.py
@@ -12,3 +12,23 @@ def test_metric_sample_accepts_iso_timestamp_with_z_suffix() -> None:
 
     assert sample.timestamp == datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc)
     assert sample.roi == 1.25
+
+
+def test_metric_sample_defaults_invalid_numeric_fields() -> None:
+    payload = {
+        "timestamp": 0,
+        "roi": "not-a-number",
+        "gmv": None,
+        "cost": {},
+        "successes": "7",
+        "failures": "oops",
+    }
+
+    sample = MetricSample.from_payload(payload)
+
+    assert sample.timestamp == datetime.fromtimestamp(0, tz=timezone.utc)
+    assert sample.roi == 0.0
+    assert sample.gmv == 0.0
+    assert sample.cost == 0.0
+    assert sample.successes == 7
+    assert sample.failures == 0


### PR DESCRIPTION
### Motivation

- Prevent runtime errors when metric payloads contain malformed or non-numeric values by making parsing tolerant.  
- Improve robustness of the thermostat ingestion pipeline so downstream controllers do not crash on bad telemetry.  
- Preserve existing behaviour for valid inputs while providing sensible defaults for invalid fields.  

### Description

- Add safe coercion helpers `_coerce_float` and `_coerce_int` to `services/thermostat/metrics.py` to handle malformed numeric inputs.  
- Use the coercion helpers in `MetricSample.from_payload` for `roi`, `gmv`, `cost`, `successes`, and `failures`.  
- Add `test_metric_sample_defaults_invalid_numeric_fields` to `services/thermostat/tests/test_metrics.py` to assert defaults are applied for invalid numeric fields.  

### Testing

- Ran `pytest services/thermostat/tests/test_metrics.py -q` and it passed with `2 passed`.  
- Ran `pytest services/thermostat/tests/test_controller.py -q` and it passed with `4 passed`.  
- Ran `pytest services/sentinel/tests -q` earlier in the session and it passed with `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c8c28a8208333af36e873ab6d14cd)