### PR TITLE
Fix orchestrator worker local hgm_core import resolution

### DIFF
--- a/orchestrator/worker.py
+++ b/orchestrator/worker.py
@@ -3,8 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import logging
+import sys
+from pathlib import Path
 from typing import Awaitable, Callable, Dict
+
+if importlib.util.find_spec("hgm_core") is None:
+    repo_root = Path(__file__).resolve().parents[1]
+    hgm_core_path = repo_root / "packages" / "hgm-core" / "src"
+    if hgm_core_path.exists() and str(hgm_core_path) not in sys.path:
+        sys.path.insert(0, str(hgm_core_path))
 
 from hgm_core.config import EngineConfig
 


### PR DESCRIPTION
### Motivation
- Tests and runtime were failing with `ModuleNotFoundError: No module named 'hgm_core'` when the `hgm_core` package was not installed.
- The orchestrator worker must be able to run against the repository’s local `packages/hgm-core/src` during development and CI without requiring a pip install.
- Add a safe, minimal fallback to resolve the in-repo package to follow best practices for local package imports.
- Preserve existing behavior when `hgm_core` is already available in the environment.

### Description
- Update `orchestrator/worker.py` to detect whether `hgm_core` is importable using `importlib.util.find_spec` and, if missing, prepend `packages/hgm-core/src` to `sys.path` when present.
- Add imports for `importlib.util`, `sys`, and `pathlib.Path`, and keep the `from hgm_core.config import EngineConfig` import unchanged so downstream code is unaffected.
- This change only adjusts module resolution at startup and does not modify workflow logic or public APIs.
- The file modified is `orchestrator/worker.py` and the change is defensive and idempotent.

### Testing
- Ran `pytest -q test/orchestrator/test_worker.py` and it passed (`2 passed`).
- Ran `pytest -q tests/backend/test_hgm_repository.py` and it passed (`3 passed`).
- Ran `pytest -q tests/routes/test_hgm_routes.py` and it passed (`3 passed`).
- Ran `pytest -q tests/orchestrator/test_hgm_workflow.py` and it passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c985afdb48333a0bd9c6fdf1bf1c0)