### PR TITLE
Disable auto-loaded pytest_ethereum plugin in pytest config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -p no:web3.tools -p no:web3.tools.pytest_ethereum --import-mode=importlib
+addopts = -p no:pytest_ethereum -p no:web3.tools -p no:web3.tools.pytest_ethereum -p no:web3.tools.pytest_ethereum.plugins --import-mode=importlib
 pythonpath = .
 testpaths =
     tests


### PR DESCRIPTION
### Motivation

- The test environment was loading an entrypoint plugin (`pytest_ethereum`) automatically and introducing non-deterministic plugin registration during pytest startup.
- Preventing auto-loaded external pytest plugins keeps test runs reproducible and avoids unexpected side-effects from environment-installed packages.

### Description

- Update `pytest.ini` `addopts` to explicitly disable the `pytest_ethereum` entrypoint via `-p no:pytest_ethereum`.
- Also add an explicit exclusion for the nested plugin module `web3.tools.pytest_ethereum.plugins` to ensure the web3-related pytest hooks are suppressed.
- Preserve existing exclusions (`web3.tools` and `web3.tools.pytest_ethereum`) while making plugin disablement deterministic.

### Testing

- Ran `pytest services/thermostat/tests` and observed all tests pass (`6 passed`).
- Ran `pytest --trace-config -q services/thermostat/tests` to verify plugin registration and confirmed deterministic startup with the `pytest_ethereum` plugin disabled.
- Test runs completed successfully with no regressions observed in the thermostat test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cf9334b148333a977709ccdc846fb)