### PR TITLE
Create parent directories for owner command center output

### DIFF
--- a/scripts/v2/ownerCommandCenter.ts
+++ b/scripts/v2/ownerCommandCenter.ts
@@ -1214,6 +1214,10 @@ async function main(): Promise<void> {
   }
 
   if (options.outPath) {
+    const outputDir = path.dirname(options.outPath);
+    if (outputDir && outputDir !== '.') {
+      await fs.mkdir(outputDir, { recursive: true });
+    }
     await fs.writeFile(options.outPath, output, 'utf8');
   } else {
     console.log(output);
@@ -1224,4 +1228,3 @@ main().catch((error) => {
   console.error('ownerCommandCenter failed:', error);
   process.exitCode = 1;
 });
-


### PR DESCRIPTION
### Motivation

- The `owner:command-center` script can be invoked with `--output` pointing to a nested path, which previously failed when the target directory did not exist.
- Preventing `ENOENT` on `fs.writeFile` is a small, low-risk hardening that improves local and CI ergonomics when generating reports.
- Creating the parent directory before writing follows best practices for CLI tools that emit artefacts to user-specified paths.

### Description

- Add logic to compute `path.dirname(options.outPath)` and create the directory with `fs.mkdir(..., { recursive: true })` when `--output` is provided.
- Skip directory creation when the output path is the current directory (`.`) to avoid no-op work.
- The change is limited to `scripts/v2/ownerCommandCenter.ts` and only affects the write path behaviour prior to `fs.writeFile`.

### Testing

- Ran `npm run owner:command-center -- --format markdown --output reports/owner-control/test/command-center.md --no-mermaid` and the command completed successfully writing the file to the nested `reports/owner-control/test` directory.
- Verified the script prints to stdout when `--output` is not provided by running `npm run owner:command-center -- --format markdown` which also completed successfully.
- No automated unit tests were modified as part of this change and no test failures were observed when exercising the CLI behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d24a8b6a4833396ec8b2449aedea5)