### PR TITLE
Handle non-string HGM metadata payloads safely

### DIFF
--- a/backend/models/hgm.py
+++ b/backend/models/hgm.py
@@ -26,6 +26,10 @@ def _serialize(metadata: Optional[Dict[str, Any]]) -> str:
 def _deserialize(payload: Any) -> Dict[str, Any]:
     if payload in (None, "", b""):
         return {}
+    if isinstance(payload, dict):
+        return payload
+    if isinstance(payload, list):
+        return {"items": payload}
     if isinstance(payload, (bytes, bytearray)):
         payload = payload.decode("utf-8")
     try:


### PR DESCRIPTION
### Motivation
- Metadata stored for HGM entities can already be a native Python object (dict/list) or an array-like JSON value, which previously caused decoding errors or unexpected shapes when reading rows.  
- Make repository reads robust so lineage APIs and downstream callers do not fail on benign metadata shape variations.  

### Description
- Modify `_deserialize` in `backend/models/hgm.py` to return dict payloads unchanged and to convert list payloads into a consistent dict shape (`{"items": [...]}`).  
- Preserve existing handling for bytes/bytearray and string payloads by decoding and delegating to `json.loads`, and keep the defensive warning/fallback for corrupted payloads.  
- No schema, API signatures, or other modules were changed.

### Testing
- Ran `pytest tests/backend/test_hgm_repository.py tests/routes/test_hgm_routes.py tests/orchestrator/test_hgm_workflow.py -q` and all tests passed (`9 passed`).  
- During development broader suites used for validation also passed locally (e.g. orchestrator and demo tests executed earlier), confirming the change is backward compatible with existing test coverage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d35781b3c8333a5be1e549a854839)