### PR TITLE
Handle thermostat update failures safely

### DIFF
--- a/services/thermostat/controller.py
+++ b/services/thermostat/controller.py
@@ -187,7 +187,8 @@ class ThermostatController:
                 return None
 
             new_config = replace(current, **updates)
-            self._config_snapshot = new_config
+            if not self._apply_updates:
+                self._config_snapshot = new_config
             self._cooldown = self._config.cooldown_steps
 
             parameters = {
@@ -203,9 +204,17 @@ class ThermostatController:
 
         if adjustment is not None:
             if self._apply_updates:
-                applied = await self._workflow.update_engine_parameters(
-                    **{k: v[1] for k, v in adjustment.parameters.items()}
-                )
+                try:
+                    applied = await self._workflow.update_engine_parameters(
+                        **{k: v[1] for k, v in adjustment.parameters.items()}
+                    )
+                except Exception:
+                    self._logger.exception("Thermostat update failed; retaining previous configuration")
+                    async with self._lock:
+                        if current is not None:
+                            self._config_snapshot = current
+                        self._cooldown = 0
+                    return None
                 if current is not None:
                     async with self._lock:
                         self._config_snapshot = replace(applied)

--- a/services/thermostat/tests/test_controller.py
+++ b/services/thermostat/tests/test_controller.py
@@ -56,6 +56,22 @@ class DummyWorkflow:
         return replace(self._config)
 
 
+class FailingWorkflow(DummyWorkflow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attempts = 0
+
+    async def update_engine_parameters(
+        self,
+        *,
+        widening_alpha: float | None = None,
+        min_visitations: int | None = None,
+        thompson_prior: float | None = None,
+    ) -> EngineConfig:
+        self.attempts += 1
+        raise RuntimeError("Update failed")
+
+
 def make_sample(roi: float) -> MetricSample:
     return MetricSample(
         timestamp=datetime.now(tz=timezone.utc),
@@ -196,3 +212,35 @@ def test_controller_dry_run_skips_workflow_updates() -> None:
 
     assert adjustment is not None
     assert not workflow.calls
+
+
+def test_controller_retries_after_failed_update() -> None:
+    workflow = FailingWorkflow()
+    config = ThermostatConfig(
+        target_roi=1.2,
+        lower_margin=0.05,
+        upper_margin=0.2,
+        roi_window=3,
+        widening_step=0.1,
+        min_widening_alpha=0.2,
+        max_widening_alpha=1.2,
+        thompson_step=0.2,
+        min_thompson_prior=0.5,
+        max_thompson_prior=3.0,
+        cooldown_steps=2,
+    )
+    controller = ThermostatController(workflow, config)
+
+    async def scenario() -> tuple[ThermostatAdjustment | None, ThermostatAdjustment | None]:
+        first = None
+        await controller.initialize()
+        for roi in (0.9, 0.88, 0.86):
+            first = await controller.ingest(make_sample(roi))
+        second = await controller.ingest(make_sample(0.84))
+        return first, second
+
+    first, second = asyncio.run(scenario())
+
+    assert first is None
+    assert second is None
+    assert workflow.attempts == 2


### PR DESCRIPTION
### Motivation
- Prevent the thermostat controller from entering an inconsistent state when external workflow updates fail.  
- Ensure the controller does not consume or overwrite the last-applied engine config when `apply_updates` is disabled.  
- Allow retries to proceed by resetting cooldown on failed updates so transient failures do not block future attempts.  
- Improve observability by logging update failures and failing fast from the `ingest` path when appropriate.  

### Description
- Only update the in-memory config snapshot when `apply_updates` is `False`; otherwise defer snapshot updates until the workflow actually applies changes.  
- Wrap calls to `update_engine_parameters` in a `try/except` and on exception log the error, restore the previous `config_snapshot`, reset the cooldown, and return `None`.  
- Add a `FailingWorkflow` test double and new test `test_controller_retries_after_failed_update` to assert the controller recovers and allows retries after a failed update.  
- Keep existing behaviour for dry-run mode and normal successful update flows intact.  

### Testing
- Ran `pytest services/thermostat/tests/test_controller.py` which contains unit tests for `ThermostatController`.  
- Test suite completed with all tests passing (`5 passed`).  
- New test verifies the controller records attempts and resets state when updates raise exceptions.  
- Existing thermostat tests for increase/decrease/cooldown/dry-run behaviours remain green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d420ec5348333946c106b8d128840)