### PR TITLE
Stream NDJSON parsing for thermostat metrics and improve error handling

### DIFF
--- a/scripts/thermostat.py
+++ b/scripts/thermostat.py
@@ -99,17 +99,23 @@ def _prometheus_query(base_url: str, query: str) -> dict[str, object]:
 def load_metrics_from_path(path: Path) -> Iterable[MetricSample]:
     """Load metrics from a JSON or NDJSON file."""
 
-    text = path.read_text()
     suffix = path.suffix.lower()
     if suffix in {".ndjson", ".jsonl"}:
-        for line in text.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            payload = json.loads(line)
-            yield MetricSample.from_payload(payload)
+        with path.open("r", encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Invalid JSON on line {line_number} of {path}"
+                    ) from exc
+                yield MetricSample.from_payload(payload)
     else:
-        payload = json.loads(text)
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
         if isinstance(payload, list):
             for entry in payload:
                 yield MetricSample.from_payload(entry)


### PR DESCRIPTION
### Motivation
- Avoid loading entire replay files into memory when replaying thermostat metrics to support large NDJSON files.
- Provide clearer diagnostics when replay files contain invalid JSON by surfacing the failing line number.
- Ensure consistent decoding by reading JSON payloads through explicit UTF-8 file handles.

### Description
- Replace `path.read_text()` with streaming reads via `path.open("r", encoding="utf-8")` in `load_metrics_from_path` to process NDJSON line-by-line.
- Parse each NDJSON line with `json.loads()` and raise a contextual `ValueError` on `json.JSONDecodeError` that includes the line number and file path.
- Use `json.load()` on the opened handle for whole-file JSON payloads instead of parsing from a single string, and preserve support for list/dict structures.
- Remove behavior that previously split the entire file into memory, reducing peak memory usage for large replay files.

### Testing
- Ran the repository test suite with `pytest -q` (pre-change), which completed successfully with `245 passed, 1 skipped`.
- Ran the focused tests with `pytest tests -q` after the change, which completed successfully with `58 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d47fed3f08333808d1da47c3cbb14)