### PR TITLE
Fix deterministic offline ENS verification

### DIFF
--- a/demo/AGI-Alpha-Node-v0/src/agi_alpha_node_demo/blockchain/ens.py
+++ b/demo/AGI-Alpha-Node-v0/src/agi_alpha_node_demo/blockchain/ens.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 from dataclasses import dataclass
 from typing import Optional
@@ -62,7 +63,8 @@ class ENSVerifier:
             except Exception as exc:  # pragma: no cover - network branch
                 logger.warning("ENS RPC unavailable, falling back to offline mode", exc_info=exc)
 
-        mock_owner = f"0x{abs(hash(domain)) % (10**40):040x}"
+        digest = hashlib.sha256(domain.encode("utf-8")).hexdigest()
+        mock_owner = f"0x{digest[:40]}"
         verified = mock_owner.lower() == expected_owner.lower()
         return ENSVerificationResult(domain, expected_owner, mock_owner, verified)
 

--- a/demo/AGI-Alpha-Node-v0/tests/test_ens.py
+++ b/demo/AGI-Alpha-Node-v0/tests/test_ens.py
@@ -1,0 +1,27 @@
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+
+ROOT = Path(__file__).resolve().parents[1]
+src_path = ROOT / "src"
+if str(src_path) not in sys.path:
+    sys.path.insert(0, str(src_path))
+
+from agi_alpha_node_demo.blockchain.ens import ENSVerifier
+
+
+def test_offline_ens_verification_uses_deterministic_hash():
+    ens = ENSVerifier("", 1)
+    ens._web3 = None
+    domain = "example.eth"
+    expected_owner = "0x" + hashlib.sha256(domain.encode("utf-8")).hexdigest()[:40]
+
+    result = ens.verify(domain, expected_owner)
+    assert result.actual_owner == expected_owner
+    assert result.verified is True
+
+    repeat = ens.verify(domain, expected_owner)
+    assert repeat.actual_owner == expected_owner


### PR DESCRIPTION
### Motivation
- The offline ENS mock used Python's built-in `hash()` which is non-deterministic across processes and Python versions, causing flaky behavior and making audits difficult.
- Deterministic, auditable offline behavior is required so demo runs and tests are reproducible without an RPC provider.

### Description
- Replace the non-deterministic mock owner generation with a stable SHA-256 derivation using `hashlib.sha256` and construct `mock_owner` as `0x{digest[:40]}`.
- Add an import for `hashlib` and update `ENSVerifier.verify` to use the deterministic digest when offline.
- Add a regression test file `demo/AGI-Alpha-Node-v0/tests/test_ens.py` that asserts offline verification returns the deterministic owner for repeated calls.

### Testing
- Ran `pytest -q demo/AGI-Alpha-Node-v0/tests/test_ens.py` and it passed (`1 passed`).
- The change is focused and the added unit test locks the offline ENS behavior to prevent regressions in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d508af01c833399c26bdc7da666ff)