### PR TITLE
Improve Playwright download reachability checks

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -651,12 +651,14 @@ def _playwright_downloads_reachable() -> bool:
     clearly unreachable.
     """
 
-    try:
-        for host in _PLAYWRIGHT_DOWNLOAD_HOSTS:
+    for host in _PLAYWRIGHT_DOWNLOAD_HOSTS:
+        try:
             socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
-    except OSError:
-        return False
-    return True
+        except OSError:
+            continue
+        else:
+            return True
+    return False
 
 
 def _apt_repos_reachable(timeout: float = 3.0) -> bool:

--- a/demo/tests/test_run_demo_tests_runner.py
+++ b/demo/tests/test_run_demo_tests_runner.py
@@ -222,6 +222,40 @@ def test_playwright_dep_check_accepts_root(monkeypatch: pytest.MonkeyPatch) -> N
     assert run_demo_tests._can_install_playwright_deps() is True
 
 
+def test_playwright_download_probe_accepts_any_resolvable_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hosts = run_demo_tests._PLAYWRIGHT_DOWNLOAD_HOSTS
+    calls: list[str] = []
+
+    def fake_getaddrinfo(host: str, *_args: object, **_kwargs: object) -> list[object]:
+        calls.append(host)
+        if host == hosts[0]:
+            raise OSError("simulated DNS failure")
+        return [object()]
+
+    monkeypatch.setattr(run_demo_tests.socket, "getaddrinfo", fake_getaddrinfo)
+
+    assert run_demo_tests._playwright_downloads_reachable() is True
+    assert calls == [hosts[0], hosts[1]]
+
+
+def test_playwright_download_probe_requires_any_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hosts = run_demo_tests._PLAYWRIGHT_DOWNLOAD_HOSTS
+    calls: list[str] = []
+
+    def fake_getaddrinfo(host: str, *_args: object, **_kwargs: object) -> list[object]:
+        calls.append(host)
+        raise OSError("simulated DNS failure")
+
+    monkeypatch.setattr(run_demo_tests.socket, "getaddrinfo", fake_getaddrinfo)
+
+    assert run_demo_tests._playwright_downloads_reachable() is False
+    assert calls == list(hosts)
+
+
 def test_playwright_dep_readiness_detects_installed_libs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation

- The Playwright download probe previously treated the host list as a single-point test and returned failure when any mirror failed, producing false negatives in sandboxed/DNS-partial environments.
- A more robust heuristic is to consider downloads reachable when at least one mirror resolves, reducing spurious opt-outs for Playwright installs.

### Description

- Change `_playwright_downloads_reachable()` in `demo/run_demo_tests.py` to return `True` as soon as any download host successfully resolves and only return `False` if none resolve. 
- Add two unit tests to `demo/tests/test_run_demo_tests_runner.py` that simulate mixed (one host fails, one succeeds) and all-hosts-fail DNS probe scenarios.

### Testing

- Ran `pytest demo/tests/test_run_demo_tests_runner.py -k "playwright_download_probe"` and the two new tests passed (2 passed, 45 deselected).
- The added tests exercise both a mixed-resolution case and a fully failing case to ensure the probe behaves as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d563020148333bb8171ab70acd0b6)