### PR TITLE
Skip non-finite ROI samples in thermostat controller

### DIFF
--- a/services/thermostat/controller.py
+++ b/services/thermostat/controller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from collections import deque
 from dataclasses import dataclass, replace
 from typing import AsyncIterable, Deque, Dict, Optional
@@ -124,6 +125,9 @@ class ThermostatController:
         """Process a metrics sample and update parameters when necessary."""
 
         await self.initialize()
+        if not math.isfinite(sample.roi):
+            self._logger.warning("Skipping non-finite ROI sample: %s", sample.roi)
+            return None
         adjustment: Optional[ThermostatAdjustment] = None
         current: EngineConfig | None = None
         updates: Dict[str, float] = {}

--- a/services/thermostat/tests/test_controller.py
+++ b/services/thermostat/tests/test_controller.py
@@ -244,3 +244,33 @@ def test_controller_retries_after_failed_update() -> None:
     assert first is None
     assert second is None
     assert workflow.attempts == 2
+
+
+def test_controller_skips_non_finite_samples() -> None:
+    workflow = DummyWorkflow()
+    config = ThermostatConfig(
+        target_roi=1.2,
+        lower_margin=0.05,
+        upper_margin=0.2,
+        roi_window=3,
+        widening_step=0.1,
+        min_widening_alpha=0.2,
+        max_widening_alpha=1.2,
+        thompson_step=0.2,
+        min_thompson_prior=0.5,
+        max_thompson_prior=3.0,
+        cooldown_steps=0,
+    )
+    controller = ThermostatController(workflow, config)
+
+    async def scenario() -> ThermostatAdjustment | None:
+        await controller.initialize()
+        await controller.ingest(make_sample(float("nan")))
+        adjustment = None
+        for roi in (0.9, 0.88, 0.86):
+            adjustment = await controller.ingest(make_sample(roi))
+        return adjustment
+
+    adjustment = asyncio.run(scenario())
+
+    assert adjustment is not None


### PR DESCRIPTION
### Motivation
- Prevent NaN/Inf ROI samples from poisoning the rolling ROI window and blocking controller decisions.
- Make the thermostat resilient to malformed or transient metric responses from the monitoring pipeline.
- Fail-safe behavior: skip invalid inputs early and log a warning rather than propagating errors into control logic.

### Description
- Add a `math.isfinite` guard in `ThermostatController.ingest` to skip non-finite `sample.roi` values and emit a warning via the controller logger.
- Import `math` and return early from `ingest` when the ROI is not finite, preventing the value from being appended to `_roi_history`.
- Add a regression test `test_controller_skips_non_finite_samples` in `services/thermostat/tests/test_controller.py` to ensure NaN samples do not block subsequent adjustments.

### Testing
- Ran `pytest services/thermostat/tests/test_controller.py` and confirmed the suite completes successfully.
- Test results: `6 passed` (all tests in the thermostat controller suite passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d81159a1c8333b1d3982cb9d2def1)