### PR TITLE
Handle string HTTP status codes in error formatting

### DIFF
--- a/apps/onebox-static/lib.mjs
+++ b/apps/onebox-static/lib.mjs
@@ -507,6 +507,21 @@ function pushUnique(array, value) {
   }
 }
 
+function coerceStatus(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
 function collectErrorContext(err, state = { messages: [], codes: [], statuses: [] }, seen = new Set()) {
   if (err === null || err === undefined) {
     return state;
@@ -529,9 +544,9 @@ function collectErrorContext(err, state = { messages: [], codes: [], statuses: [
     if ("name" in err && err.name && err.name !== "Error") {
       pushUnique(state.codes, err.name);
     }
-    if ("status" in err && Number.isFinite(err.status)) {
-      const status = Number(err.status);
-      if (!state.statuses.includes(status)) {
+    if ("status" in err) {
+      const status = coerceStatus(err.status);
+      if (status !== undefined && !state.statuses.includes(status)) {
         state.statuses.push(status);
       }
     }
@@ -544,15 +559,15 @@ function collectErrorContext(err, state = { messages: [], codes: [], statuses: [
     if ("message" in err && err.message) {
       pushUnique(state.messages, err.message);
     }
-    if ("status" in err && Number.isFinite(err.status)) {
-      const status = Number(err.status);
-      if (!state.statuses.includes(status)) {
+    if ("status" in err) {
+      const status = coerceStatus(err.status);
+      if (status !== undefined && !state.statuses.includes(status)) {
         state.statuses.push(status);
       }
     }
-    if ("statusCode" in err && Number.isFinite(err.statusCode)) {
-      const status = Number(err.statusCode);
-      if (!state.statuses.includes(status)) {
+    if ("statusCode" in err) {
+      const status = coerceStatus(err.statusCode);
+      if (status !== undefined && !state.statuses.includes(status)) {
         state.statuses.push(status);
       }
     }

--- a/apps/onebox-static/test/error-formatting.test.mjs
+++ b/apps/onebox-static/test/error-formatting.test.mjs
@@ -160,6 +160,15 @@ const RULE_EXPECTATIONS = [
     expected: 'The orchestrator rejected our credentials. Tip: Check that your API token is correct and hasn’t expired.',
   },
   {
+    id: 'unauthorized_string_status',
+    error: () => {
+      const err = new Error('unauthorized');
+      err.status = '401';
+      return err;
+    },
+    expected: 'The orchestrator rejected our credentials. Tip: Check that your API token is correct and hasn’t expired.',
+  },
+  {
     id: 'not_found',
     error: () => {
       const err = new Error('not found');


### PR DESCRIPTION
### Motivation

- Friendly error matching can miss rules when HTTP status values are supplied as strings instead of numbers, reducing robustness of error formatting.
- Make error context extraction tolerant to common variations in error shapes coming from different libraries or environments.

### Description

- Add `coerceStatus` helper to normalise numeric status values provided as numbers or numeric strings.
- Update `collectErrorContext` to use `coerceStatus` for both `status` and `statusCode` fields so string HTTP codes are converted to numbers before being recorded.
- Add a unit test case `unauthorized_string_status` to `apps/onebox-static/test/error-formatting.test.mjs` that verifies a string `'401'` status triggers the same friendly error rule as numeric `401`.

### Testing

- Ran the onebox-static test suite with `node --test apps/onebox-static/test/*.mjs` and all tests passed (47 passed, 0 failed).
- Ran the focused test file with `node --test apps/onebox-static/test/error-formatting.test.mjs` and it passed (tests passed: friendly error rules including the new `unauthorized_string_status`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9b6d79088333b704b7f601a452f4)