### PR TITLE
Scope Playwright cache to demo runtime sandboxes

### DIFF
--- a/demo/run_demo_tests.py
+++ b/demo/run_demo_tests.py
@@ -112,7 +112,12 @@ def _configure_runtime_env(runtime_root: Path) -> dict[str, str]:
     """Route orchestrator state into a temporary sandbox."""
 
     storage_root = runtime_root / "orchestrator"
-    cache_root = Path(os.environ.get("DEMO_PLAYWRIGHT_CACHE", Path.home() / ".cache" / "agi-jobs-demo" / "ms-playwright"))
+    cache_root = Path(
+        os.environ.get(
+            "DEMO_PLAYWRIGHT_CACHE",
+            runtime_root / "playwright" / "ms-playwright",
+        )
+    )
     overrides = {
         "ORCHESTRATOR_SCOREBOARD_PATH": storage_root / "scoreboard.json",
         "ORCHESTRATOR_CHECKPOINT_PATH": storage_root / "checkpoint.json",
@@ -221,7 +226,12 @@ def _run_suite(
         # fast and non-invasive while still allowing suites to download the
         # browser binaries they need.
         runtime_root = Path(env.get("DEMO_RUNTIME_ROOT", Path(__file__).resolve().parent))
-        playwright_cache = Path(env.get("DEMO_PLAYWRIGHT_CACHE", Path.home() / ".cache" / "agi-jobs-demo" / "ms-playwright"))
+        playwright_cache = Path(
+            env.get(
+                "DEMO_PLAYWRIGHT_CACHE",
+                runtime_root / "playwright" / "ms-playwright",
+            )
+        )
         playwright_cache.mkdir(parents=True, exist_ok=True)
         user_playwright_pref = env.get("PLAYWRIGHT_INSTALL_WITH_DEPS")
         env.setdefault("PLAYWRIGHT_BROWSERS_PATH", str(playwright_cache))

--- a/demo/tests/test_run_demo_tests_runner.py
+++ b/demo/tests/test_run_demo_tests_runner.py
@@ -885,7 +885,10 @@ def test_node_suites_use_runtime_root_playwright_cache(
     assert exit_code == 0
     cache_path = Path(captured_env["PLAYWRIGHT_BROWSERS_PATH"])
     expected_cache = Path(
-        os.environ.get("DEMO_PLAYWRIGHT_CACHE", Path.home() / ".cache" / "agi-jobs-demo" / "ms-playwright")
+        os.environ.get(
+            "DEMO_PLAYWRIGHT_CACHE",
+            runtime_root / "playwright" / "ms-playwright",
+        )
     )
     assert cache_path == expected_cache
     assert cache_path.exists()


### PR DESCRIPTION
### Motivation

- Ensure Playwright browser artifacts are isolated per demo run to avoid cross-demo contamination and shared home-directory caches.
- Keep runtime sandboxes hermetic so demos can run in parallel without interfering via global Playwright state.
- Provide a deterministic default that places the cache inside the demo runtime directory when no override is supplied.

### Description

- Default `DEMO_PLAYWRIGHT_CACHE` in `_configure_runtime_env` to `runtime_root / "playwright" / "ms-playwright"` when not explicitly set.
- Use the same runtime-scoped default for `playwright_cache` in `_run_suite` when launching Node-based suites.
- Update the test expectation in `demo/tests/test_run_demo_tests_runner.py` to assert the runtime-scoped cache path when `DEMO_PLAYWRIGHT_CACHE` is not set.

### Testing

- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/tests -q` and observed `47 passed`.
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/AGIJobs-Day-One-Utility-Benchmark/tests -q` and observed `19 passed`.
- Re-ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest demo/tests -q` after changes and observed `47 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db4ba8d108333a2564fd01ecb44ff)