### PR TITLE
Validate thermostat configuration bounds

### DIFF
--- a/services/thermostat/controller.py
+++ b/services/thermostat/controller.py
@@ -42,6 +42,18 @@ class ThermostatConfig:
             raise ValueError("upper_margin must be between 0 and 1")
         if self.target_roi <= 0:
             raise ValueError("target_roi must be positive")
+        if self.widening_step <= 0:
+            raise ValueError("widening_step must be positive")
+        if self.thompson_step <= 0:
+            raise ValueError("thompson_step must be positive")
+        if self.min_widening_alpha <= 0 or self.max_widening_alpha <= 0:
+            raise ValueError("widening alpha bounds must be positive")
+        if self.min_widening_alpha > self.max_widening_alpha:
+            raise ValueError("min_widening_alpha cannot exceed max_widening_alpha")
+        if self.min_thompson_prior <= 0 or self.max_thompson_prior <= 0:
+            raise ValueError("thompson prior bounds must be positive")
+        if self.min_thompson_prior > self.max_thompson_prior:
+            raise ValueError("min_thompson_prior cannot exceed max_thompson_prior")
         if self.cooldown_steps < 0:
             raise ValueError("cooldown_steps cannot be negative")
 

--- a/services/thermostat/tests/test_controller.py
+++ b/services/thermostat/tests/test_controller.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Dict
 
 import sys
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 HGM_CORE_SRC = ROOT / "packages" / "hgm-core" / "src"
@@ -274,3 +275,18 @@ def test_controller_skips_non_finite_samples() -> None:
     adjustment = asyncio.run(scenario())
 
     assert adjustment is not None
+
+
+def test_config_rejects_invalid_bounds() -> None:
+    with pytest.raises(ValueError, match="widening_step must be positive"):
+        ThermostatConfig(widening_step=0)
+    with pytest.raises(ValueError, match="thompson_step must be positive"):
+        ThermostatConfig(thompson_step=0)
+    with pytest.raises(ValueError, match="widening alpha bounds must be positive"):
+        ThermostatConfig(min_widening_alpha=0)
+    with pytest.raises(ValueError, match="min_widening_alpha cannot exceed max_widening_alpha"):
+        ThermostatConfig(min_widening_alpha=2.0, max_widening_alpha=1.0)
+    with pytest.raises(ValueError, match="thompson prior bounds must be positive"):
+        ThermostatConfig(min_thompson_prior=0)
+    with pytest.raises(ValueError, match="min_thompson_prior cannot exceed max_thompson_prior"):
+        ThermostatConfig(min_thompson_prior=4.0, max_thompson_prior=3.0)


### PR DESCRIPTION
### Motivation
- Prevent invalid thermostat parameters from reaching runtime by enforcing invariants early in configuration.
- The thermostat controller drives HGM engine parameters (`widening_alpha`, `thompson_prior`) and must rely on sane step sizes and bounds to avoid unsafe updates.
- Catching misconfiguration at construction time reduces unexpected exceptions during metric-driven tuning.
- Improve overall robustness and developer ergonomics by failing fast on invalid inputs.

### Description
- Add validation checks to `ThermostatConfig.__post_init__` to ensure `widening_step` and `thompson_step` are positive and that min/max bounds for widening alpha and thompson prior are positive and ordered.
- Ensure `min_widening_alpha <= max_widening_alpha` and `min_thompson_prior <= max_thompson_prior` with clear `ValueError` messages.
- Add unit tests in `services/thermostat/tests/test_controller.py` (`test_config_rejects_invalid_bounds`) to assert invalid configs raise `ValueError` and import `pytest` for assertions.
- Keep behavior unchanged when configuration is valid and the controller logic continues to operate as before.

### Testing
- Ran `pytest services/thermostat/tests/test_controller.py` which executed the thermostat unit tests.
- All tests in that file passed: `7 passed`.
- No other automated test failures were introduced by these changes.
- The change is limited to constructor validation and unit tests, so broader test suites were not required to validate the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dcafe6c6483339d342929e97bcf8b)