### PR TITLE
Handle workflow file extensions in CI context utilities

### DIFF
--- a/scripts/ci/utils/workflow.ts
+++ b/scripts/ci/utils/workflow.ts
@@ -76,10 +76,15 @@ export function listCiWorkflowJobs(): CiWorkflowJob[] {
 
 export function listWorkflowJobsByName(workflowName: string): CiWorkflowJob[] {
   const workflowsDir = resolve(__dirname, '../../../.github/workflows');
-  const candidates = [
-    resolve(workflowsDir, `${workflowName}.yml`),
-    resolve(workflowsDir, `${workflowName}.yaml`),
-  ];
+  const trimmedName = workflowName.trim();
+  const hasExtension =
+    trimmedName.endsWith('.yml') || trimmedName.endsWith('.yaml');
+  const candidates = hasExtension
+    ? [resolve(workflowsDir, trimmedName)]
+    : [
+        resolve(workflowsDir, `${trimmedName}.yml`),
+        resolve(workflowsDir, `${trimmedName}.yaml`),
+      ];
 
   const existingPath = candidates.find((candidate) => existsSync(candidate));
 


### PR DESCRIPTION
### Motivation
- Companion/required-context tooling could fail to locate workflows when a workflow name was supplied with an explicit `.yml`/`.yaml` extension or contained surrounding whitespace.
- The verification scripts expect to map context entries to actual workflow files in `.github/workflows`, so resilient filename resolution is required to avoid false missing-workflow errors.
- Making the lookup robust reduces CI flakiness when companion contexts reference workflows by filename rather than by implicit name.

### Description
- Trim the incoming `workflowName` and detect whether it already ends with `.yml` or `.yaml` in `scripts/ci/utils/workflow.ts` within `listWorkflowJobsByName`.
- If an extension is present, resolve that exact path; otherwise try both `${workflow}.yml` and `${workflow}.yaml` when searching the workflows directory.
- Preserve existing job discovery via `listWorkflowJobsFromPath` and keep error behavior when no matching file is found.

### Testing
- Ran `npm run ci:verify-companion-contexts` and the command completed successfully, reporting: `✅ Companion contexts verified (9 entries across 5 workflows).`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ddb4603048333be961372727b41de)