### PR TITLE
Handle pagination when checking GitHub Actions jobs

### DIFF
--- a/scripts/ci/check-ci-status-wall.ts
+++ b/scripts/ci/check-ci-status-wall.ts
@@ -139,15 +139,46 @@ function buildRunsUrl(
   return `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflow}/runs?${params.toString()}`;
 }
 
+const JOBS_PER_PAGE = 100;
+
 function buildJobsUrl(
   owner: string,
   repo: string,
-  runId: number
+  runId: number,
+  page: number
 ): string {
   const params = new URLSearchParams({
-    per_page: '100',
+    per_page: String(JOBS_PER_PAGE),
+    page: String(page),
   });
   return `https://api.github.com/repos/${owner}/${repo}/actions/runs/${runId}/jobs?${params.toString()}`;
+}
+
+async function fetchAllJobs(
+  owner: string,
+  repo: string,
+  runId: number,
+  token: string
+): Promise<WorkflowJob[]> {
+  const jobs: WorkflowJob[] = [];
+  let page = 1;
+  let totalCount = 0;
+
+  while (true) {
+    const jobsUrl = buildJobsUrl(owner, repo, runId, page);
+    const jobsResponse = await githubJson<WorkflowJobsResponse>(jobsUrl, token);
+    const batch = jobsResponse.jobs ?? [];
+    totalCount = jobsResponse.total_count ?? totalCount;
+    jobs.push(...batch);
+
+    if (batch.length < JOBS_PER_PAGE || jobs.length >= totalCount) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return jobs;
 }
 
 function normaliseConclusion(job: WorkflowJob): string {
@@ -188,9 +219,7 @@ async function verifyWorkflow(
     );
   }
 
-  const jobsUrl = buildJobsUrl(argv.owner, argv.repo, run.id);
-  const jobsResponse = await githubJson<WorkflowJobsResponse>(jobsUrl, token);
-  const jobs = jobsResponse.jobs ?? [];
+  const jobs = await fetchAllJobs(argv.owner, argv.repo, run.id, token);
 
   if (jobs.length === 0) {
     throw new Error(


### PR DESCRIPTION
### Motivation
- The CI status wall verifier assumed a single-page API response for workflow run jobs, which can miss jobs when the GitHub API paginates results. 
- Missing jobs cause false negatives when validating required CI jobs against branch-protection manifests. 
- Improve robustness so the tool reliably inspects all jobs for a run regardless of count. 

### Description
- Updated `scripts/ci/check-ci-status-wall.ts` to accept page parameters and centralised `JOBS_PER_PAGE` for job listing requests. 
- Added `fetchAllJobs` which pages through the GitHub API (`per_page` + `page`) and aggregates `workflow_runs[].jobs` until all jobs are retrieved using `total_count`. 
- Replaced the single-request job fetch in `verifyWorkflow` with the new `fetchAllJobs` to ensure all jobs are evaluated. 

### Testing
- Ran `npm run ci:verify-toolchain` and it completed successfully indicating toolchain pins are valid. 
- Ran `npm run ci:lock-integrity` and it completed successfully confirming deterministic lockfiles. 
- Ran `npm run ci:verify-contexts` and `npm run ci:verify-companion-contexts` and both completed successfully validating CI context manifests. 
- Ran `npm run lint:ci` after the change and it completed without errors (linter passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e6d5def788333a251a396a9812ec7)