### PR TITLE
Fix config root resolution for Kardashev demo

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -2895,15 +2895,26 @@ function resolveConfigRoot({ configRoot, demoRoot }) {
   if (!fs.existsSync(resolved)) {
     throw new Error(`Config root override not found: ${resolved}`);
   }
-  if (fs.existsSync(path.join(resolved, 'config'))) {
-    return resolved;
-  }
   const configFiles = [
     'fabric.json',
     'energy-feeds.json',
     'kardashev-ii.manifest.json',
     'task-lattice.json',
   ];
+  const stats = fs.statSync(resolved);
+  if (stats.isFile()) {
+    const parent = path.dirname(resolved);
+    if (path.basename(parent) === 'config') {
+      const grandparent = path.dirname(parent);
+      if (fs.existsSync(path.join(grandparent, 'config'))) {
+        return grandparent;
+      }
+    }
+    return parent;
+  }
+  if (fs.existsSync(path.join(resolved, 'config'))) {
+    return resolved;
+  }
   if (configFiles.some((filename) => fs.existsSync(path.join(resolved, filename)))) {
     const parent = path.dirname(resolved);
     if (fs.existsSync(path.join(parent, 'config'))) {


### PR DESCRIPTION
### Motivation
- `resolveConfigRoot` did not handle overrides that point to specific config files, causing the demo to fail when passed a file path for `--config-root`.
- The demo should accept either a config directory or a single config file and still resolve the expected `config` layout for downstream `loadJson` calls.
- Preserve existing behavior for directory-based overrides while supporting file-based inputs.
- Improve robustness for CLI-driven demos and CI usage where single-file overrides are convenient.

### Description
- Update `resolveConfigRoot` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs` to `stat` the resolved path and handle file inputs by returning the file's parent (or grandparent when parent is named `config`).
- Retain previous logic that detects a `config` subdirectory or configuration files (`fabric.json`, `energy-feeds.json`, `kardashev-ii.manifest.json`, `task-lattice.json`) inside the resolved path.
- Keep the final fallback of returning the resolved path when no special-case matches are found.
- Narrow change surface to path-resolution logic only; no behavior changes to Monte Carlo or energy-model code.

### Testing
- Ran `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs --check` and it completed successfully (check mode validation passed).
- Ran `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs --check --config-root demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/config/fabric.json` and it completed successfully (file override resolved correctly).
- No existing automated unit tests were modified; manual smoke checks above succeeded.
- No failures observed during the test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e78377e308333888d5d0e85c5642a)