### PR TITLE
Allow CI status wall to run without token

### DIFF
--- a/scripts/ci/check-ci-status-wall.ts
+++ b/scripts/ci/check-ci-status-wall.ts
@@ -99,16 +99,19 @@ function renderMarkdownSummary(outputs: StructuredWorkflowSummary[]): string {
   return lines.join('\n');
 }
 
-async function githubJson<T>(url: string, token: string): Promise<T> {
+async function githubJson<T>(url: string, token?: string): Promise<T> {
   let response: Response;
   try {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'agijobsv0-ci-status-wall',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
     response = await fetch(url, {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${token}`,
-        'User-Agent': 'agijobsv0-ci-status-wall',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
+      headers,
     });
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
@@ -158,7 +161,7 @@ async function fetchAllJobs(
   owner: string,
   repo: string,
   runId: number,
-  token: string
+  token?: string
 ): Promise<WorkflowJob[]> {
   const jobs: WorkflowJob[] = [];
   let page = 1;
@@ -192,7 +195,7 @@ function normaliseConclusion(job: WorkflowJob): string {
 async function verifyWorkflow(
   descriptor: WorkflowVerificationDescriptor,
   argv: CliArguments,
-  token: string
+  token?: string
 ): Promise<VerificationOutput> {
   const runsUrl = buildRunsUrl(
     argv.owner,
@@ -349,12 +352,10 @@ async function main(): Promise<void> {
     .alias('help', 'h')
     .parseSync() as CliArguments;
 
-  const token =
-    argv.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? '';
-
+  const token = argv.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
   if (!token) {
-    throw new Error(
-      'A GitHub token is required. Provide one via --token, GITHUB_TOKEN, or GH_TOKEN.'
+    console.warn(
+      'No GitHub token provided; falling back to unauthenticated API requests (rate limits apply).'
     );
   }
 


### PR DESCRIPTION
### Motivation
- Make the CI status wall script usable in environments where a GitHub token is not available so operators can perform lightweight checks on public repos or from local machines. 
- Reduce hard failure modes when token is omitted and instead fall back to unauthenticated requests while warning about rate limits. 
- Preserve existing authenticated behavior for higher rate limits and privileged access when a token is supplied. 
- Improve robustness by propagating optional token handling through job-run fetching and verification paths. 

### Description
- Made `githubJson` accept an optional `token` and build request headers conditionally so requests can be authenticated when a token is present or unauthenticated otherwise. 
- Propagated optional token types through `fetchAllJobs` and `verifyWorkflow` so downstream calls accept an absent token. 
- Changed `main` to no longer require a token and to emit a `console.warn` when no token is provided, preserving backward-compatible behavior when `--token` or `GITHUB_TOKEN`/`GH_TOKEN` is present. 
- Kept existing verification logic unchanged and retained the same job discovery and summary output paths. 

### Testing
- Ran the Python test suite with `pytest -q` (result: `245 passed, 1 skipped`).
- Executed the status-wall CLI help via `npm run ci:status-wall -- --help` which completed successfully and showed the expected options.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e865a5dc08333ab077bd0e363f789)