### PR TITLE
Improve demo config path resolution

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs
@@ -41,15 +41,39 @@ function createRng(seed) {
 
 function resolveConfigPath(envVar, fallbackRelative, baseDir = __dirname) {
   const override = normalizePathOverride(process.env[envVar]);
-  const target = override ? path.resolve(override) : path.join(baseDir, fallbackRelative);
+  const fallbackName = path.basename(fallbackRelative);
 
-  if (!fs.existsSync(target)) {
-    throw new Error(
-      `Missing configuration file at ${target} (${override ? `${envVar} override` : 'default path'})`,
-    );
+  if (override) {
+    const resolvedOverride = path.resolve(override);
+    if (fs.existsSync(resolvedOverride)) {
+      const stats = fs.statSync(resolvedOverride);
+      if (stats.isDirectory()) {
+        const candidate = path.join(resolvedOverride, fallbackName);
+        if (fs.existsSync(candidate)) {
+          return candidate;
+        }
+        throw new Error(
+          `Missing configuration file at ${candidate} (derived from ${envVar} directory override).`,
+        );
+      }
+      return resolvedOverride;
+    }
+    throw new Error(`Missing configuration file at ${resolvedOverride} (${envVar} override).`);
   }
 
-  return target;
+  const defaultTarget = path.join(baseDir, fallbackRelative);
+  if (fs.existsSync(defaultTarget)) {
+    return defaultTarget;
+  }
+
+  const flatTarget = path.join(baseDir, fallbackName);
+  if (fs.existsSync(flatTarget)) {
+    return flatTarget;
+  }
+
+  throw new Error(
+    `Missing configuration file at ${defaultTarget} (default path); also checked ${flatTarget} for flat config roots.`,
+  );
 }
 
 function normalizePathOverride(override) {


### PR DESCRIPTION
### Motivation
- The demo's config loader could fail when an environment override pointed at a directory or when config files were placed at a flat root, causing unclear missing-file errors.
- Make configuration resolution robust for CI/dev workflows where overrides may be file paths, directories, or flat config roots.

### Description
- Rewrote `resolveConfigPath` to accept an env override that is either a file or a directory and to derive the expected config filename when a directory is provided.
- Added fallback checks for the default config location and a flat config root (checking both `baseDir/<fallbackRelative>` and `baseDir/<basename(fallbackRelative)>`).
- Improved error messages to indicate which locations were checked and whether the override was a directory-derived candidate.

### Testing
- Ran the demo validation in check mode with `node demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run-demo.cjs --check` and it completed successfully.
- The script printed the expected validation summary and exited without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8f1e138c8333b6af992dfa58ccd5)