### PR TITLE
Fix static server path traversal guard in One-Box launcher

### DIFF
--- a/demo/One-Box/lib/launcher.js
+++ b/demo/One-Box/lib/launcher.js
@@ -565,11 +565,13 @@ function startOrchestrator(rootDir, env, config) {
 }
 
 function safeJoin(root, targetPath) {
-  const resolved = path.resolve(root, targetPath);
-  if (!resolved.startsWith(path.resolve(root))) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedTarget = path.resolve(resolvedRoot, targetPath);
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
     return null;
   }
-  return resolved;
+  return resolvedTarget;
 }
 
 function startStaticServer(distDir, config) {


### PR DESCRIPTION
### Motivation
- Harden the static asset server against path traversal attacks by replacing a brittle prefix check with robust path resolution and relative-path validation.
- Ensure the demo `startStaticServer` cannot serve files outside the `dist` directory when handling crafted request paths.
- Preserve existing behaviour for valid requests while removing a security gap in `safeJoin`.

### Description
- Replaced `safeJoin` in `demo/One-Box/lib/launcher.js` to compute `resolvedRoot` and `resolvedTarget`, use `path.relative` and reject targets where the relative path starts with `..` or is absolute, returning `null` for forbidden joins.
- The `startStaticServer` flow continues to call `safeJoin` and now benefits from the improved traversal protection without other behavioural changes.
- No features were removed and no other files were modified.

### Testing
- Executed a Node one-liner that exercises `safeJoin` with traversal and valid paths and observed the expected outputs (two `null` results for forbidden joins and the resolved path for a valid file).
- Reviewed `demo/One-Box/lib/launcher.js` to confirm `safeJoin` is used by `startStaticServer` and validated the new logic by inspection.
- No existing unit tests covered this helper, and no test files were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e973de8608333b3a63bc1b9faa57d)