### PR TITLE
Add __main__.py entrypoints for omega upgrade demo packages (v3, v4, v5)

### DIFF
--- a/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v3/__main__.py
+++ b/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v3/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v4/__main__.py
+++ b/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v4/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v5/__main__.py
+++ b/kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v5/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Bridge packages for several Omega-Grade upgrade demos lacked `__main__` entrypoints, preventing reliable `python -m <package>` invocation.
- Operators and CI rely on the `-m` invocation to launch demo CLIs from the top-level compatibility packages.
- Providing a uniform module entrypoint avoids surprises and improves ergonomics for tooling and automated pipelines.

### Description
- Added `__main__.py` to `kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v3` that imports and runs `main` from `.cli`.
- Added `__main__.py` to `kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v4` that imports and runs `main` from `.cli`.
- Added `__main__.py` to `kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v5` that imports and runs `main` from `.cli`.

### Testing
- Ran `python -m kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v3 --help` and it returned the CLI usage successfully.
- Ran `python -m kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v4 --help` and it returned the CLI usage successfully.
- Ran `python -m kardashev_ii_omega_grade_upgrade_for_alpha_agi_business_3_demo_v5 --help` and it returned the CLI usage successfully.
- The broader Kardashev-II demo test suite was executed and the demo tests completed (existing demo tests previously reported as passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec0079e3083339642e1fcf8dda23a)