### PR TITLE
Handle UNC-style file:// URLs in Kardashev II demo wrapper

### DIFF
--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py
@@ -37,7 +37,11 @@ def _normalize_output_dir(raw: str | Path) -> Path:
 
     parsed = urlparse(raw)
     if parsed.scheme == "file":
-        parsed_path = unquote(parsed.path)
+        if parsed.netloc and parsed.netloc not in ("", "localhost"):
+            parsed_path = f"//{parsed.netloc}{parsed.path}"
+        else:
+            parsed_path = parsed.path
+        parsed_path = unquote(parsed_path)
         if not parsed_path:
             raise ValueError(f"Output directory URL is missing a path: {raw}")
         return Path(parsed_path)

--- a/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
+++ b/demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -13,6 +14,16 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 DEMO_ROOT = PROJECT_ROOT / "demo" / "AGI-Jobs-Platform-at-Kardashev-II-Scale"
 PYTHON_ENTRYPOINT = DEMO_ROOT / "run_demo.py"
 NODE_ENTRYPOINT = DEMO_ROOT / "run-demo.cjs"
+
+
+def _load_run_demo_module():
+    spec = importlib.util.spec_from_file_location("kardashev_run_demo", PYTHON_ENTRYPOINT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load Kardashev II demo wrapper module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")
@@ -29,6 +40,14 @@ def test_run_demo_check_mode(tmp_path: Path) -> None:
     assert "validated (check mode)" in result.stdout
     assert "Free energy margin" in result.stdout
     assert "Sentient welfare equilibrium" in result.stdout
+
+
+def test_normalize_output_dir_handles_unc_file_url() -> None:
+    """UNC-style file URLs should retain their host segment."""
+
+    module = _load_run_demo_module()
+    output_dir = module._normalize_output_dir("file://nebula/share/telemetry")
+    assert output_dir == Path("//nebula/share/telemetry")
 
 
 @pytest.mark.skipif(not PYTHON_ENTRYPOINT.exists(), reason="Demo entrypoint is missing")


### PR DESCRIPTION
### Motivation
- Normalize `file://` output directory handling to preserve non-local host segments (UNC-style URLs) so Windows/UNC file URLs are interpreted correctly.
- Prevent loss of the host component when callers pass file URIs like `file://nebula/share/telemetry` which previously produced an incorrect local-only path.

### Description
- Update `_normalize_output_dir` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/run_demo.py` to prepend `//{netloc}` when `urlparse` returns a non-empty `netloc` that is not `localhost` and then `unquote` the result before creating a `Path`.
- Add helper `_load_run_demo_module` and a focused unit test `test_normalize_output_dir_handles_unc_file_url` in `demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py` to validate UNC-style `file://` normalization.

### Testing
- Ran `pytest -q demo/AGI-Jobs-Platform-at-Kardashev-II-Scale/tests/test_run_demo.py::test_normalize_output_dir_handles_unc_file_url` and it passed (`1 passed`).
- The new test exercises the updated `_normalize_output_dir` behavior using a `file://nebula/share/telemetry` example and asserts the returned path is `Path("//nebula/share/telemetry")`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed253a4fc8333a9648ea64a95c610)