### PR TITLE
Fix Hardhat test arg parsing

### DIFF
--- a/scripts/run-hardhat-tests.cjs
+++ b/scripts/run-hardhat-tests.cjs
@@ -49,6 +49,7 @@ function getLatestMtime(rootPath) {
 // meaningful for Hardhat to keep the test harness robust.
 const passthroughArgs = [];
 const ignoredPrefixes = ['--runinband', '--maxworkers', '--silent', '--listtests'];
+const ignoredValuePrefixes = ['--maxworkers'];
 const translatedArgs = [];
 let shouldSkipHardhat = false;
 let reporterOption;
@@ -109,7 +110,10 @@ for (let i = 0; i < process.argv.length; i += 1) {
       shouldSkipHardhat = true;
     }
     // Drop Jest/npm convenience flags that Hardhat doesn't understand
-    if (arg.includes('=') === false && process.argv[i + 1] && !process.argv[i + 1].startsWith('-')) {
+    if (ignoredValuePrefixes.some((prefix) => normalised.startsWith(prefix))
+      && arg.includes('=') === false
+      && process.argv[i + 1]
+      && !process.argv[i + 1].startsWith('-')) {
       // If the ignored flag expects a value (e.g. --maxWorkers 4), skip the next token too
       i += 1;
     }


### PR DESCRIPTION
### Motivation
- The Hardhat test wrapper was consuming the next positional argument when ignoring Jest/npm convenience flags, which could drop test file paths or other positional args.
- Only some ignored flags accept a following value (for example `--maxWorkers`), so the parser must only skip the next token for those.

### Description
- Added an `ignoredValuePrefixes` array and included `--maxworkers` to represent ignored flags that accept a value.
- Updated the argv filtering logic in `scripts/run-hardhat-tests.cjs` to only skip the next token when the ignored flag is known to accept a value.
- Preserved existing behavior for reporter options, `--runTestsByPath` translation, and Jest-only flag detection like `--listTests`.

### Testing
- Ran `npm test` and observed the full pretest + Hardhat suite complete successfully with the Solidity tests passing (Hardhat runner completed). 
- Ran `node scripts/run-hardhat-tests.cjs --listTests` which printed the expected message and exited successfully.
- Verified the updated script no longer consumes positional args when invoked with Jest-style boolean flags.
- No automated test failures were observed during these runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef505663483339677719c741988f6)