### PR TITLE
Allow signed Hamiltonian monitor records and add parsing test

### DIFF
--- a/scripts/config/index.js
+++ b/scripts/config/index.js
@@ -174,6 +174,40 @@ function ensureUint(
   return parsed.toString();
 }
 
+function ensureInt(
+  value,
+  label,
+  { allowZero = false, optional = false, allowNegative = false } = {}
+) {
+  if (value === undefined || value === null || value === '') {
+    if (optional) {
+      return undefined;
+    }
+    throw new Error(`${label} is missing`);
+  }
+  const asString = typeof value === 'string' ? value.trim() : String(value);
+  if (!asString) {
+    if (optional) {
+      return undefined;
+    }
+    throw new Error(`${label} is missing`);
+  }
+  const pattern = allowNegative ? /^-?\d+$/ : /^\d+$/;
+  if (!pattern.test(asString)) {
+    throw new Error(
+      `${label} must be a${allowNegative ? '' : ' non-negative'} integer`
+    );
+  }
+  const parsed = BigInt(asString);
+  if (!allowNegative && parsed < 0n) {
+    throw new Error(`${label} must be non-negative`);
+  }
+  if (!allowZero && parsed === 0n) {
+    throw new Error(`${label} must be greater than zero`);
+  }
+  return parsed.toString();
+}
+
 function parseBooleanFlag(value, label) {
   if (value === undefined || value === null || value === '') {
     return undefined;
@@ -1726,11 +1760,13 @@ function normaliseHamiltonianRecord(entry, index) {
     entry.d ?? entry.dissipation ?? entry.delta ?? entry.energy ?? entry.D;
   const uValue = entry.u ?? entry.utility ?? entry.U;
 
-  record.d = ensureUint(dValue, `records[${index}].d`, {
+  record.d = ensureInt(dValue, `records[${index}].d`, {
     allowZero: true,
+    allowNegative: true,
   });
-  record.u = ensureUint(uValue, `records[${index}].u`, {
+  record.u = ensureInt(uValue, `records[${index}].u`, {
     allowZero: true,
+    allowNegative: true,
   });
 
   if (entry.timestamp !== undefined && entry.timestamp !== null) {

--- a/test/hamiltonian-monitor.config.test.js
+++ b/test/hamiltonian-monitor.config.test.js
@@ -1,0 +1,33 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { test } = require('node:test');
+
+const { loadHamiltonianMonitorConfig } = require('../scripts/config');
+
+test('loadHamiltonianMonitorConfig accepts signed Hamiltonian records', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hamiltonian-config-'));
+  const configPath = path.join(tmpDir, 'hamiltonian-monitor.json');
+  const payload = {
+    window: 12,
+    records: [
+      {
+        d: -42,
+        u: '0',
+        timestamp: 0,
+        note: 'negative delta with zero utility',
+      },
+    ],
+  };
+
+  fs.writeFileSync(configPath, JSON.stringify(payload));
+
+  const result = loadHamiltonianMonitorConfig({ path: configPath });
+  const record = result.config.records[0];
+
+  assert.equal(record.d, '-42');
+  assert.equal(record.u, '0');
+  assert.equal(record.timestamp, '0');
+  assert.equal(record.note, 'negative delta with zero utility');
+});


### PR DESCRIPTION
### Motivation
- Hamiltonian monitor configuration should accept signed integer observations (negative deltas/utilities) which are valid free-energy measurements for thermodynamic audits. 
- Existing normalization used `ensureUint` which rejected negative values and prevented legitimate records from being loaded. 

### Description
- Added an `ensureInt` helper to `scripts/config/index.js` to validate signed or unsigned integer strings and return canonical stringified BigInt values. 
- Updated `normaliseHamiltonianRecord` in `scripts/config/index.js` to use `ensureInt(..., { allowZero: true, allowNegative: true })` for `d` and `u` fields so negative and zero values are accepted. 
- Added a Node unit test `test/hamiltonian-monitor.config.test.js` that writes a temporary `hamiltonian-monitor.json` and asserts negative/zero record parsing via `loadHamiltonianMonitorConfig`. 

### Testing
- Ran `node --test test/hamiltonian-monitor.config.test.js` and it passed (test verifies signed/zero record parsing). 
- Ran thermostat controller unit tests with `pytest services/thermostat/tests/test_controller.py` and the suite passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f15868b48833381804adb29ddc16f)