### PR TITLE
Harden orchestrator health auth token handling

### DIFF
--- a/apps/onebox/src/lib/orchestratorHealth.ts
+++ b/apps/onebox/src/lib/orchestratorHealth.ts
@@ -15,13 +15,32 @@ export type OrchestratorHealthOptions = {
 };
 
 const DEFAULT_TIMEOUT_MS = 5000;
+const AUTH_TOKEN_PATTERN = /^[A-Za-z0-9._~+/=:-]{1,512}$/;
+
+const sanitizeAuthToken = (value?: string): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (/[\r\n]/.test(trimmed)) {
+    return undefined;
+  }
+  if (!AUTH_TOKEN_PATTERN.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+};
 
 const buildHeaders = (apiToken?: string): HeadersInit | undefined => {
-  if (!apiToken) {
+  const sanitizedToken = sanitizeAuthToken(apiToken);
+  if (!sanitizedToken) {
     return undefined;
   }
   return {
-    Authorization: `Bearer ${apiToken}`,
+    Authorization: `Bearer ${sanitizedToken}`,
   };
 };
 

--- a/apps/onebox/test/orchestrator-health.test.ts
+++ b/apps/onebox/test/orchestrator-health.test.ts
@@ -34,6 +34,42 @@ test('checkOrchestratorHealth hits metrics endpoint with token', async () => {
   assert.ok(calls[0]?.init?.signal instanceof AbortSignal);
 });
 
+test('checkOrchestratorHealth trims auth tokens before sending headers', async () => {
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  const fetchMock: typeof fetch = async (input, init) => {
+    calls.push({ input, init });
+    return responseOk();
+  };
+
+  await checkOrchestratorHealth({
+    orchestratorBase: 'https://demo.example/orchestrator',
+    apiToken: '  trimmed-token  ',
+    fetchImpl: fetchMock,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0]?.init?.headers, {
+    Authorization: 'Bearer trimmed-token',
+  });
+});
+
+test('checkOrchestratorHealth drops unsafe auth tokens', async () => {
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  const fetchMock: typeof fetch = async (input, init) => {
+    calls.push({ input, init });
+    return responseOk();
+  };
+
+  await checkOrchestratorHealth({
+    orchestratorBase: 'https://demo.example/orchestrator',
+    apiToken: 'bad\nheader',
+    fetchImpl: fetchMock,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.init?.headers, undefined);
+});
+
 test('checkOrchestratorHealth strips trailing /onebox before hitting metrics', async () => {
   const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
   const fetchMock: typeof fetch = async (input, init) => {


### PR DESCRIPTION
### Motivation

- Prevent header injection and inconsistent authorization headers by normalising and validating orchestrator API tokens before use. 
- Follow best practices for client-side networking by rejecting tokens with control characters or invalid symbols. 
- Make the orchestrator health probe resilient when provided with noisy or user-supplied tokens. 
- Improve test coverage for token sanitisation behavior.

### Description

- Add `AUTH_TOKEN_PATTERN` and `sanitizeAuthToken` to validate and normalise API tokens used by the health check. 
- Update `buildHeaders` in `apps/onebox/src/lib/orchestratorHealth.ts` to trim and reject unsafe tokens and only emit an `Authorization` header for validated tokens. 
- Expand `apps/onebox/test/orchestrator-health.test.ts` with tests that assert token trimming and rejection of unsafe tokens. 
- Keep existing behaviour for metrics URL resolution and timeout handling unchanged.

### Testing

- Ran `node --test apps/onebox/test/orchestrator-health.test.ts` which failed due to Node not recognising the `.ts` extension when invoked directly. 
- Bundled the test with `npx esbuild apps/onebox/test/orchestrator-health.test.ts --bundle --platform=node --format=esm --target=es2022 --outfile=apps/onebox/test/dist/orchestrator-health.test.mjs && node apps/onebox/test/dist/orchestrator-health.test.mjs` and observed all tests pass (`7` tests passed). 
- Existing smoke checks for related UI helpers were left unaffected and the added tests run within the repository test harness as shown above. 
- No other automated test failures introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f273dc2048333918cb9e1588197a8)