### PR TITLE
Derive thermostat ROI from GMV/cost when missing or invalid

### DIFF
--- a/services/thermostat/metrics.py
+++ b/services/thermostat/metrics.py
@@ -1,6 +1,7 @@
 """Shared data structures for thermostat metrics ingestion."""
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Mapping
@@ -63,9 +64,14 @@ class MetricSample:
         else:
             timestamp = datetime.now(tz=timezone.utc)
 
-        roi = _coerce_float(payload.get("roi", 0.0))
         gmv = _coerce_float(payload.get("gmv", payload.get("revenue", 0.0)))
         cost = _coerce_float(payload.get("cost", payload.get("spend", 0.0)))
+        roi = _coerce_float(payload.get("roi"), default=float("nan"))
+        if not math.isfinite(roi):
+            if cost:
+                roi = gmv / cost
+            else:
+                roi = 0.0
         successes = _coerce_int(payload.get("successes", 0))
         failures = _coerce_int(payload.get("failures", 0))
         return cls(

--- a/services/thermostat/tests/test_metrics.py
+++ b/services/thermostat/tests/test_metrics.py
@@ -40,3 +40,11 @@ def test_metric_sample_defaults_invalid_numeric_fields() -> None:
     assert sample.cost == 0.0
     assert sample.successes == 7
     assert sample.failures == 0
+
+
+def test_metric_sample_derives_roi_from_gmv_and_cost() -> None:
+    payload = {"timestamp": 0, "gmv": 250.0, "cost": 100.0}
+
+    sample = MetricSample.from_payload(payload)
+
+    assert sample.roi == 2.5


### PR DESCRIPTION
### Motivation
- Improve resilience of thermostat metrics ingestion when `roi` is missing or non-finite in payloads.
- Ensure downstream controller logic receives a usable ROI value derived from available revenue/cost data.
- Avoid silent failures or skipped samples caused by malformed monitoring inputs.

### Description
- Update `MetricSample.from_payload` in `services/thermostat/metrics.py` to compute `roi` from `gmv / cost` when the provided `roi` is missing or not finite, and default to `0.0` when `cost` is zero.
- Add an import of `math` to detect non-finite `roi` values via `math.isfinite`.
- Add a unit test `test_metric_sample_derives_roi_from_gmv_and_cost` in `services/thermostat/tests/test_metrics.py` to verify ROI derivation from `gmv` and `cost`.

### Testing
- Ran `pytest services/thermostat/tests -q` and observed all tests passing.
- Test suite result: `11 passed` (all tests in the thermostat test module succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2ed3e63c8333911318607bcb65e0)