### PR TITLE
Upgrade Alpine packages in gateway image builds

### DIFF
--- a/agent-gateway/Dockerfile
+++ b/agent-gateway/Dockerfile
@@ -3,7 +3,7 @@
 FROM node:20.18.1-alpine3.20 AS base-build
 WORKDIR /app
 RUN apk add --no-cache python3 make g++ \
-    && apk upgrade --no-cache libssl3 libcrypto3 \
+    && apk upgrade --no-cache \
     && ln -sf python3 /usr/bin/python
 ENV PYTHON=/usr/bin/python3 \
     CYPRESS_INSTALL_BINARY=0 \
@@ -37,7 +37,7 @@ COPY --from=builder /app/package-lock.json ./
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/agent-gateway/dist ./agent-gateway/dist
 COPY --from=builder /app/scripts/start-telemetry.sh ./scripts/start-telemetry.sh
-RUN apk upgrade --no-cache libssl3 libcrypto3 \
+RUN apk upgrade --no-cache \
     && chmod +x ./scripts/start-telemetry.sh \
     && mkdir -p /app/storage /app/logs \
     && chown -R node:node /app


### PR DESCRIPTION
### Motivation

- Address an OS-level vulnerability reported by Trivy (musl libc) by ensuring image build stages pick up the latest Alpine package fixes.
- Prefer a full package upgrade during the Docker build stages instead of targeting specific packages to avoid missing related fixes.

### Description

- Updated `agent-gateway/Dockerfile` to run a full Alpine package upgrade in the build and runner stages by using `apk upgrade --no-cache`.
- Removed explicit `libssl3`/`libcrypto3` targets so the upgrade will apply all available package updates during image creation.
- Changes are limited to two `RUN` lines in `agent-gateway/Dockerfile` and do not affect application code or runtime behavior other than updated base packages.

### Testing

- No automated tests were run against the modified code in this change.
- A Trivy scan previously reported a HIGH severity musl vulnerability which motivated this change, but the scan was not re-run after the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fbad922ec83339d9fe5b1dfa3add4)