### PR TITLE
Format CI workflows and scripts to satisfy Prettier and CI v2 checks

### DIFF
--- a/.github/workflows/demo-asi-global.yml
+++ b/.github/workflows/demo-asi-global.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run ASI Global demo (local rehearsal)
         env:
-          PRIVATE_KEY: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
           AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
           AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
           AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6

--- a/.github/workflows/demo-zenith-sapience-omnidominion.yml
+++ b/.github/workflows/demo-zenith-sapience-omnidominion.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run OmniDominion local rehearsal
         env:
-          PRIVATE_KEY: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
           AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
           AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
           AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6

--- a/.github/workflows/demo-zenith-sapience-planetary-os.yml
+++ b/.github/workflows/demo-zenith-sapience-planetary-os.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run Zenith Sapience Planetary OS local rehearsal
         env:
-          PRIVATE_KEY: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
           AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
           AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
           AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -29,7 +29,9 @@ function parseMochaReporterOptions(name) {
     }
 
     if (Object.keys(options).length === 0) {
-      throw new Error(`Invalid reporter options provided in ${name}: ${error.message}`);
+      throw new Error(
+        `Invalid reporter options provided in ${name}: ${error.message}`
+      );
     }
 
     return options;
@@ -89,7 +91,8 @@ const jobRegistryViaIROverride = process.env.HARDHAT_JOBREGISTRY_VIA_IR;
 // opt-out via HARDHAT_VIA_IR=false. Fast compile runs keep viaIR enabled by
 // default to preserve correctness while other toggles (like reduced compiler
 // sets) keep turnaround times manageable.
-const baseViaIR = viaIROverride === undefined ? !isCoverageRun : viaIROverride === 'true';
+const baseViaIR =
+  viaIROverride === undefined ? !isCoverageRun : viaIROverride === 'true';
 const compilerViaIR = baseViaIR;
 
 // JobRegistry relies on viaIR to avoid stack depth issues in several
@@ -100,14 +103,13 @@ const jobRegistryViaIR =
   jobRegistryViaIROverride === 'true'
     ? true
     : jobRegistryViaIROverride === 'false'
-      ? false
-      : true;
+    ? false
+    : true;
 
 const SOLIDITY_VERSIONS = ['0.8.25', '0.8.23', '0.8.21'];
 
-const solidityVersions = isCoverageRun || isFastCompile
-  ? [SOLIDITY_VERSIONS[0]]
-  : SOLIDITY_VERSIONS;
+const solidityVersions =
+  isCoverageRun || isFastCompile ? [SOLIDITY_VERSIONS[0]] : SOLIDITY_VERSIONS;
 
 const solidityCompilers = solidityVersions.map((version) => ({
   version,

--- a/scripts/ci/check-lock-integrity.js
+++ b/scripts/ci/check-lock-integrity.js
@@ -19,7 +19,9 @@ function checkLockfile(relPath) {
   }
 
   if (Buffer.byteLength(contents, 'utf8') < 128) {
-    failures.push(`${relPath} is unexpectedly small; regenerate with npm install --package-lock-only`);
+    failures.push(
+      `${relPath} is unexpectedly small; regenerate with npm install --package-lock-only`
+    );
   }
 
   let data;
@@ -31,20 +33,34 @@ function checkLockfile(relPath) {
   }
 
   if (data.lockfileVersion !== 3) {
-    failures.push(`${relPath} must set lockfileVersion = 3 (found ${data.lockfileVersion ?? 'undefined'})`);
+    failures.push(
+      `${relPath} must set lockfileVersion = 3 (found ${
+        data.lockfileVersion ?? 'undefined'
+      })`
+    );
   }
 
   if (!data.packages || typeof data.packages !== 'object') {
-    failures.push(`${relPath} is missing the "packages" map; run npm install --package-lock-only`);
+    failures.push(
+      `${relPath} is missing the "packages" map; run npm install --package-lock-only`
+    );
   }
 }
 
 function main() {
   let stdout = '';
   try {
-    stdout = execSync("git ls-files '**/package-lock.json'", { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    stdout = execSync("git ls-files '**/package-lock.json'", {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
   } catch (error) {
-    failures.push(`Unable to enumerate package-lock.json files: ${error.stderr || error.message}`);
+    failures.push(
+      `Unable to enumerate package-lock.json files: ${
+        error.stderr || error.message
+      }`
+    );
   }
 
   const files = stdout
@@ -65,7 +81,9 @@ function main() {
     for (const failure of failures) {
       console.error(` - ${failure}`);
     }
-    console.error('\nRun npm install --package-lock-only in each affected workspace.');
+    console.error(
+      '\nRun npm install --package-lock-only in each affected workspace.'
+    );
     process.exit(1);
   }
 

--- a/scripts/ci/check-summary-needs.js
+++ b/scripts/ci/check-summary-needs.js
@@ -83,7 +83,9 @@ function main() {
       issues.push(`unexpected needs entries: ${extra.join(', ')}`);
     }
     throw new Error(
-      `ci (v2) summary needs list does not match job set (${issues.join('; ')}).`
+      `ci (v2) summary needs list does not match job set (${issues.join(
+        '; '
+      )}).`
     );
   }
 

--- a/scripts/ci/check-toolchain-locks.js
+++ b/scripts/ci/check-toolchain-locks.js
@@ -62,14 +62,18 @@ function checkNodeVersion() {
   if (!enginesNpm) {
     problems.push('package.json is missing engines.npm pin');
   } else if (!/^>=10\.8\.0\s*<11/.test(enginesNpm.trim())) {
-    problems.push(`package.json engines.npm must bound npm 10.x (found "${enginesNpm}")`);
+    problems.push(
+      `package.json engines.npm must bound npm 10.x (found "${enginesNpm}")`
+    );
   }
 
   const packageManager = pkg?.packageManager;
   if (!packageManager) {
     problems.push('package.json is missing packageManager declaration');
   } else if (!/^npm@10\.8\.[0-9]+$/.test(packageManager.trim())) {
-    problems.push(`package.json packageManager must pin npm@10.8.x (found "${packageManager}")`);
+    problems.push(
+      `package.json packageManager must pin npm@10.8.x (found "${packageManager}")`
+    );
   }
 }
 
@@ -124,7 +128,9 @@ function checkRootLockfile() {
     const contents = fs.readFileSync(lockfilePath, 'utf8');
     JSON.parse(contents);
     if (Buffer.byteLength(contents, 'utf8') < MIN_ROOT_LOCKFILE_BYTES) {
-      problems.push('Root package-lock.json is unexpectedly small; regenerate it with npm install --package-lock-only');
+      problems.push(
+        'Root package-lock.json is unexpectedly small; regenerate it with npm install --package-lock-only'
+      );
     }
   } catch (error) {
     problems.push(`Root package-lock.json is invalid JSON: ${error.message}`);

--- a/scripts/ci/ensure-cypress-binary.js
+++ b/scripts/ci/ensure-cypress-binary.js
@@ -5,22 +5,38 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const repoRoot = path.resolve(__dirname, '..', '..');
-const cypressPkgPath = path.join(repoRoot, 'node_modules', 'cypress', 'package.json');
+const cypressPkgPath = path.join(
+  repoRoot,
+  'node_modules',
+  'cypress',
+  'package.json'
+);
 
 if (!fs.existsSync(cypressPkgPath)) {
-  console.error('Cypress is not installed in node_modules; run `npm install` first.');
+  console.error(
+    'Cypress is not installed in node_modules; run `npm install` first.'
+  );
   process.exit(1);
 }
 
 const cypressVersion = require(cypressPkgPath).version;
-const expectedBinary = path.join(os.homedir(), '.cache', 'Cypress', cypressVersion, 'Cypress', 'Cypress');
+const expectedBinary = path.join(
+  os.homedir(),
+  '.cache',
+  'Cypress',
+  cypressVersion,
+  'Cypress',
+  'Cypress'
+);
 
 if (fs.existsSync(expectedBinary)) {
   console.log(`Cypress binary already present for version ${cypressVersion}.`);
   process.exit(0);
 }
 
-console.log(`Cypress binary missing for version ${cypressVersion}; installing...`);
+console.log(
+  `Cypress binary missing for version ${cypressVersion}; installing...`
+);
 const install = spawnSync('npx', ['cypress', 'install', '--force'], {
   stdio: 'inherit',
   cwd: repoRoot,


### PR DESCRIPTION
### Motivation
- Prettier/format checks failed for several CI workflow YAMLs and helper scripts causing `npm run format:check` to fail. 
- Long lines and inconsistent quoting in `hardhat.config.js` and CI scripts triggered style warnings and risked failing CI gates. 
- Apply minimal, non-functional edits to satisfy formatting and lint rules so the full CI v2 runbook can pass.

### Description
- Applied Prettier-style formatting to workflow files and normalized quoting for demo workflow `PRIVATE_KEY` env entries in `.github/workflows/demo-*.yml` files. 
- Reflowed long lines and wrapped string literals/console messages in `hardhat.config.js` and CI scripts: `scripts/ci/check-lock-integrity.js`, `scripts/ci/check-summary-needs.js`, `scripts/ci/check-toolchain-locks.js`, and `scripts/ci/ensure-cypress-binary.js`. 
- Changes are formatting and whitespace/line-wrapping only; no behavioral or dependency changes were introduced. 

### Testing
- Executed the prescribed runbook commands `npm ci --no-audit --prefer-offline --progress=false`, `npm run ci:verify-toolchain`, `npm run lint:ci`, `npm run format:check`, `npm run monitoring:validate`, `npm run ci:sync-contexts -- --check`, `npm run ci:verify-contexts`, and `npm run ci:verify-companion-contexts`, all of which passed. 
- Ran `npm test`, which executed the JS unit tests and the Hardhat suite and completed successfully (Hardhat reported 570 passing tests). 
- `npm run format:check` initially reported issues which were fixed by running `npm run format` and then re-checking to confirm formatting compliance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fd686d44883339e313a6dabf8e16b)