### PR TITLE
Upgrade libpng in owner-console runtime image to address Trivy OS vulnerabilities

### DIFF
--- a/apps/console/Dockerfile
+++ b/apps/console/Dockerfile
@@ -10,6 +10,7 @@ RUN npm run build
 FROM nginx:1.27-alpine AS runner
 RUN apk upgrade --no-cache \
     libexpat \
+    libpng \
     libxml2
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html


### PR DESCRIPTION
### Motivation
- A Trivy OS-package scan flagged `libpng` CVEs in the `owner-console` container image, causing the hardened container CI to fail. 
- The failure was rooted in the runtime image not upgrading `libpng` in the final `nginx` runner stage. 
- The change aims to remediate the OS-level vulnerability without altering CI gates or toolchain pins. 

### Description
- Updated `apps/console/Dockerfile` to include `libpng` in the `apk upgrade --no-cache` line in the `nginx` runner stage. 
- This ensures the runtime image will upgrade `libpng` to a fixed version during image build. 
- The change is minimal and surgical, touching only the runtime Dockerfile for `owner-console`. 

### Testing
- Ran the prescribed local CI v2 runbook: `npm ci --no-audit --prefer-offline --progress=false`, and `npm run ci:verify-toolchain`, both succeeded. 
- Ran static checks and formatting: `npm run lint:ci` and `npm run format:check`, both succeeded. 
- Validated monitoring and CI contexts: `npm run monitoring:validate`, `npm run ci:sync-contexts -- --check`, `npm run ci:verify-contexts`, and `npm run ci:verify-companion-contexts`, all succeeded. 
- Executed the full test suite via `npm test` (including the Hardhat tests), which completed successfully (all automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe5fbb0148333a1767546a1813b81)