### PR TITLE
Allow GitHub Actions artifact endpoints in demo workflows

### DIFF
--- a/.github/workflows/demo-agi-labor-market.yml
+++ b/.github/workflows/demo-agi-labor-market.yml
@@ -31,6 +31,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-alpha-agi-insight-mark.yml
+++ b/.github/workflows/demo-alpha-agi-insight-mark.yml
@@ -38,6 +38,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -38,6 +38,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-asi-global.yml
+++ b/.github/workflows/demo-asi-global.yml
@@ -36,6 +36,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-asi-takeoff.yml
+++ b/.github/workflows/demo-asi-takeoff.yml
@@ -26,6 +26,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-aurora.yml
+++ b/.github/workflows/demo-aurora.yml
@@ -26,6 +26,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-cosmic-flagship.yml
+++ b/.github/workflows/demo-cosmic-flagship.yml
@@ -29,6 +29,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
             binaries.soliditylang.org

--- a/.github/workflows/demo-day-one-utility-benchmark.yml
+++ b/.github/workflows/demo-day-one-utility-benchmark.yml
@@ -33,9 +33,12 @@ jobs:
           egress-policy: block
           allowed-endpoints: |
             api.github.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
             files.pythonhosted.org
             github.com
             objects.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             pypi.org
             registry.npmjs.org
             nodejs.org

--- a/.github/workflows/demo-kardashev-ii-omega-k2.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-k2.yml
@@ -32,6 +32,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-kardashev-ii-omega-operator.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-operator.yml
@@ -33,6 +33,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-kardashev-ii-omega-ultra.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-ultra.yml
@@ -33,6 +33,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-kardashev-ii-omega-upgrade-k2.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-upgrade-k2.yml
@@ -31,9 +31,12 @@ jobs:
           egress-policy: block
           allowed-endpoints: |
             api.github.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
             files.pythonhosted.org
             github.com
             objects.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             pypi.org
 
       - name: Setup Python

--- a/.github/workflows/demo-kardashev-ii-omega-upgrade-v2.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-upgrade-v2.yml
@@ -31,6 +31,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-kardashev-ii-omega-upgrade-v4.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-upgrade-v4.yml
@@ -32,6 +32,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-kardashev-ii-omega-upgrade-v5.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-upgrade-v5.yml
@@ -32,6 +32,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-kardashev-ii-omega-upgrade.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-upgrade.yml
@@ -31,6 +31,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-kardashev-ii.yml
+++ b/.github/workflows/demo-kardashev-ii.yml
@@ -31,6 +31,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-kardashev-omega-iii.yml
+++ b/.github/workflows/demo-kardashev-omega-iii.yml
@@ -33,6 +33,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             pypi.org
             files.pythonhosted.org
 

--- a/.github/workflows/demo-meta-agentic-program-synthesis.yml
+++ b/.github/workflows/demo-meta-agentic-program-synthesis.yml
@@ -29,6 +29,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             pypi.org
             files.pythonhosted.org
 

--- a/.github/workflows/demo-national-supply-chain.yml
+++ b/.github/workflows/demo-national-supply-chain.yml
@@ -32,6 +32,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-phase-8-universal-value-dominance.yml
+++ b/.github/workflows/demo-phase-8-universal-value-dominance.yml
@@ -30,6 +30,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-planetary-orchestrator-fabric.yml
+++ b/.github/workflows/demo-planetary-orchestrator-fabric.yml
@@ -38,6 +38,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
             download.cypress.io

--- a/.github/workflows/demo-redenomination.yml
+++ b/.github/workflows/demo-redenomination.yml
@@ -31,6 +31,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-trustless-economic-core.yml
+++ b/.github/workflows/demo-trustless-economic-core.yml
@@ -40,6 +40,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
             binaries.soliditylang.org

--- a/.github/workflows/demo-validator-constellation.yml
+++ b/.github/workflows/demo-validator-constellation.yml
@@ -38,6 +38,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-zenith-hypernova.yml
+++ b/.github/workflows/demo-zenith-hypernova.yml
@@ -40,6 +40,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-zenith-sapience-celestial-archon.yml
+++ b/.github/workflows/demo-zenith-sapience-celestial-archon.yml
@@ -40,6 +40,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-zenith-sapience-initiative.yml
+++ b/.github/workflows/demo-zenith-sapience-initiative.yml
@@ -40,6 +40,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-zenith-sapience-omnidominion.yml
+++ b/.github/workflows/demo-zenith-sapience-omnidominion.yml
@@ -40,6 +40,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 

--- a/.github/workflows/demo-zenith-sapience-planetary-os.yml
+++ b/.github/workflows/demo-zenith-sapience-planetary-os.yml
@@ -40,6 +40,9 @@ jobs:
             github.com
             objects.githubusercontent.com
             raw.githubusercontent.com
+            actions.githubusercontent.com
+            actions-results.githubusercontent.com
+            pipelines.actions.githubusercontent.com
             registry.npmjs.org
             nodejs.org
 


### PR DESCRIPTION
### Motivation
- Several demo workflows use `step-security/harden-runner` with `egress-policy: block`, which prevented `actions/upload-artifact` from reaching GitHub's artifact services.
- The change is intended to permit CI demos to upload artefacts while keeping the runner hardening in place.
- Maintain existing allowed endpoints and only expand the minimal set needed for artifact uploads.

### Description
- Added `actions.githubusercontent.com`, `actions-results.githubusercontent.com`, and `pipelines.actions.githubusercontent.com` to the `allowed-endpoints` lists in demo workflow YAMLs under `.github/workflows/`.
- Applied the update across multiple demo workflows so artifact uploads are unblocked for all demo jobs.
- No functional code or scripts were modified, only workflow configuration entries were changed.

### Testing
- No CI or unit test suites were run because this is a workflow-only change.
- Ran a local Python verification that scanned the workflows for the required endpoints and it reported `All workflows include required endpoints`.
- Performed a targeted grep/check to ensure no `egress-policy: block` workflow is missing the new allowlist entries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960131fca008333a45fc357f47f036a)