### PR TITLE
Grant `actions: write` permission for artifact uploads in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  actions: read
+  actions: write
   checks: read
 
 concurrency:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
   packages: write
   id-token: write
 

--- a/.github/workflows/culture-ci.yml
+++ b/.github/workflows/culture-ci.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
   checks: read
 
 env:

--- a/.github/workflows/demo-agi-governance.yml
+++ b/.github/workflows/demo-agi-governance.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: demo-agi-governance-${{ github.ref }}

--- a/.github/workflows/demo-agi-labor-market.yml
+++ b/.github/workflows/demo-agi-labor-market.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   agi-labor-market-demo:

--- a/.github/workflows/demo-alpha-agi-insight-mark.yml
+++ b/.github/workflows/demo-alpha-agi-insight-mark.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   alpha-agi-insight-mark-demo:

--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   alpha-agi-mark-demo:

--- a/.github/workflows/demo-asi-global.yml
+++ b/.github/workflows/demo-asi-global.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   asi-global:

--- a/.github/workflows/demo-asi-takeoff.yml
+++ b/.github/workflows/demo-asi-takeoff.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   asi-takeoff-local:

--- a/.github/workflows/demo-aurora.yml
+++ b/.github/workflows/demo-aurora.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   aurora-local:

--- a/.github/workflows/demo-cosmic-flagship.yml
+++ b/.github/workflows/demo-cosmic-flagship.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   flagship-dry-run:

--- a/.github/workflows/demo-meta-agentic-alpha-agi-jobs.yml
+++ b/.github/workflows/demo-meta-agentic-alpha-agi-jobs.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: demo-meta-agentic-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/demo-meta-agentic-program-synthesis.yml
+++ b/.github/workflows/demo-meta-agentic-program-synthesis.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   demo:

--- a/.github/workflows/demo-national-supply-chain.yml
+++ b/.github/workflows/demo-national-supply-chain.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   national-supply-chain-demo:

--- a/.github/workflows/demo-phase-8-universal-value-dominance.yml
+++ b/.github/workflows/demo-phase-8-universal-value-dominance.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   phase8-demo:

--- a/.github/workflows/demo-redenomination.yml
+++ b/.github/workflows/demo-redenomination.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   redenomination-demo:

--- a/.github/workflows/demo-zenith-hypernova.yml
+++ b/.github/workflows/demo-zenith-hypernova.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   hypernova:

--- a/.github/workflows/demo-zenith-sapience-celestial-archon.yml
+++ b/.github/workflows/demo-zenith-sapience-celestial-archon.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   celestial-archon:

--- a/.github/workflows/demo-zenith-sapience-initiative.yml
+++ b/.github/workflows/demo-zenith-sapience-initiative.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   zenith-sapience:

--- a/.github/workflows/demo-zenith-sapience-omnidominion.yml
+++ b/.github/workflows/demo-zenith-sapience-omnidominion.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   zenith-omnidominion:

--- a/.github/workflows/demo-zenith-sapience-planetary-os.yml
+++ b/.github/workflows/demo-zenith-sapience-planetary-os.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   zenith-planetary-os:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: e2e-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-mainnet.yml
+++ b/.github/workflows/release-mainnet.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
   id-token: write
   packages: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
   packages: write
   id-token: write
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,7 +18,7 @@ jobs:
   analyze:
     name: OpenSSF Scorecard
     permissions:
-      actions: read
+      actions: write
       contents: read
       security-events: write
       id-token: write

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-  actions: read
+  actions: write
   security-events: write
 
 concurrency:

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: webapp-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Motivation
- Artifact upload steps using `actions/upload-artifact` require the runner to have `actions: write` permission, otherwise uploads fail.
- Several demo, CI, release, and analysis workflows were missing `actions: write` and could not persist artifacts from runs.
- The change ensures workflows that produce artifacts can successfully upload them to GitHub Actions.
- Also aligns job-level permissions for security scorecard and static analysis so their uploads succeed.

### Description
- Added `actions: write` to the `permissions` block of multiple workflows under `.github/workflows` that upload artifacts.
- Updated the Scorecard job-level `permissions` to use `actions: write` so it can publish results artifacts.
- Updated the static-analysis workflow `permissions` to `actions: write` to allow artifact publishing from analysis steps.
- Committed the permission updates across affected workflow YAML files.

### Testing
- Performed an automated repository scan to locate workflows using `actions/upload-artifact` and verified they now include `actions: write`.
- Ran `git status` and created a commit to record the configuration changes successfully. 
- No CI/workflow executions were run as part of this change since it is a workflow configuration update.
- No unit or integration tests were applicable to this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69602bcc04e08333a103110d6a45940a)