### PR TITLE
Guard demo workflow artifact uploads on forked PRs

### DIFF
--- a/.github/workflows/demo-asi-global.yml
+++ b/.github/workflows/demo-asi-global.yml
@@ -75,6 +75,7 @@ jobs:
         run: npm run demo:asi-global:local
 
       - name: Upload global demo artefacts
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: asi-global-receipts

--- a/.github/workflows/demo-asi-takeoff.yml
+++ b/.github/workflows/demo-asi-takeoff.yml
@@ -65,6 +65,7 @@ jobs:
         run: npm run demo:asi-takeoff:local
 
       - name: Upload demo receipts
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: asi-takeoff-receipts

--- a/.github/workflows/demo-aurora.yml
+++ b/.github/workflows/demo-aurora.yml
@@ -62,6 +62,7 @@ jobs:
         run: bash demo/aurora/bin/aurora-local.sh
 
       - name: Upload demo receipts
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: aurora-receipts

--- a/.github/workflows/demo-zenith-hypernova.yml
+++ b/.github/workflows/demo-zenith-hypernova.yml
@@ -79,6 +79,7 @@ jobs:
         run: npm run demo:zenith-hypernova:local
 
       - name: Upload Hypernova artefacts
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: zenith-hypernova-reports

--- a/.github/workflows/demo-zenith-sapience-celestial-archon.yml
+++ b/.github/workflows/demo-zenith-sapience-celestial-archon.yml
@@ -79,6 +79,7 @@ jobs:
         run: npm run demo:zenith-sapience-celestial-archon:local
 
       - name: Upload Celestial Archon artefacts
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: zenith-celestial-archon-reports

--- a/.github/workflows/demo-zenith-sapience-initiative.yml
+++ b/.github/workflows/demo-zenith-sapience-initiative.yml
@@ -79,6 +79,7 @@ jobs:
         run: npm run demo:zenith-sapience-initiative:local
 
       - name: Upload Zenith Sapience artefacts
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: zenith-sapience-reports

--- a/.github/workflows/demo-zenith-sapience-omnidominion.yml
+++ b/.github/workflows/demo-zenith-sapience-omnidominion.yml
@@ -79,6 +79,7 @@ jobs:
         run: npm run demo:zenith-sapience-omnidominion:local
 
       - name: Upload OmniDominion artefacts
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: zenith-omnidominion-reports

--- a/.github/workflows/demo-zenith-sapience-planetary-os.yml
+++ b/.github/workflows/demo-zenith-sapience-planetary-os.yml
@@ -79,6 +79,7 @@ jobs:
         run: npm run demo:zenith-sapience-planetary-os:local
 
       - name: Upload Zenith Sapience Planetary OS artefacts
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: zenith-planetary-os-reports


### PR DESCRIPTION
### Motivation
- Prevent failing artifact uploads and permission errors when demo workflows run for forked pull requests where the runner token lacks write permissions. 
- Avoid attempting to publish artifacts from untrusted fork contexts by gating uploads to events that have a writable token.

### Description
- Added an `if` guard (`${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}`) to `actions/upload-artifact` steps in demo workflows. 
- Updated the following workflow files: `.github/workflows/demo-asi-global.yml`, `.github/workflows/demo-asi-takeoff.yml`, `.github/workflows/demo-aurora.yml`, `.github/workflows/demo-zenith-hypernova.yml`, `.github/workflows/demo-zenith-sapience-celestial-archon.yml`, `.github/workflows/demo-zenith-sapience-initiative.yml`, `.github/workflows/demo-zenith-sapience-omnidominion.yml`, and `.github/workflows/demo-zenith-sapience-planetary-os.yml`. 
- The guard preserves uploads for non-pull_request events and for pull requests originating from the same repository (non-forks).

### Testing
- No automated tests were executed because this is a workflow-only change. 
- Behavior will be validated on subsequent workflow runs where CI executes these demo workflows under both forked and non-forked contexts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696032e0f6948333a0e0145e33f04aef)