### PR TITLE
Add explicit read-only `GITHUB_TOKEN` permissions to demo workflows

### DIFF
--- a/.github/workflows/demo-agi-alpha-node.yml
+++ b/.github/workflows/demo-agi-alpha-node.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'demo/AGI-Alpha-Node-v0/**'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/demo-economic-power.yml
+++ b/.github/workflows/demo-economic-power.yml
@@ -14,6 +14,9 @@ on:
       - 'package.json'
       - 'package-lock.json'
 
+permissions:
+  contents: read
+
 jobs:
   run-demo:
     runs-on: ubuntu-24.04

--- a/.github/workflows/demo-huxley-godel-machine.yml
+++ b/.github/workflows/demo-huxley-godel-machine.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/demo-huxley-godel-machine.yml'
       - 'Makefile'
 
+permissions:
+  contents: read
+
 jobs:
   smoke-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/demo-muzero-style.yml
+++ b/.github/workflows/demo-muzero-style.yml
@@ -11,6 +11,9 @@ on:
       - 'demo/MuZero-style-v0/**'
       - '.github/workflows/demo-muzero-style.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/demo-sovereign-constellation.yml
+++ b/.github/workflows/demo-sovereign-constellation.yml
@@ -12,6 +12,9 @@ on:
       - package.json
       - package-lock.json
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-24.04

--- a/.github/workflows/demo-tiny-recursive-model.yml
+++ b/.github/workflows/demo-tiny-recursive-model.yml
@@ -10,6 +10,9 @@ on:
       - 'demo/Tiny-Recursive-Model-v0/**'
       - '.github/workflows/demo-tiny-recursive-model.yml'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/validator-constellation-demo.yml
+++ b/.github/workflows/validator-constellation-demo.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Run Validator Constellation demo tests


### PR DESCRIPTION
### Motivation
- Ensure demo workflows explicitly declare `GITHUB_TOKEN` permissions to follow least-privilege best practices.
- Prevent implicit permission assumptions and reduce risk of overly-broad token scopes for CI demos.
- Make repository workflow intent explicit and consistent across demo pipelines.
- Limit scope to read-only access for repository contents where no write is required.

### Description
- Added a `permissions` block with `contents: read` to the following demo workflow files: ` .github/workflows/demo-agi-alpha-node.yml`, ` .github/workflows/demo-economic-power.yml`, ` .github/workflows/demo-huxley-godel-machine.yml`, ` .github/workflows/demo-muzero-style.yml`, ` .github/workflows/demo-sovereign-constellation.yml`, ` .github/workflows/demo-tiny-recursive-model.yml`, and ` .github/workflows/validator-constellation-demo.yml`.
- Changes are workflow-only (YAML) updates and do not modify application code or tests.
- Commit message: `Add explicit workflow token permissions` to record the change intent.
- Files updated to align with repository security and CI gating conventions.

### Testing
- No automated tests were executed because these are workflow-only configuration changes.
- CI jobs will use the updated permissions on next workflow runs to validate behavior (no failures observed yet).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696032e0f6948333a0e0145e33f04aef)