### PR TITLE
Expand harden-runner allowlists in demo workflows

### DIFF
--- a/.github/workflows/demo-agi-labor-market.yml
+++ b/.github/workflows/demo-agi-labor-market.yml
@@ -30,6 +30,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-alpha-agi-insight-mark.yml
+++ b/.github/workflows/demo-alpha-agi-insight-mark.yml
@@ -37,6 +37,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-alpha-agi-mark.yml
+++ b/.github/workflows/demo-alpha-agi-mark.yml
@@ -37,6 +37,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-asi-global.yml
+++ b/.github/workflows/demo-asi-global.yml
@@ -38,6 +38,9 @@ jobs:
           allowed-endpoints: >
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-asi-takeoff.yml
+++ b/.github/workflows/demo-asi-takeoff.yml
@@ -28,6 +28,9 @@ jobs:
           allowed-endpoints: >
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-aurora.yml
+++ b/.github/workflows/demo-aurora.yml
@@ -28,6 +28,9 @@ jobs:
           allowed-endpoints: >
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-cosmic-flagship.yml
+++ b/.github/workflows/demo-cosmic-flagship.yml
@@ -31,6 +31,8 @@ jobs:
           allowed-endpoints: >
             api.github.com
             github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-day-one-utility-benchmark.yml
+++ b/.github/workflows/demo-day-one-utility-benchmark.yml
@@ -37,6 +37,9 @@ jobs:
             actions-results.githubusercontent.com
             files.pythonhosted.org
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             pipelines.actions.githubusercontent.com
             pypi.org

--- a/.github/workflows/demo-kardashev-ii-omega-k2.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-k2.yml
@@ -30,6 +30,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-kardashev-ii-omega-operator.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-operator.yml
@@ -31,6 +31,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-kardashev-ii-omega-ultra.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-ultra.yml
@@ -31,6 +31,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-kardashev-ii-omega-upgrade-k2.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-upgrade-k2.yml
@@ -35,6 +35,9 @@ jobs:
             actions-results.githubusercontent.com
             files.pythonhosted.org
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             pipelines.actions.githubusercontent.com
             pypi.org

--- a/.github/workflows/demo-kardashev-ii-omega-upgrade-v2.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-upgrade-v2.yml
@@ -29,6 +29,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-kardashev-ii-omega-upgrade-v4.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-upgrade-v4.yml
@@ -30,6 +30,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-kardashev-ii-omega-upgrade-v5.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-upgrade-v5.yml
@@ -30,6 +30,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-kardashev-ii-omega-upgrade.yml
+++ b/.github/workflows/demo-kardashev-ii-omega-upgrade.yml
@@ -29,6 +29,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-kardashev-ii.yml
+++ b/.github/workflows/demo-kardashev-ii.yml
@@ -29,6 +29,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-kardashev-omega-iii.yml
+++ b/.github/workflows/demo-kardashev-omega-iii.yml
@@ -31,6 +31,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-meta-agentic-program-synthesis.yml
+++ b/.github/workflows/demo-meta-agentic-program-synthesis.yml
@@ -28,6 +28,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-national-supply-chain.yml
+++ b/.github/workflows/demo-national-supply-chain.yml
@@ -31,6 +31,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-phase-8-universal-value-dominance.yml
+++ b/.github/workflows/demo-phase-8-universal-value-dominance.yml
@@ -29,6 +29,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-planetary-orchestrator-fabric.yml
+++ b/.github/workflows/demo-planetary-orchestrator-fabric.yml
@@ -36,6 +36,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-redenomination.yml
+++ b/.github/workflows/demo-redenomination.yml
@@ -30,6 +30,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-trustless-economic-core.yml
+++ b/.github/workflows/demo-trustless-economic-core.yml
@@ -38,6 +38,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-validator-constellation.yml
+++ b/.github/workflows/demo-validator-constellation.yml
@@ -36,6 +36,9 @@ jobs:
           allowed-endpoints: |
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-zenith-hypernova.yml
+++ b/.github/workflows/demo-zenith-hypernova.yml
@@ -42,6 +42,9 @@ jobs:
           allowed-endpoints: >
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-zenith-sapience-celestial-archon.yml
+++ b/.github/workflows/demo-zenith-sapience-celestial-archon.yml
@@ -42,6 +42,9 @@ jobs:
           allowed-endpoints: >
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-zenith-sapience-initiative.yml
+++ b/.github/workflows/demo-zenith-sapience-initiative.yml
@@ -42,6 +42,9 @@ jobs:
           allowed-endpoints: >
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-zenith-sapience-omnidominion.yml
+++ b/.github/workflows/demo-zenith-sapience-omnidominion.yml
@@ -42,6 +42,9 @@ jobs:
           allowed-endpoints: >
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com

--- a/.github/workflows/demo-zenith-sapience-planetary-os.yml
+++ b/.github/workflows/demo-zenith-sapience-planetary-os.yml
@@ -42,6 +42,9 @@ jobs:
           allowed-endpoints: >
             api.github.com
             github.com
+            codeload.github.com
+            uploads.github.com
+            release-assets.githubusercontent.com
             objects.githubusercontent.com
             raw.githubusercontent.com
             actions.githubusercontent.com


### PR DESCRIPTION
### Motivation

- Prevent CI flakes in demo workflows caused by blocked GitHub download/upload domains when `harden-runner` enforces egress restrictions.
- Ensure demo jobs can fetch release artefacts, toolchains and package data from GitHub endpoints used by `npm`, `foundry`, and other demo tooling.
- Keep workflow network allowlists aligned with the actual endpoints observed in `package-lock.json` and demo scripts.

### Description

- Added `codeload.github.com`, `uploads.github.com`, and `release-assets.githubusercontent.com` to the `allowed-endpoints` list in multiple demo workflow files under `.github/workflows/` so `step-security/harden-runner` can permit required GitHub asset downloads.
- Applied the same allowlist expansion across many demo workflows (examples: `demo-asi-global.yml`, `demo-alpha-agi-mark.yml`, and numerous other `demo-*.yml` files) to maintain consistency.
- Retained existing endpoints (e.g. `api.github.com`, `objects.githubusercontent.com`, `raw.githubusercontent.com`, `actions.githubusercontent.com`, `registry.npmjs.org`, `nodejs.org`) and preserved the block/pipe YAML styles used by each workflow.

### Testing

- No automated tests were executed because this change only updates GitHub Actions workflow configuration files and does not alter runtime code.
- Linting or CI jobs were not run as part of this change verification (`workflow change only`).
- Manual validation: updated workflows were parsed and saved; no runtime demo executions were performed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696039c326208333805c0455c0281252)