### PR TITLE
Use ASI Global local runner for Zenith local demos

### DIFF
--- a/demo/zenith-sapience-initiative-celestial-archon-governance/bin/zenith-celestial-archon-local.sh
+++ b/demo/zenith-sapience-initiative-celestial-archon-governance/bin/zenith-celestial-archon-local.sh
@@ -27,4 +27,4 @@ export AURORA_REPORT_TITLE="Zenith Sapience Celestial Archon — Mission Report"
 rm -rf "$LOCAL_REPORT_ROOT"
 mkdir -p "$LOCAL_REPORT_ROOT"
 
-NETWORK="$NETWORK_NAME" npm run demo:asi-global -- "$@"
+NETWORK="$NETWORK_NAME" npm run demo:asi-global:local -- "$@"

--- a/demo/zenith-sapience-initiative-global-governance/bin/zenith-sapience-local.sh
+++ b/demo/zenith-sapience-initiative-global-governance/bin/zenith-sapience-local.sh
@@ -27,4 +27,4 @@ export AURORA_REPORT_TITLE="Zenith Sapience Initiative — Mission Report"
 rm -rf "$LOCAL_REPORT_ROOT"
 mkdir -p "$LOCAL_REPORT_ROOT"
 
-NETWORK="$NETWORK_NAME" npm run demo:asi-global -- "$@"
+NETWORK="$NETWORK_NAME" npm run demo:asi-global:local -- "$@"

--- a/demo/zenith-sapience-initiative-omnidominion-governance/bin/zenith-omnidominion-local.sh
+++ b/demo/zenith-sapience-initiative-omnidominion-governance/bin/zenith-omnidominion-local.sh
@@ -28,4 +28,4 @@ export AURORA_REPORT_TITLE="Zenith Sapience OmniDominion — Mission Report"
 rm -rf "$LOCAL_REPORT_ROOT"
 mkdir -p "$LOCAL_REPORT_ROOT"
 
-NETWORK="$NETWORK_NAME" npm run demo:asi-global -- "$@"
+NETWORK="$NETWORK_NAME" npm run demo:asi-global:local -- "$@"

--- a/demo/zenith-sapience-initiative-planetary-operating-system-governance/bin/zenith-planetary-os-local.sh
+++ b/demo/zenith-sapience-initiative-planetary-operating-system-governance/bin/zenith-planetary-os-local.sh
@@ -29,4 +29,4 @@ export AURORA_REPORT_TITLE="Zenith Sapience Planetary OS — Mission Report"
 rm -rf "$LOCAL_REPORT_ROOT"
 mkdir -p "$LOCAL_REPORT_ROOT"
 
-NETWORK="$NETWORK_NAME" npm run demo:asi-global -- "$@"
+NETWORK="$NETWORK_NAME" npm run demo:asi-global:local -- "$@"

--- a/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/bin/zenith-hypernova-local.sh
+++ b/demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/bin/zenith-hypernova-local.sh
@@ -27,4 +27,4 @@ export AURORA_REPORT_TITLE="Hypernova Initiative — Mission Report"
 rm -rf "$LOCAL_REPORT_ROOT"
 mkdir -p "$LOCAL_REPORT_ROOT"
 
-NETWORK="$NETWORK_NAME" npm run demo:asi-global -- "$@"
+NETWORK="$NETWORK_NAME" npm run demo:asi-global:local -- "$@"


### PR DESCRIPTION
### Motivation
- Ensure local demo scripts start a local node by invoking the local runner (`npm run demo:asi-global:local`) instead of the deterministic kit.
- Make local rehearsal behavior consistent across multiple Zenith demo variants.
- Avoid requiring contributors to manually start a local node for local rehearsals.
- Align local demo scripts with the existing ASI Global local-runner semantics.

### Description
- Replaced `npm run demo:asi-global` with `npm run demo:asi-global:local` in five local demo entry scripts.
- Files modified: `demo/zenith-sapience-initiative-global-governance/bin/zenith-sapience-local.sh`, `demo/zenith-sapience-initiative-celestial-archon-governance/bin/zenith-celestial-archon-local.sh`, `demo/zenith-sapience-initiative-omnidominion-governance/bin/zenith-omnidominion-local.sh`, `demo/zenith-sapience-initiative-planetary-operating-system-governance/bin/zenith-planetary-os-local.sh`, and `demo/zenith-sapience-initiative-supra-sovereign-hypernova-governance/bin/zenith-hypernova-local.sh`.
- No changes were made to environment variable exports or report directory handling.
- Commit message used: `Fix zenith local demos to use local runner`.

### Testing
- No automated tests were executed for this change.
- Shell-only updates that will be validated by the repository CI pipeline on merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696047210fc0833390bec6a7ff82bbef)