### PR TITLE
Remove explicit `any` usage and enforce stricter lint/type rules

### DIFF
--- a/apps/console/src/components/ConnectionPanel.tsx
+++ b/apps/console/src/components/ConnectionPanel.tsx
@@ -86,7 +86,7 @@ export function ConnectionPanel({ onConfigSaved }: ConnectionPanelProps) {
   }
 
   async function connectWallet() {
-    if (!(window as any).ethereum) {
+    if (!window.ethereum) {
       setWalletStatus({
         state: 'error',
         message:
@@ -96,11 +96,14 @@ export function ConnectionPanel({ onConfigSaved }: ConnectionPanelProps) {
     }
     try {
       setWalletStatus({ state: 'idle' });
-      const accounts = (await (window as any).ethereum.request({
+      const accounts = await window.ethereum.request({
         method: 'eth_requestAccounts',
-      })) as string[];
-      if (accounts && accounts.length > 0) {
-        setWalletStatus({ state: 'connected', address: accounts[0] });
+      });
+      const accountList = Array.isArray(accounts)
+        ? accounts.filter((account): account is string => typeof account === 'string')
+        : [];
+      if (accountList.length > 0) {
+        setWalletStatus({ state: 'connected', address: accountList[0] });
       } else {
         setWalletStatus({
           state: 'error',

--- a/apps/console/src/types/ethereum.d.ts
+++ b/apps/console/src/types/ethereum.d.ts
@@ -1,0 +1,9 @@
+import type { Eip1193Provider } from 'ethers';
+
+declare global {
+  interface Window {
+    ethereum?: Eip1193Provider;
+  }
+}
+
+export {};

--- a/apps/mission-control/components/ArtifactGraph.tsx
+++ b/apps/mission-control/components/ArtifactGraph.tsx
@@ -40,7 +40,10 @@ const links: GraphLink[] = [
 export function ArtifactGraph() {
   const [selected, setSelected] = useState<GraphNode | null>(null);
 
-  const data = useMemo(() => ({ nodes, links }), []);
+  const data = useMemo<{ nodes: GraphNode[]; links: GraphLink[] }>(
+    () => ({ nodes, links }),
+    []
+  );
 
   const handleAction = () => {
     if (!selected) return;
@@ -58,28 +61,26 @@ export function ArtifactGraph() {
         <CardBody>
           <Box height={{ base: '320px', md: '520px' }}>
             <ForceGraph2D
-              graphData={data as any}
-              nodeLabel={(node) => {
-                const typed = node as GraphNode;
-                return `${typed.name} — influence ${(typed.influence * 100).toFixed(0)}%`;
+              graphData={data}
+              nodeLabel={(node: GraphNode) => {
+                return `${node.name} — influence ${(node.influence * 100).toFixed(0)}%`;
               }}
-              nodeCanvasObject={(node, ctx, globalScale) => {
-                const typed = node as GraphNode;
-                const label = typed.name;
+              nodeCanvasObject={(node: GraphNode, ctx, globalScale) => {
+                const label = node.name;
                 const fontSize = 12 / globalScale;
-                const radius = 6 + typed.influence * 10;
+                const radius = 6 + node.influence * 10;
                 ctx.beginPath();
-                ctx.arc((typed.x ?? 0) as number, (typed.y ?? 0) as number, radius, 0, 2 * Math.PI, false);
-                ctx.fillStyle = typed.actionable ? '#34d399' : '#6366f1';
+                ctx.arc(node.x ?? 0, node.y ?? 0, radius, 0, 2 * Math.PI, false);
+                ctx.fillStyle = node.actionable ? '#34d399' : '#6366f1';
                 ctx.fill();
                 ctx.font = `${fontSize}px Sans-Serif`;
                 ctx.textAlign = 'center';
                 ctx.textBaseline = 'top';
                 ctx.fillStyle = '#e2e8f0';
-                ctx.fillText(label, (typed.x ?? 0) as number, ((typed.y ?? 0) as number) + radius);
+                ctx.fillText(label, node.x ?? 0, (node.y ?? 0) + radius);
               }}
-              linkLabel={(link) => (link as GraphLink).label}
-              onNodeClick={(node) => setSelected(node as GraphNode)}
+              linkLabel={(link: GraphLink) => link.label}
+              onNodeClick={(node: GraphNode) => setSelected(node)}
             />
           </Box>
         </CardBody>

--- a/apps/mission-control/components/ScoreboardView.tsx
+++ b/apps/mission-control/components/ScoreboardView.tsx
@@ -38,8 +38,31 @@ const SCOREBOARD_QUERY = gql`
   }
 `;
 
+interface ArtifactScore {
+  id: string;
+  name: string;
+  elo: number;
+  difficultyTrend: number[];
+  successRate: number;
+}
+
+interface HonestySample {
+  label: string;
+  honesty: number;
+}
+
+interface ValidatorHonesty {
+  median: number;
+  latestSample: HonestySample[];
+}
+
+interface ScoreboardData {
+  artifacts: ArtifactScore[];
+  validatorHonesty: ValidatorHonesty;
+}
+
 export function ScoreboardView() {
-  const { data } = useQuery(SCOREBOARD_QUERY, { fetchPolicy: 'cache-first' });
+  const { data } = useQuery<ScoreboardData>(SCOREBOARD_QUERY, { fetchPolicy: 'cache-first' });
   const artifacts = data?.artifacts ?? [];
   const validatorHonesty = data?.validatorHonesty ?? { median: 0, latestSample: [] };
 
@@ -62,7 +85,7 @@ export function ScoreboardView() {
               </Tr>
             </Thead>
             <Tbody>
-              {artifacts.map((artifact: any) => (
+              {artifacts.map((artifact) => (
                 <Tr key={artifact.id}>
                   <Td>{artifact.name}</Td>
                   <Td>{artifact.elo}</Td>
@@ -93,7 +116,7 @@ export function ScoreboardView() {
         </CardHeader>
         <CardBody>
           <ResponsiveContainer width="100%" height={260}>
-            <AreaChart data={artifacts.map((artifact: any) => ({ name: artifact.name, success: artifact.successRate * 100 }))}>
+            <AreaChart data={artifacts.map((artifact) => ({ name: artifact.name, success: artifact.successRate * 100 }))}>
               <defs>
                 <linearGradient id="colorSuccess" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor="#38bdf8" stopOpacity={0.7} />

--- a/apps/orchestrator/__tests__/oneboxRouter.test.ts
+++ b/apps/orchestrator/__tests__/oneboxRouter.test.ts
@@ -6,6 +6,10 @@ import type { Wallet } from 'ethers';
 import express from 'express';
 import request from 'supertest';
 import type { IntentEnvelope } from '../../../packages/onebox-orchestrator/src/ics/types';
+import type {
+  PlannerClient,
+  PlannerPlanResult,
+} from '../../../packages/onebox-orchestrator/src';
 import {
   createOneboxRouter,
   plannerIntentToJobIntent,
@@ -304,7 +308,14 @@ test('DefaultOneboxService produces calldata for wallet mode', async () => {
     },
   } as unknown as ethers.AbstractProvider;
 
-  const plannerStub = { plan: async () => ({}) } as unknown as any;
+  const plannerStub: Pick<PlannerClient, 'plan'> = {
+    plan: async () =>
+      ({
+        source: 'fallback',
+        rawText: '',
+        intent: { ok: false, issues: [] },
+      } satisfies PlannerPlanResult),
+  };
 
   const service = new DefaultOneboxService({
     planner: plannerStub,
@@ -338,13 +349,19 @@ test('DefaultOneboxService produces calldata for wallet mode', async () => {
 
 test('finalizeJob invokes registry finalize function', async () => {
   const finalizeCall = mock.fn(async () => ({ hash: '0xabc', wait: async () => undefined }));
-  const ethersModule = require('ethers') as { ethers: { Contract: new (...args: any[]) => unknown } };
+  type ContractConstructor = new (
+    ...args: ConstructorParameters<typeof ethers.Contract>
+  ) => { finalize: typeof finalizeCall };
+  const ethersModule = require('ethers') as { ethers: { Contract: ContractConstructor } };
   const originalDescriptor = Object.getOwnPropertyDescriptor(ethersModule.ethers, 'Contract');
+  const ContractMock: ContractConstructor = class {
+    constructor(..._args: ConstructorParameters<typeof ethers.Contract>) {}
+
+    finalize = finalizeCall;
+  };
   Object.defineProperty(ethersModule.ethers, 'Contract', {
     configurable: true,
-    value: function () {
-      return { finalize: finalizeCall };
-    } as unknown as new (...args: any[]) => unknown,
+    value: ContractMock,
   });
 
   const loadStateMock = mock.method(execution, 'loadState', () => ({}));

--- a/apps/orchestrator/agents.ts
+++ b/apps/orchestrator/agents.ts
@@ -17,6 +17,9 @@ export type AgentHandler = (input: AgentHandlerInput) => Promise<unknown>;
 
 const handlers = new Map<string, AgentHandler>();
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
 function ensureText(value: unknown): string {
   if (typeof value === 'string') return value;
   if (value === null || value === undefined) return '';
@@ -69,9 +72,9 @@ async function analyticalAgent(
 async function financialEstimator(
   input: AgentHandlerInput
 ): Promise<Record<string, unknown>> {
-  const payload = input.payload as Record<string, unknown> | null;
-  const reward = Number((payload && (payload as any).reward) ?? 0);
-  const stake = Number((payload && (payload as any).stake) ?? 0);
+  const payload = isRecord(input.payload) ? input.payload : {};
+  const reward = Number(payload.reward ?? 0);
+  const stake = Number(payload.stake ?? 0);
   const efficiency = reward > 0 ? reward / (stake + 1) : 0;
   return {
     type: 'financial-model',

--- a/apps/orchestrator/anchoring.ts
+++ b/apps/orchestrator/anchoring.ts
@@ -135,7 +135,7 @@ export class AuditAnchoringService {
       }
       const parsed = JSON.parse(raw) as AnchorState;
       return { anchored: parsed.anchored ?? {} };
-    } catch (err: any) {
+    } catch (err) {
       if (err.code === 'ENOENT') {
         await ensureDirectory(path.dirname(this.stateFile));
         return { anchored: {} };

--- a/apps/orchestrator/bidding.ts
+++ b/apps/orchestrator/bidding.ts
@@ -50,7 +50,7 @@ const JOB_AGENT_PCT_MASK = 0xffffffffn << JOB_AGENT_PCT_OFFSET;
 const JOB_DEADLINE_MASK = 0xffffffffffffffffn << JOB_DEADLINE_OFFSET;
 const JOB_ASSIGNED_AT_MASK = 0xffffffffffffffffn << JOB_ASSIGNED_AT_OFFSET;
 
-function decodePackedJobMetadata(packed: any): {
+function decodePackedJobMetadata(packed: unknown): {
   state?: number;
   success?: boolean;
   burnConfirmed?: boolean;
@@ -70,8 +70,13 @@ function decodePackedJobMetadata(packed: any): {
     value = BigInt(packed);
   } else if (typeof packed === 'string') {
     value = BigInt(packed);
-  } else if (typeof (packed as any).toString === 'function') {
-    value = BigInt((packed as any).toString());
+  } else if (
+    typeof packed === 'object' &&
+    packed !== null &&
+    'toString' in packed &&
+    typeof packed.toString === 'function'
+  ) {
+    value = BigInt(packed.toString());
   } else {
     return {};
   }

--- a/apps/orchestrator/employer.ts
+++ b/apps/orchestrator/employer.ts
@@ -17,7 +17,7 @@ const REGISTRY_ABI = [
 export interface PostJobSpec {
   reward: bigint | number | string;
   deadline: number;
-  metadata: any;
+  metadata: Record<string, unknown>;
   wallet: Wallet;
   dependencies?: (string | number)[];
   agentTypes?: number;
@@ -29,14 +29,17 @@ export interface JobArtifacts {
   specHash: string;
 }
 
-export async function prepareJobArtifacts(metadata: any): Promise<JobArtifacts> {
+export async function prepareJobArtifacts(
+  metadata: Record<string, unknown>
+): Promise<JobArtifacts> {
   const jsonSpec = JSON.stringify(metadata ?? {}, null, 2);
   const jsonPin = await uploadToIPFS(jsonSpec);
   const jsonCid = jsonPin.cid;
 
-  const markdown = metadata?.markdown
-    ? metadata.markdown
-    : `# Job Specification\n\n\`\`\`json\n${jsonSpec}\n\`\`\`\n`;
+  const markdown =
+    typeof metadata.markdown === 'string'
+      ? metadata.markdown
+      : `# Job Specification\n\n\`\`\`json\n${jsonSpec}\n\`\`\`\n`;
   const markdownPin = await uploadToIPFS(markdown);
   const markdownCid = markdownPin.cid;
 

--- a/apps/orchestrator/execution.ts
+++ b/apps/orchestrator/execution.ts
@@ -22,7 +22,7 @@ import {
 
 export interface StageDefinition {
   name: string;
-  agent: string | ((input: any) => Promise<any>);
+  agent: string | ((input: unknown) => Promise<unknown>);
   signerId?: string;
   context: AgentHandlerContext;
 }
@@ -119,9 +119,9 @@ export function saveJobGraph(graph: Record<string, string[]>): void {
 }
 
 export async function invokeAgent(
-  agent: string | ((input: any) => Promise<any>),
-  payload: any
-): Promise<any> {
+  agent: string | ((input: unknown) => Promise<unknown>),
+  payload: unknown
+): Promise<unknown> {
   if (typeof agent === 'function') {
     return agent(payload);
   }
@@ -363,7 +363,7 @@ function buildPinnerCandidates(
 }
 
 function ensureBlob(
-  content: any,
+  content: unknown,
   explicitType?: string
 ): { blob: Blob; suggestedFileName: string } {
   if (content instanceof Blob) {
@@ -383,10 +383,10 @@ function ensureBlob(
     const buffer =
       content instanceof ArrayBuffer
         ? content
-        : ((content as ArrayBufferView).buffer.slice(
-            (content as ArrayBufferView).byteOffset,
-            (content as ArrayBufferView).byteOffset + (content as ArrayBufferView).byteLength
-          ) as ArrayBuffer);
+        : content.buffer.slice(
+            content.byteOffset,
+            content.byteOffset + content.byteLength
+          );
     data = new Uint8Array(buffer);
     type = type ?? 'application/octet-stream';
   } else if (content && typeof content === 'object') {
@@ -542,7 +542,7 @@ function isRetryableStatus(status: number): boolean {
 }
 
 async function pinViaIpfsApi(
-  content: any,
+  content: unknown,
   options: UploadToIPFSOptions
 ): Promise<PinnedContent> {
   const apiUrl = options.apiUrl ?? process.env.IPFS_API_URL ?? DEFAULT_IPFS_API;
@@ -566,7 +566,7 @@ async function pinViaIpfsApi(
 }
 
 async function pinViaPinner(
-  content: any,
+  content: unknown,
   options: UploadToIPFSOptions,
   candidate: PinningCandidateConfig
 ): Promise<PinnedContent> {
@@ -658,9 +658,9 @@ async function pinViaPinner(
       let size: number | undefined;
       let pinnedAt: string | undefined;
 
-      if (payload && typeof payload === 'object') {
-        const record = payload as Record<string, unknown>;
-        const pinRecord = record.pin as Record<string, unknown> | undefined;
+      if (isRecord(payload)) {
+        const record = payload;
+        const pinRecord = isRecord(record.pin) ? record.pin : undefined;
         requestId =
           (typeof record.requestid === 'string' && record.requestid) ||
           (typeof record.requestId === 'string' && record.requestId) ||
@@ -781,9 +781,12 @@ async function fetchPinStatus(
       return {};
     }
     if (provider === 'pinata') {
-      const result = payload as { rows?: any[] };
-      const firstRow = Array.isArray(result.rows) ? result.rows[0] : undefined;
-      if (!firstRow || typeof firstRow !== 'object') {
+      if (!isRecord(payload)) {
+        return {};
+      }
+      const rows = Array.isArray(payload.rows) ? payload.rows : [];
+      const firstRow = rows.find((row) => isRecord(row));
+      if (!firstRow || !isRecord(firstRow)) {
         return {};
       }
       const status = typeof firstRow.status === 'string' ? firstRow.status : undefined;
@@ -801,17 +804,20 @@ async function fetchPinStatus(
           : undefined;
       return { status, size, pinnedAt };
     }
-    const record = payload as Record<string, unknown>;
-    const pinRecord = record.pin as Record<string, unknown> | undefined;
+    if (!isRecord(payload)) {
+      return {};
+    }
+    const record = payload;
+    const pinRecord = isRecord(record.pin) ? record.pin : undefined;
     const status =
       (typeof record.status === 'string' && record.status) ||
       (pinRecord && typeof pinRecord.status === 'string' ? pinRecord.status : undefined);
     const size =
       (pinRecord && typeof pinRecord.size === 'number' ? pinRecord.size : undefined) ??
-      (typeof record.pinSize === 'number' ? (record.pinSize as number) : undefined);
+      (typeof record.pinSize === 'number' ? record.pinSize : undefined);
     const pinnedAt =
       (pinRecord && typeof pinRecord.created === 'string' ? pinRecord.created : undefined) ||
-      (typeof record.created === 'string' ? (record.created as string) : undefined);
+      (typeof record.created === 'string' ? record.created : undefined);
     return { status, size, pinnedAt };
   } catch (error) {
     if (error instanceof PinningServiceError) {
@@ -828,7 +834,7 @@ async function fetchPinStatus(
 }
 
 export async function uploadToIPFS(
-  content: any,
+  content: unknown,
   options?: string | UploadToIPFSOptions
 ): Promise<PinnedContent> {
   const resolved = normalizeUploadOptions(options);
@@ -868,7 +874,7 @@ export async function uploadToIPFS(
 export async function runJob(
   jobId: string,
   stages: StageDefinition[],
-  initialInput?: any
+  initialInput?: unknown
 ): Promise<JobRunResult> {
   auditLog('job.start', {
     jobId,
@@ -1181,3 +1187,5 @@ function toMetricsSummary(
     errorMessage: metrics.errorMessage,
   };
 }
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;

--- a/apps/orchestrator/gateway.ts
+++ b/apps/orchestrator/gateway.ts
@@ -25,11 +25,44 @@ export async function resolveAddress(
   return resolved;
 }
 
+interface JobCreatedDetails {
+  employer: string;
+  reward: string;
+  stake: string;
+  fee: string;
+  specHash: string;
+  uri: string;
+}
+
+type JobDetectedHandler = (
+  jobId: string,
+  details: JobCreatedDetails
+) => void | Promise<void>;
+
+type JobCreatedListener = (
+  jobId: bigint,
+  employer: string,
+  assignedAgent: string,
+  reward: bigint,
+  stake: bigint,
+  fee: bigint,
+  specHash: string,
+  uri: string
+) => void | Promise<void>;
+
+interface JobRegistryContract {
+  on(event: 'JobCreated', listener: JobCreatedListener): void;
+}
+
+interface StakeManagerContract {
+  stakeOf(address: string, role: number): Promise<bigint>;
+}
+
 export function setupJobListener(
-  jobRegistry: any,
-  stakeManager: { stakeOf(address: string, role: number): Promise<bigint> },
+  jobRegistry: JobRegistryContract,
+  stakeManager: StakeManagerContract,
   agentAddress: string,
-  onJobDetected: (jobId: string, details: any) => void | Promise<void>
+  onJobDetected: JobDetectedHandler
 ): void {
   jobRegistry.on(
     'JobCreated',
@@ -60,10 +93,7 @@ export function setupJobListener(
 }
 
 export async function start(
-  onJobDetected: (
-    jobId: string,
-    details: any
-  ) => void | Promise<void> = defaultCallback
+  onJobDetected: JobDetectedHandler = defaultCallback
 ): Promise<void> {
   const provider = new ethers.JsonRpcProvider(RPC_URL);
   const jobRegistryAddress = await resolveAddress(
@@ -84,11 +114,17 @@ export async function start(
     stakeManagerAbi,
     provider
   );
-  setupJobListener(
-    jobRegistry,
-    stakeManager as unknown as {
-      stakeOf(address: string, role: number): Promise<bigint>;
+  const jobRegistryContract: JobRegistryContract = {
+    on: (event, listener) => {
+      jobRegistry.on(event, listener);
     },
+  };
+  const stakeManagerContract: StakeManagerContract = {
+    stakeOf: (address, role) => stakeManager.stakeOf(address, role),
+  };
+  setupJobListener(
+    jobRegistryContract,
+    stakeManagerContract,
     AGENT_ADDRESS,
     onJobDetected
   );
@@ -96,7 +132,7 @@ export async function start(
 
 export async function defaultCallback(
   jobId: string,
-  details: any
+  details: JobCreatedDetails
 ): Promise<void> {
   if (!ORCHESTRATOR_ENDPOINT) return;
   await fetch(ORCHESTRATOR_ENDPOINT, {

--- a/apps/orchestrator/learning.ts
+++ b/apps/orchestrator/learning.ts
@@ -74,7 +74,13 @@ function toBigIntOrNull(value: unknown): bigint | null {
   if (value === null || value === undefined) return null;
   try {
     if (typeof value === 'bigint') return value;
-    return ethers.getBigInt(value as any);
+    if (typeof value === 'string' || typeof value === 'number') {
+      return ethers.getBigInt(value);
+    }
+    if (value instanceof Uint8Array) {
+      return ethers.getBigInt(value);
+    }
+    return null;
   } catch {
     return null;
   }

--- a/apps/orchestrator/oneboxRouter.ts
+++ b/apps/orchestrator/oneboxRouter.ts
@@ -78,6 +78,10 @@ function errorMessage(error: unknown): string {
   return typeof error === 'string' ? error : 'Unexpected error';
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 function statusFromError(error: unknown): number {
   if (error instanceof HttpError) return error.status;
   if (error && typeof (error as { status?: number }).status === 'number') {
@@ -1134,8 +1138,8 @@ async function decoratePlanResponse(response: OneboxPlanResponse): Promise<PlanR
     warnings: response.warnings,
     planHash: response.planHash,
   };
-  if (Array.isArray((response as any).missingFields)) {
-    metadata.missingFields = (response as any).missingFields;
+  if (isRecord(response) && Array.isArray(response.missingFields)) {
+    metadata.missingFields = response.missingFields;
   }
   const createdAt = new Date().toISOString();
   const attested = await decorateReceipt('PLAN', metadata, {
@@ -1829,8 +1833,13 @@ export function decodePackedJobMetadata(
     value = BigInt(packed);
   } else if (typeof packed === 'string') {
     value = BigInt(packed);
-  } else if (typeof (packed as any).toString === 'function') {
-    value = BigInt((packed as any).toString());
+  } else if (
+    typeof packed === 'object' &&
+    packed !== null &&
+    'toString' in packed &&
+    typeof packed.toString === 'function'
+  ) {
+    value = BigInt(packed.toString());
   } else {
     return {};
   }
@@ -1890,7 +1899,7 @@ function formatReward(value: unknown, decimals: number): string | undefined {
         ? value
         : typeof value === 'number'
         ? BigInt(value)
-        : BigInt(value as any);
+        : BigInt(String(value));
     return ethers.formatUnits(amount, decimals);
   } catch {
     return undefined;

--- a/apps/orchestrator/service.ts
+++ b/apps/orchestrator/service.ts
@@ -150,7 +150,33 @@ const JOB_AGENT_PCT_MASK = 0xffffffffn << JOB_AGENT_PCT_OFFSET;
 const JOB_DEADLINE_MASK = 0xffffffffffffffffn << JOB_DEADLINE_OFFSET;
 const JOB_ASSIGNED_AT_MASK = 0xffffffffffffffffn << JOB_ASSIGNED_AT_OFFSET;
 
-function decodePackedJobMetadata(packed: any): {
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const toStringValue = (value: unknown): string | undefined => {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value.toString();
+  }
+  if (typeof value === 'bigint') return value.toString();
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'toString' in value &&
+    typeof value.toString === 'function'
+  ) {
+    try {
+      const result = value.toString();
+      return typeof result === 'string' ? result : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+};
+
+function decodePackedJobMetadata(packed: unknown): {
   state?: number;
   success?: boolean;
   burnConfirmed?: boolean;
@@ -170,8 +196,13 @@ function decodePackedJobMetadata(packed: any): {
     value = BigInt(packed);
   } else if (typeof packed === 'string') {
     value = BigInt(packed);
-  } else if (typeof (packed as any).toString === 'function') {
-    value = BigInt((packed as any).toString());
+  } else if (
+    typeof packed === 'object' &&
+    packed !== null &&
+    'toString' in packed &&
+    typeof packed.toString === 'function'
+  ) {
+    value = BigInt(packed.toString());
   } else {
     return {};
   }
@@ -726,7 +757,7 @@ export class MetaOrchestrator {
     if (!identity) return;
     this.fallbackSelections.add(jobKey);
     const wallet = identity.wallet.connect(this.provider);
-    const writer = this.validationModule.connect(wallet) as any;
+    const writer = this.validationModule.connect(wallet);
     const entropy = ethers.hexlify(ethers.randomBytes(32));
     try {
       const tx = await writer.selectValidators(jobId, entropy);
@@ -887,7 +918,7 @@ export class MetaOrchestrator {
     if (this.stakeManager) {
       await ensureStake(wallet, requirements.stake, this.provider);
     }
-    const registry = this.registry.connect(wallet) as any;
+    const registry = this.registry.connect(wallet);
     const subdomain = toSubdomain(identity);
     const tx = await registry.applyForJob(summary.jobId, subdomain, []);
     await tx.wait();
@@ -939,16 +970,21 @@ export class MetaOrchestrator {
   private async executeAssignedJob(
     jobId: string,
     state: AppliedJobState,
-    chainJob: any
+    chainJob: unknown
   ): Promise<void> {
+    const chainJobRecord = isRecord(chainJob) ? chainJob : {};
+    const employer =
+      typeof chainJobRecord.employer === 'string' ? chainJobRecord.employer : undefined;
+    const reward = toStringValue(chainJobRecord.reward);
+    const stake = toStringValue(chainJobRecord.stake);
     auditLog('job.assigned', {
       jobId,
       actor: state.identity.address,
       details: {
         category: state.classification.category,
-        employer: chainJob.employer,
-        reward: chainJob.reward?.toString?.(),
-        stake: chainJob.stake?.toString?.(),
+        employer,
+        reward,
+        stake,
       },
     });
     const pipelineContext: PipelineContext = {
@@ -966,9 +1002,9 @@ export class MetaOrchestrator {
       spec: state.spec,
       classification: state.classification,
       onChain: {
-        reward: chainJob.reward?.toString?.(),
-        stake: chainJob.stake?.toString?.(),
-        employer: chainJob.employer,
+        reward,
+        stake,
+        employer,
       },
     };
     try {
@@ -1152,7 +1188,7 @@ export class MetaOrchestrator {
       ['uint256', 'uint256', 'bool', 'bytes32'],
       [jobId, nonce, approve, salt]
     );
-    const writer = this.validationModule.connect(wallet) as any;
+    const writer = this.validationModule.connect(wallet);
     const tx = await writer.commitValidation(jobId, commitHash, '', []);
     await tx.wait();
     auditLog('validator.commit', {
@@ -1178,7 +1214,7 @@ export class MetaOrchestrator {
     const key = `${jobId.toString()}:${identity.address.toLowerCase()}`;
     const data = this.commits.get(key);
     if (!data) return;
-    const writer = this.validationModule.connect(data.wallet) as any;
+    const writer = this.validationModule.connect(data.wallet);
     const tx = await writer.revealValidation(
       jobId,
       data.approve,
@@ -1199,41 +1235,25 @@ export class MetaOrchestrator {
     this.commitTimers.delete(key);
   }
 
-  private normaliseChainJob(job: any): OnChainJobSnapshot {
-    const toString = (value: any): string | undefined => {
-      if (value === null || value === undefined) return undefined;
-      if (typeof value === 'string') return value;
-      if (typeof value === 'number' && Number.isFinite(value)) {
-        return value.toString();
-      }
-      if (typeof value === 'bigint') return value.toString();
-      try {
-        if (typeof value.toString === 'function') {
-          const result = value.toString();
-          return typeof result === 'string' ? result : undefined;
-        }
-      } catch {
-        return undefined;
-      }
-      return undefined;
-    };
-    const metadata = decodePackedJobMetadata(job?.packedMetadata);
+  private normaliseChainJob(job: unknown): OnChainJobSnapshot {
+    const record = isRecord(job) ? job : {};
+    const metadata = decodePackedJobMetadata(record.packedMetadata);
     return {
-      employer: job?.employer,
-      agent: job?.agent,
-      reward: toString(job?.reward),
-      stake: toString(job?.stake),
-      feePct: toString(metadata.feePct),
-      agentPct: toString(metadata.agentPct),
+      employer: typeof record.employer === 'string' ? record.employer : undefined,
+      agent: typeof record.agent === 'string' ? record.agent : undefined,
+      reward: toStringValue(record.reward),
+      stake: toStringValue(record.stake),
+      feePct: toStringValue(metadata.feePct),
+      agentPct: toStringValue(metadata.agentPct),
       state: metadata.state,
       success: Boolean(metadata.success),
-      assignedAt: toString(metadata.assignedAt),
-      deadline: toString(metadata.deadline),
+      assignedAt: toStringValue(metadata.assignedAt),
+      deadline: toStringValue(metadata.deadline),
       agentTypes: metadata.agentTypes,
-      resultHash: toString(job?.resultHash),
-      specHash: toString(job?.specHash),
-      uriHash: toString(job?.uriHash),
-      burnReceiptAmount: toString(job?.burnReceiptAmount),
+      resultHash: toStringValue(record.resultHash),
+      specHash: toStringValue(record.specHash),
+      uriHash: toStringValue(record.uriHash),
+      burnReceiptAmount: toStringValue(record.burnReceiptAmount),
     };
   }
 
@@ -1242,7 +1262,7 @@ export class MetaOrchestrator {
     state: AppliedJobState,
     runResult: JobRunResult,
     resultRef: string,
-    chainJob: any
+    chainJob: unknown
   ): void {
     const agentProfile = {
       address: state.identity.address,

--- a/apps/orchestrator/signing.ts
+++ b/apps/orchestrator/signing.ts
@@ -114,10 +114,10 @@ function normalizeValue(value: unknown): unknown {
       .map((item) => normalizeValue(item))
       .sort();
   if (typeof value === 'object') {
-    if (typeof (value as any).toJSON === 'function') {
-      return normalizeValue((value as any).toJSON());
+    if ('toJSON' in value && typeof value.toJSON === 'function') {
+      return normalizeValue(value.toJSON());
     }
-    const entries = Object.entries(value as Record<string, unknown>);
+    const entries = Object.entries(value);
     entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
     const normalized: Record<string, unknown> = {};
     for (const [key, val] of entries) {

--- a/apps/validator-ui/pages/attest.tsx
+++ b/apps/validator-ui/pages/attest.tsx
@@ -12,11 +12,11 @@ export default function AttestPage() {
 
   async function send(action: 'attest' | 'revoke') {
     try {
-      if (!(window as any).ethereum) {
+      if (!window.ethereum) {
         setError('wallet not found');
         return;
       }
-      const provider = new ethers.BrowserProvider((window as any).ethereum);
+      const provider = new ethers.BrowserProvider(window.ethereum);
       const signer = await provider.getSigner();
       const addr = await signer.getAddress();
       const warning = await verifyEnsSubdomain(provider, addr);

--- a/apps/validator-ui/pages/index.tsx
+++ b/apps/validator-ui/pages/index.tsx
@@ -24,6 +24,29 @@ export default function Home() {
   const [message, setMessage] = useState('');
   const { setError } = useError();
 
+  const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null;
+
+  const formatUnitsValue = (value: unknown) => {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint') {
+      return ethers.formatUnits(value, DECIMALS);
+    }
+    return ethers.formatUnits(0, DECIMALS);
+  };
+
+  const toJobId = (value: unknown): string => {
+    if (typeof value === 'string' && value.trim()) {
+      return value;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value.toString();
+    }
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+    return '';
+  };
+
   useEffect(() => {
     async function loadJobs() {
       try {
@@ -49,20 +72,38 @@ export default function Home() {
         );
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), timeout);
-        const data = await fetch(`${url}/jobs`, { signal: controller.signal })
+        const data: unknown = await fetch(`${url}/jobs`, { signal: controller.signal })
           .then((res) => res.json())
           .finally(() => clearTimeout(timer));
-        setJobs(
-          data.map((job: any) => ({
-            ...job,
-            reward: ethers.formatUnits(job.rewardRaw ?? job.reward, DECIMALS),
-            stake: ethers.formatUnits(job.stakeRaw ?? job.stake, DECIMALS),
-            fee: ethers.formatUnits(job.feeRaw ?? job.fee, DECIMALS),
-            specHash: job.specHash ?? ethers.ZeroHash,
-          }))
-        );
-      } catch (err: any) {
-        if (err.name === 'AbortError') {
+        if (!Array.isArray(data)) {
+          setJobs([]);
+          setMessage('No jobs available');
+          return;
+        }
+        const parsedJobs = data
+          .map((entry) => {
+            if (!isRecord(entry)) {
+              return null;
+            }
+            const jobId = toJobId(entry.jobId);
+            if (!jobId) {
+              return null;
+            }
+            return {
+              jobId,
+              employer: String(entry.employer ?? ''),
+              agent: String(entry.agent ?? ''),
+              reward: formatUnitsValue(entry.rewardRaw ?? entry.reward),
+              stake: formatUnitsValue(entry.stakeRaw ?? entry.stake),
+              fee: formatUnitsValue(entry.feeRaw ?? entry.fee),
+              specHash:
+                typeof entry.specHash === 'string' ? entry.specHash : ethers.ZeroHash,
+            } satisfies Job;
+          })
+          .filter((entry): entry is Job => entry !== null);
+        setJobs(parsedJobs);
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
           console.error('Job fetch timed out');
           setMessage('Job request timed out');
         } else {
@@ -74,11 +115,11 @@ export default function Home() {
   }, []);
 
   async function vote(jobId: string, approve: boolean, specHash: string) {
-    if (!(window as any).ethereum) {
+    if (!window.ethereum) {
       setError('wallet not found');
       return;
     }
-    const provider = new ethers.BrowserProvider((window as any).ethereum);
+    const provider = new ethers.BrowserProvider(window.ethereum);
     const signer = await provider.getSigner();
     const addr = await signer.getAddress();
     const warning = await verifyEnsSubdomain(provider, addr);

--- a/apps/validator-ui/types/ethereum.d.ts
+++ b/apps/validator-ui/types/ethereum.d.ts
@@ -1,0 +1,9 @@
+import type { Eip1193Provider } from 'ethers';
+
+declare global {
+  interface Window {
+    ethereum?: Eip1193Provider;
+  }
+}
+
+export {};

--- a/apps/validator/index.ts
+++ b/apps/validator/index.ts
@@ -120,7 +120,10 @@ const JOB_AGENT_PCT_MASK = 0xffffffffn << JOB_AGENT_PCT_OFFSET;
 const JOB_DEADLINE_MASK = 0xffffffffffffffffn << JOB_DEADLINE_OFFSET;
 const JOB_ASSIGNED_AT_MASK = 0xffffffffffffffffn << JOB_ASSIGNED_AT_OFFSET;
 
-function decodePackedJobMetadata(packed: any): {
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+function decodePackedJobMetadata(packed: unknown): {
   state?: number;
   success?: boolean;
   burnConfirmed?: boolean;
@@ -140,8 +143,13 @@ function decodePackedJobMetadata(packed: any): {
     value = BigInt(packed);
   } else if (typeof packed === 'string') {
     value = BigInt(packed);
-  } else if (typeof (packed as any).toString === 'function') {
-    value = BigInt((packed as any).toString());
+  } else if (
+    typeof packed === 'object' &&
+    packed !== null &&
+    'toString' in packed &&
+    typeof packed.toString === 'function'
+  ) {
+    value = BigInt(packed.toString());
   } else {
     return {};
   }
@@ -383,19 +391,22 @@ async function fetchSubmissionEvent(jobId: bigint): Promise<SubmissionRecord> {
     throw new Error('No submission events found');
   }
   const evt = events[events.length - 1] as EventLog;
-  const args = evt.args as any;
+  const args = evt.args;
+  const argsRecord = isRecord(args) ? args : {};
+  const argsArray = Array.isArray(args) ? args : [];
   const worker: string =
-    (args?.worker as string) ??
-    (Array.isArray(args) ? args[1] : ethers.ZeroAddress);
+    (typeof argsRecord.worker === 'string' && argsRecord.worker) ||
+    (typeof argsArray[1] === 'string' ? argsArray[1] : ethers.ZeroAddress);
   const resultHash: string =
-    (args?.resultHash as string) ??
-    (Array.isArray(args) ? args[2] : ethers.ZeroHash);
+    (typeof argsRecord.resultHash === 'string' && argsRecord.resultHash) ||
+    (typeof argsArray[2] === 'string' ? argsArray[2] : ethers.ZeroHash);
   const resultUri: string =
-    (args?.resultURI as string) ??
-    (args?.resultUri as string) ??
-    (Array.isArray(args) ? args[3] : '');
+    (typeof argsRecord.resultURI === 'string' && argsRecord.resultURI) ||
+    (typeof argsRecord.resultUri === 'string' && argsRecord.resultUri) ||
+    (typeof argsArray[3] === 'string' ? argsArray[3] : '');
   const subdomain: string | undefined =
-    (args?.subdomain as string) ?? (Array.isArray(args) ? args[4] : undefined);
+    (typeof argsRecord.subdomain === 'string' && argsRecord.subdomain) ||
+    (typeof argsArray[4] === 'string' ? argsArray[4] : undefined);
   return {
     jobId: jobId.toString(),
     worker,
@@ -558,8 +569,11 @@ async function getBurnTxHash(jobId: bigint): Promise<string> {
   const events = await registry.queryFilter(filter, 0, 'latest');
   if (events.length === 0) return ethers.ZeroHash;
   const evt = events[events.length - 1] as EventLog;
-  const args = evt.args as any;
-  return (args?.burnTxHash as string) ?? ethers.ZeroHash;
+  const args = evt.args;
+  if (isRecord(args) && typeof args.burnTxHash === 'string') {
+    return args.burnTxHash;
+  }
+  return ethers.ZeroHash;
 }
 
 async function handleValidatorsSelected(jobId: bigint, validators: string[]) {
@@ -593,7 +607,7 @@ async function handleValidatorsSelected(jobId: bigint, validators: string[]) {
     [jobId, nonce, approve, burnTxHash, salt, specHash]
   );
 
-  const writer = validation.connect(wallet) as any;
+  const writer = validation.connect(wallet);
   const tx = await writer.commitValidation(jobId, commitHash, personaLabel, []);
   await tx.wait();
 
@@ -693,7 +707,7 @@ async function reveal(jobId: bigint) {
   const file = storagePath(jobId, address);
   if (!fs.existsSync(file)) return;
   const data = JSON.parse(fs.readFileSync(file, 'utf8')) as StoredCommit;
-  const writer = validation.connect(wallet) as any;
+  const writer = validation.connect(wallet);
   const tx = await writer.revealValidation(
     jobId,
     data.approve,
@@ -820,10 +834,11 @@ async function markDisputeResolution(
   employerWins: boolean
 ) {
   const file = disputePath(jobId, validatorAddress);
-  let existing: any = null;
+  let existing: Record<string, unknown> | null = null;
   if (fs.existsSync(file)) {
     try {
-      existing = JSON.parse(fs.readFileSync(file, 'utf8'));
+      const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+      existing = isRecord(parsed) ? parsed : null;
     } catch (err) {
       console.warn('Failed to read existing dispute record', err);
     }

--- a/contracts/v2/JobRegistry.sol
+++ b/contracts/v2/JobRegistry.sol
@@ -16,7 +16,6 @@ import {ICertificateNFT} from "./interfaces/ICertificateNFT.sol";
 import {IJobRegistryAck} from "./interfaces/IJobRegistryAck.sol";
 import {IAuditModule} from "./interfaces/IAuditModule.sol";
 import {TOKEN_SCALE} from "./Constants.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @title JobRegistry
 /// @notice Coordinates job lifecycle and external modules.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,7 +48,7 @@ module.exports = [
     rules: {
       ...tsPlugin.configs.recommended.rules,
       '@typescript-eslint/no-unused-vars': 'warn',
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'error',
       'prettier/prettier': 'error',
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
@@ -58,11 +58,14 @@ module.exports = [
     files: [
       'examples/**/*.{js,ts,tsx}',
       'test/**/*.{js,ts,tsx}',
+      'tests/**/*.{js,ts,tsx}',
+      'demo/**/*.{js,ts,tsx}',
       'scripts/**/*.ts',
     ],
     rules: {
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
     },
   },
 ];

--- a/packages/onebox-orchestrator/src/ics/schema.ts
+++ b/packages/onebox-orchestrator/src/ics/schema.ts
@@ -175,7 +175,7 @@ const AdminSetIntentSchema = baseIntentSchema.extend({
     key: z
       .string({ invalid_type_error: 'Admin setting key must be provided' })
       .min(1),
-    value: z.any(),
+    value: z.unknown(),
   }),
 });
 

--- a/packages/onebox-sdk/src/types.ts
+++ b/packages/onebox-sdk/src/types.ts
@@ -14,13 +14,13 @@ export const JobIntentSchema = z.object({
   deadline_days: z.number().int().nonnegative().optional(),
   job_id: z.number().int().optional(),
   attachments: z.array(AttachmentSchema).default([]),
-  constraints: z.record(z.any()).default({}),
+  constraints: z.record(z.unknown()).default({}),
 });
 
 export const StepOutputSchema = z.object({
   cid: z.string().optional(),
   tx: z.string().optional(),
-  data: z.record(z.any()).optional(),
+  data: z.record(z.unknown()).optional(),
 });
 
 export const StepSchema = z.object({
@@ -28,7 +28,7 @@ export const StepSchema = z.object({
   name: z.string(),
   kind: z.enum(['plan', 'pin', 'chain', 'llm', 'code', 'fetch', 'validate', 'finalize']),
   tool: z.string().optional(),
-  params: z.record(z.any()).default({}),
+  params: z.record(z.unknown()).default({}),
   needs: z.array(z.string()).default([]),
   out: StepOutputSchema.optional(),
 });
@@ -58,7 +58,7 @@ export const PlanResponseSchema = z.object({
   preview_summary: z.string(),
   warnings: z.array(z.string()).default([]),
   requiresConfirmation: z.boolean().default(true),
-  receipt: z.record(z.any()).optional(),
+  receipt: z.record(z.unknown()).optional(),
   receiptDigest: z.string().optional(),
   receiptAttestationUid: z.string().optional(),
   receiptAttestationTxHash: z.string().optional(),
@@ -82,7 +82,7 @@ export const SimulationResponseSchema = z.object({
   risks: z.array(z.string()).default([]),
   confirmations: z.array(z.string()).default([]),
   blockers: z.array(z.string()).default([]),
-  receipt: z.record(z.any()).optional(),
+  receipt: z.record(z.unknown()).optional(),
   receiptDigest: z.string().optional(),
   receiptAttestationUid: z.string().optional(),
   receiptAttestationTxHash: z.string().optional(),
@@ -115,8 +115,8 @@ export const ReceiptSchema = z.object({
   job_id: z.number().optional(),
   txes: z.array(z.string()).default([]),
   cids: z.array(z.string()).default([]),
-  payouts: z.array(z.record(z.any())).default([]),
-  timings: z.record(z.any()).default({}),
+  payouts: z.array(z.record(z.unknown())).default([]),
+  timings: z.record(z.unknown()).default({}),
 });
 
 export const StatusResponseSchema = z.object({
@@ -145,7 +145,7 @@ export const ExecuteResponseSchema = z.object({
   run_id: z.string(),
   started_at: z.number().optional(),
   plan_id: z.string(),
-  receipt: z.record(z.any()).optional(),
+  receipt: z.record(z.unknown()).optional(),
   receiptDigest: z.string().optional(),
   receiptAttestationUid: z.string().optional(),
   receiptAttestationTxHash: z.string().optional(),
@@ -191,4 +191,3 @@ export function parseStatusResponse(value: unknown): StatusResponse {
 export function parseExecuteResponse(value: unknown): ExecuteResponse {
   return ExecuteResponseSchema.parse(value);
 }
-

--- a/packages/orchestrator/src/ics.ts
+++ b/packages/orchestrator/src/ics.ts
@@ -46,7 +46,7 @@ const CreateJobIntentSchema = z
       job: z.object({
         rewardAGIA: amountSchema,
         deadline: deadlineSchema,
-        spec: z.record(z.any()),
+        spec: z.record(z.unknown()),
         title: z.string().optional(),
       }),
     }),
@@ -70,7 +70,7 @@ const SubmitWorkIntentSchema = z
       jobId: jobIdSchema,
       result: z
         .object({
-          payload: z.record(z.any()).optional(),
+          payload: z.record(z.unknown()).optional(),
           uri: z.string().optional(),
           hash: bytes32Schema.optional(),
         })
@@ -120,21 +120,21 @@ const WithdrawIntentSchema = z
 const ValidateIntentSchema = z
   .object({
     intent: z.literal("validate"),
-    params: z.record(z.any()).default({}),
+    params: z.record(z.unknown()).default({}),
   })
   .extend(baseFields);
 
 const DisputeIntentSchema = z
   .object({
     intent: z.literal("dispute"),
-    params: z.record(z.any()).default({}),
+    params: z.record(z.unknown()).default({}),
   })
   .extend(baseFields);
 
 const AdminSetIntentSchema = z
   .object({
     intent: z.literal("admin_set"),
-    params: z.record(z.any()).default({}),
+    params: z.record(z.unknown()).default({}),
   })
   .extend(baseFields);
 

--- a/packages/orchestrator/src/tools/dispute.ts
+++ b/packages/orchestrator/src/tools/dispute.ts
@@ -98,44 +98,46 @@ function callRaiseDispute(
   }
 
   if (params.evidenceHash) {
-    const method =
-      (jobRegistry as unknown as Record<string, unknown>)[
-        "raiseDispute(uint256,bytes32)"
-      ];
+    const method = Reflect.get(jobRegistry, "raiseDispute(uint256,bytes32)");
     if (typeof method !== "function") {
       throw new Error("raiseDispute(uint256,bytes32) overload unavailable");
     }
     const args: unknown[] = [params.jobId, params.evidenceHash];
     if (mode === "populate") {
+      const populate = Reflect.get(method, "populateTransaction");
+      if (typeof populate !== "function") {
+        throw new Error("raiseDispute populateTransaction unavailable");
+      }
       return hasOverrides
-        ? (method as any).populateTransaction(...args, overrides)
-        : (method as any).populateTransaction(...args);
+        ? populate(...args, overrides)
+        : populate(...args);
     }
     return hasOverrides
-      ? (method as any)(...args, overrides)
-      : (method as any)(...args);
+      ? method(...args, overrides)
+      : method(...args);
   }
 
   if (!params.reason) {
     throw new Error("Dispute intent requires textual reason or evidence hash");
   }
 
-  const method =
-    (jobRegistry as unknown as Record<string, unknown>)[
-      "raiseDispute(uint256,string)"
-    ];
+  const method = Reflect.get(jobRegistry, "raiseDispute(uint256,string)");
   if (typeof method !== "function") {
     throw new Error("raiseDispute(uint256,string) overload unavailable");
   }
   const args: unknown[] = [params.jobId, params.reason];
   if (mode === "populate") {
+    const populate = Reflect.get(method, "populateTransaction");
+    if (typeof populate !== "function") {
+      throw new Error("raiseDispute populateTransaction unavailable");
+    }
     return hasOverrides
-      ? (method as any).populateTransaction(...args, overrides)
-      : (method as any).populateTransaction(...args);
+      ? populate(...args, overrides)
+      : populate(...args);
   }
   return hasOverrides
-    ? (method as any)(...args, overrides)
-    : (method as any)(...args);
+    ? method(...args, overrides)
+    : method(...args);
 }
 
 export async function disputeDryRun(ics: ICSType): Promise<DryRunResult> {

--- a/packages/orchestrator/test/chainProviders.test.ts
+++ b/packages/orchestrator/test/chainProviders.test.ts
@@ -12,11 +12,13 @@ import {
   __resetAAConfigForTests,
   type AccountAbstractionConfig,
 } from "../src/chain/providers/aa.js";
+import type { BundlerClient } from "../src/chain/providers/bundler.js";
 import {
   MetaTxSigner,
   __resetForwarderConfigForTests,
 } from "../src/chain/providers/metaTx.js";
 import type { ManagedPaymasterClient } from "../src/chain/providers/paymaster.js";
+import type { UserOperationStruct } from "../src/chain/providers/userOperation.js";
 
 const relayerMnemonic = "test test test test test test test test test test test junk";
 const aaMnemonic = "test walk nut penalty hip pave soap entry language right filter choice";
@@ -41,6 +43,23 @@ function restoreEnv(entries: { key: string; value: string | undefined }[]) {
     }
   }
 }
+
+type AccountAbstractionSignerHarness = AccountAbstractionSigner & {
+  bundler: BundlerClient;
+  resolveInitCode: (sender?: string) => Promise<string>;
+  resolveNonce: (sender?: string) => Promise<bigint>;
+  ensureChainId: () => Promise<bigint>;
+  resolveFeeData: () => Promise<{ maxFee: bigint; maxPriority: bigint }>;
+  estimateCallGas: () => Promise<{
+    callGasLimit: bigint;
+    preVerificationGas: bigint;
+    verificationGasLimit: bigint;
+  }>;
+  buildUserOperation: (
+    tx: ethers.TransactionRequest,
+    policyContext?: Record<string, unknown>
+  ) => Promise<{ userOp: UserOperationStruct; charge: unknown }>;
+};
 
 class MockProvider extends ethers.AbstractProvider {
   public readonly estimateGasCalls: ethers.TransactionRequest[] = [];
@@ -212,6 +231,7 @@ test("aa signer falls back to bundler gas estimates for undeployed accounts", as
   };
 
   const signer = new AccountAbstractionSigner(wallet, config);
+  const signerHarness = signer as AccountAbstractionSignerHarness;
 
   let bundlerCalled = false;
   const bundlerEstimates = {
@@ -220,21 +240,21 @@ test("aa signer falls back to bundler gas estimates for undeployed accounts", as
     verificationGasLimit: 120_000n,
   };
 
-  const bundlerClient = (signer as any).bundler;
+  const bundlerClient = signerHarness.bundler;
   bundlerClient.estimateUserOperationGas = async () => {
     bundlerCalled = true;
     return bundlerEstimates;
   };
 
-  (signer as any).resolveInitCode = async () => "0x1234";
-  (signer as any).resolveNonce = async () => 0n;
+  signerHarness.resolveInitCode = async () => "0x1234";
+  signerHarness.resolveNonce = async () => 0n;
 
   const tx: ethers.TransactionRequest = {
     to: wallet.address,
     data: "0x",
   };
 
-  const result = await (signer as any).buildUserOperation(tx);
+  const result = await signerHarness.buildUserOperation(tx);
   const userOp = result.userOp;
 
   assert.equal(bundlerCalled, true);
@@ -271,12 +291,13 @@ test("aa signer forwards policy context to managed paymaster", async () => {
   };
 
   const signer = new AccountAbstractionSigner(wallet, config);
+  const signerHarness = signer as AccountAbstractionSignerHarness;
 
-  (signer as any).resolveInitCode = async () => "0x";
-  (signer as any).resolveNonce = async () => 0n;
-  (signer as any).ensureChainId = async () => 1n;
-  (signer as any).resolveFeeData = async () => ({ maxFee: 1n, maxPriority: 1n });
-  (signer as any).estimateCallGas = async () => ({
+  signerHarness.resolveInitCode = async () => "0x";
+  signerHarness.resolveNonce = async () => 0n;
+  signerHarness.ensureChainId = async () => 1n;
+  signerHarness.resolveFeeData = async () => ({ maxFee: 1n, maxPriority: 1n });
+  signerHarness.estimateCallGas = async () => ({
     callGasLimit: 1000n,
     preVerificationGas: config.preVerificationGas,
     verificationGasLimit: config.verificationGasLimit,
@@ -294,7 +315,7 @@ test("aa signer forwards policy context to managed paymaster", async () => {
     gasLimit: 1000n,
   };
 
-  await (signer as any).buildUserOperation(tx, policyContext);
+  await signerHarness.buildUserOperation(tx, policyContext);
 
   assert.equal(paymasterCalls.length, 1);
   const context = paymasterCalls[0].context ?? {};
@@ -484,12 +505,15 @@ test("meta-tx signer falls back to a conservative gas ceiling when estimation fa
     const relayer = randomWallet().connect(provider);
     const signer = new MetaTxSigner(user, relayer);
 
-    let capturedRequest: any;
+    let capturedRequest: Record<string, unknown> | null = null;
     const forwarderStub = {
       getNonce: async () => 1n,
       getFunction: () => ({
         populateTransaction: async (request: unknown) => {
-          capturedRequest = request;
+          capturedRequest =
+            typeof request === "object" && request !== null
+              ? (request as Record<string, unknown>)
+              : null;
           return {
             to: forwarderAddress,
             data: "0x",

--- a/packages/orchestrator/test/e2e/accountAbstraction.e2e.test.ts
+++ b/packages/orchestrator/test/e2e/accountAbstraction.e2e.test.ts
@@ -241,7 +241,7 @@ class MockMetaProvider extends ethers.AbstractProvider {
 }
 
 class MockForwarder {
-  public readonly requests: Array<{ request: any; signature: string }> = [];
+  public readonly requests: Array<{ request: Record<string, unknown>; signature: string }> = [];
 
   constructor(private readonly scenario: OptimismScenario & { userAddress: string }) {}
 
@@ -255,7 +255,11 @@ class MockForwarder {
     }
     return {
       populateTransaction: async (request: unknown, signature: string) => {
-        this.requests.push({ request, signature });
+        const record =
+          typeof request === 'object' && request !== null
+            ? (request as Record<string, unknown>)
+            : {};
+        this.requests.push({ request: record, signature });
         return {
           to: this.scenario.forwarder.address,
           data: this.scenario.metaTx.execute.data,

--- a/services/arena/src/validators.ts
+++ b/services/arena/src/validators.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const startRoundSchema = z.object({
   contestantIds: z.array(z.string().min(1)).min(1),
   validatorIds: z.array(z.string().min(1)).min(1),
-  roundMetadata: z.record(z.any()).optional(),
+  roundMetadata: z.record(z.unknown()).optional(),
   targetDurationSeconds: z.number().int().positive().max(3600).optional()
 });
 
@@ -16,6 +16,6 @@ export const commitSchema = z.object({
 export const revealSchema = z.object({
   roundId: z.string().min(1),
   agentId: z.string().min(1),
-  submission: z.any(),
+  submission: z.unknown(),
   proof: z.string().min(5)
 });

--- a/services/arena/test/__mocks__/prisma-client.ts
+++ b/services/arena/test/__mocks__/prisma-client.ts
@@ -49,11 +49,97 @@ type RoundLogRecord = {
   createdAt: Date;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+type AgentUpsertArgs = {
+  where: { id: string };
+  create: Partial<AgentRecord>;
+};
+
+type AgentFindManyArgs = {
+  orderBy?: { rating?: 'asc' | 'desc' };
+  take?: number;
+};
+
+type AgentUpdateArgs = {
+  where: { id: string };
+  data: Partial<AgentRecord>;
+};
+
+type RoundCreateArgs = {
+  data: {
+    state: RoundState;
+    targetDuration: number;
+    commitDeadline?: Date | null;
+    revealDeadline?: Date | null;
+    startedAt?: Date | null;
+    closedAt?: Date | null;
+    metadata?: Record<string, unknown> | null;
+    ipfsSnapshotCid?: string | null;
+  };
+};
+
+type RoundFindUniqueArgs = {
+  where: { id: string };
+  include?: { committee?: { include?: { agent?: boolean } } };
+};
+
+type RoundUpdateArgs = {
+  where: { id: string };
+  data: Partial<RoundRecord>;
+};
+
+type CommitteeCreateManyArgs = {
+  data: Array<{
+    roundId: string;
+    agentId: string;
+    role: CommitteeRole;
+    commitHash?: string | null;
+  }>;
+};
+
+type CommitteeUpdateArgs = {
+  where: { id: string };
+  data: Partial<CommitteeRecord>;
+};
+
+type RoundLogCreateArgs = {
+  data: {
+    roundId: string;
+    level: string;
+    message: string;
+    context?: unknown;
+  };
+};
+
 export class MockPrismaClient {
-  readonly agent: any;
-  readonly round: any;
-  readonly committeeMember: any;
-  readonly roundLog: any;
+  readonly agent: {
+    upsert: (args: AgentUpsertArgs) => Promise<AgentRecord>;
+    findMany: (args?: AgentFindManyArgs) => Promise<AgentRecord[]>;
+    update: (args: AgentUpdateArgs) => Promise<AgentRecord>;
+  };
+  readonly round: {
+    create: (args: RoundCreateArgs) => Promise<RoundRecord>;
+    findUnique: (
+      args: RoundFindUniqueArgs
+    ) => Promise<
+      | (RoundRecord & {
+          committee?: Array<
+            CommitteeRecord & { agent?: AgentRecord | null }
+          >;
+        })
+      | null
+    >;
+    update: (args: RoundUpdateArgs) => Promise<RoundRecord>;
+  };
+  readonly committeeMember: {
+    createMany: (args: CommitteeCreateManyArgs) => Promise<{ count: number }>;
+    update: (args: CommitteeUpdateArgs) => Promise<CommitteeRecord>;
+  };
+  readonly roundLog: {
+    create: (args: RoundLogCreateArgs) => Promise<RoundLogRecord>;
+  };
   private readonly agents = new Map<string, AgentRecord>();
   private readonly rounds = new Map<string, RoundRecord>();
   private readonly committees = new Map<string, CommitteeRecord>();
@@ -61,7 +147,7 @@ export class MockPrismaClient {
 
   constructor() {
     this.agent = {
-      upsert: async ({ where, create }: any) => {
+      upsert: async ({ where, create }: AgentUpsertArgs) => {
         const id = where.id;
         const existing = this.agents.get(id);
         if (existing) {
@@ -80,7 +166,7 @@ export class MockPrismaClient {
         this.agents.set(id, record);
         return record;
       },
-      findMany: async ({ orderBy, take }: any = {}) => {
+      findMany: async ({ orderBy, take }: AgentFindManyArgs = {}) => {
         const items = Array.from(this.agents.values());
         if (orderBy?.rating === 'desc') {
           items.sort((a, b) => b.rating - a.rating);
@@ -90,7 +176,7 @@ export class MockPrismaClient {
         }
         return items;
       },
-      update: async ({ where, data }: any) => {
+      update: async ({ where, data }: AgentUpdateArgs) => {
         const record = this.agents.get(where.id);
         if (!record) throw new Error('Agent not found');
         Object.assign(record, data, { updatedAt: new Date() });
@@ -99,7 +185,7 @@ export class MockPrismaClient {
     };
 
     this.round = {
-      create: async ({ data }: any) => {
+      create: async ({ data }: RoundCreateArgs) => {
         const id = crypto.randomUUID();
         const record: RoundRecord = {
           id,
@@ -110,7 +196,7 @@ export class MockPrismaClient {
           revealDeadline: data.revealDeadline ?? null,
           startedAt: data.startedAt ?? null,
           closedAt: data.closedAt ?? null,
-          metadata: (data.metadata ?? null) as Record<string, unknown> | null,
+          metadata: isRecord(data.metadata) ? data.metadata : null,
           ipfsSnapshotCid: data.ipfsSnapshotCid ?? null,
           createdAt: new Date(),
           updatedAt: new Date()
@@ -118,10 +204,12 @@ export class MockPrismaClient {
         this.rounds.set(id, record);
         return { ...record };
       },
-      findUnique: async ({ where, include }: any) => {
+      findUnique: async ({ where, include }: RoundFindUniqueArgs) => {
         const record = this.rounds.get(where.id);
         if (!record) return null;
-        const result: any = { ...record };
+        const result: RoundRecord & {
+          committee?: Array<CommitteeRecord & { agent?: AgentRecord | null }>;
+        } = { ...record };
         if (include?.committee) {
           const committee = Array.from(this.committees.values()).filter((c) => c.roundId === record.id);
           if (include.committee?.include?.agent) {
@@ -135,7 +223,7 @@ export class MockPrismaClient {
         }
         return result;
       },
-      update: async ({ where, data }: any) => {
+      update: async ({ where, data }: RoundUpdateArgs) => {
         const record = this.rounds.get(where.id);
         if (!record) throw new Error('Round not found');
         Object.assign(record, data, { updatedAt: new Date() });
@@ -145,7 +233,7 @@ export class MockPrismaClient {
     };
 
     this.committeeMember = {
-      createMany: async ({ data }: any) => {
+      createMany: async ({ data }: CommitteeCreateManyArgs) => {
         for (const entry of data) {
           const id = crypto.randomUUID();
           const record: CommitteeRecord = {
@@ -166,7 +254,7 @@ export class MockPrismaClient {
         }
         return { count: data.length };
       },
-      update: async ({ where, data }: any) => {
+      update: async ({ where, data }: CommitteeUpdateArgs) => {
         const record = this.committees.get(where.id);
         if (!record) throw new Error('Committee member not found');
         Object.assign(record, data, { updatedAt: new Date() });
@@ -176,7 +264,7 @@ export class MockPrismaClient {
     };
 
     this.roundLog = {
-      create: async ({ data }: any) => {
+      create: async ({ data }: RoundLogCreateArgs) => {
         const record: RoundLogRecord = {
           id: crypto.randomUUID(),
           roundId: data.roundId,

--- a/services/arena/test/arena.service.test.ts
+++ b/services/arena/test/arena.service.test.ts
@@ -3,8 +3,10 @@ import { Snapshotter } from '../src/ipfs.js';
 import { ArenaService } from '../src/arena.service.js';
 import { MockPrismaClient } from './__mocks__/prisma-client.js';
 import { toCommitHash } from '../src/utils.js';
+import type { PrismaClient } from '@prisma/client';
+import type { JobsClient } from '../src/jobs.client.js';
 
-const jobsClient = {
+const jobsClient: Pick<JobsClient, 'fetchTasks' | 'submitResult' | 'triggerOnChainAction'> = {
   fetchTasks: jest.fn(),
   submitResult: jest.fn(),
   triggerOnChainAction: jest.fn().mockResolvedValue(undefined)
@@ -12,8 +14,8 @@ const jobsClient = {
 
 describe('ArenaService', () => {
   it('runs a full round lifecycle', async () => {
-    const prisma = new MockPrismaClient() as any;
-    const service = new ArenaService(prisma, new DifficultyController({ targetSeconds: 60 }), new Snapshotter(false), jobsClient as any);
+    const prisma = new MockPrismaClient() as unknown as PrismaClient;
+    const service = new ArenaService(prisma, new DifficultyController({ targetSeconds: 60 }), new Snapshotter(false), jobsClient);
 
     const round = await service.startRound({
       contestantIds: ['agent-1'],
@@ -39,8 +41,8 @@ describe('ArenaService', () => {
   });
 
   it('handles concurrent commits without race conditions', async () => {
-    const prisma = new MockPrismaClient() as any;
-    const service = new ArenaService(prisma, new DifficultyController({ targetSeconds: 60 }), new Snapshotter(false), jobsClient as any);
+    const prisma = new MockPrismaClient() as unknown as PrismaClient;
+    const service = new ArenaService(prisma, new DifficultyController({ targetSeconds: 60 }), new Snapshotter(false), jobsClient);
 
     const round = await service.startRound({
       contestantIds: ['agent-1', 'agent-2'],
@@ -53,7 +55,7 @@ describe('ArenaService', () => {
     ]);
 
     const status = await service.getStatus(round.id);
-    const committedAgents = status.committee.filter((member: any) => member.commitHash);
+    const committedAgents = status.committee.filter((member) => member.commitHash);
     expect(committedAgents).toHaveLength(2);
   });
 });

--- a/services/arena/test/jobs-client.test.ts
+++ b/services/arena/test/jobs-client.test.ts
@@ -4,7 +4,8 @@ import { JobsClient } from '../src/jobs.client.js';
 describe('JobsClient', () => {
   it('fetches tasks with retries', async () => {
     const client = new JobsClient({ endpoint: 'https://jobs.example' });
-    const mock = new MockAdapter((client as any).http);
+    const http = Reflect.get(client, 'http');
+    const mock = new MockAdapter(http as Parameters<typeof MockAdapter>[0]);
     mock.onGet('/tasks').replyOnce(500).onGet('/tasks').reply(200, { tasks: [{ id: 't1' }] });
 
     const tasks = await client.fetchTasks();
@@ -13,7 +14,8 @@ describe('JobsClient', () => {
 
   it('opens circuit after repeated failures', async () => {
     const client = new JobsClient({ endpoint: 'https://jobs.example' }, { failureThreshold: 1, cooldownMs: 10 });
-    const mock = new MockAdapter((client as any).http);
+    const http = Reflect.get(client, 'http');
+    const mock = new MockAdapter(http as Parameters<typeof MockAdapter>[0]);
     mock.onPost('/onchain').reply(500);
 
     await expect(client.triggerOnChainAction('/onchain', {})).rejects.toThrow();

--- a/shared/auditLogger.ts
+++ b/shared/auditLogger.ts
@@ -125,7 +125,7 @@ export async function readAuditEvents(
       return events;
     }
     return events.slice(-limit);
-  } catch (err: any) {
+  } catch (err) {
     if (err.code === 'ENOENT') {
       return [];
     }
@@ -338,7 +338,7 @@ export async function readAuditAnchors(
       return records;
     }
     return records.slice(-limit);
-  } catch (err: any) {
+  } catch (err) {
     if (err.code === 'ENOENT') {
       return [];
     }

--- a/shared/energyInsights.ts
+++ b/shared/energyInsights.ts
@@ -123,7 +123,7 @@ function readInsightsSync(): InsightsFile {
     parsed.agents = parsed.agents ?? {};
     parsed.updatedAt = parsed.updatedAt ?? new Date(0).toISOString();
     return parsed;
-  } catch (err: any) {
+  } catch (err) {
     if (err.code === 'ENOENT') {
       return createEmptyInsights();
     }
@@ -143,7 +143,7 @@ async function readInsights(): Promise<InsightsFile> {
     parsed.agents = parsed.agents ?? {};
     parsed.updatedAt = parsed.updatedAt ?? new Date(0).toISOString();
     return parsed;
-  } catch (err: any) {
+  } catch (err) {
     if (err.code === 'ENOENT') {
       return createEmptyInsights();
     }

--- a/shared/energyMonitor.ts
+++ b/shared/energyMonitor.ts
@@ -320,7 +320,7 @@ export async function readEnergySamples(
       return samples;
     }
     return samples.slice(-limit);
-  } catch (err: any) {
+  } catch (err) {
     if (err.code === 'ENOENT') {
       return [];
     }

--- a/shared/energyTrends.ts
+++ b/shared/energyTrends.ts
@@ -133,7 +133,7 @@ async function readTrendFile(): Promise<TrendFile> {
     };
     parsed.updatedAt = parsed.updatedAt ?? new Date(0).toISOString();
     return parsed;
-  } catch (err: any) {
+  } catch (err) {
     if (err.code === 'ENOENT') {
       return emptyTrendFile();
     }
@@ -292,7 +292,7 @@ function readTrendFileSync(): TrendFile {
     };
     parsed.updatedAt = parsed.updatedAt ?? new Date(0).toISOString();
     return parsed;
-  } catch (err: any) {
+  } catch (err) {
     if (err.code !== 'ENOENT') {
       console.warn('Failed to read energy trend snapshot', err);
     }

--- a/shared/spawnManager.ts
+++ b/shared/spawnManager.ts
@@ -87,7 +87,7 @@ async function readJsonFile<T>(file: string, fallback: T): Promise<T> {
   try {
     const raw = await fs.promises.readFile(file, 'utf8');
     return JSON.parse(raw) as T;
-  } catch (err: any) {
+  } catch (err) {
     if (err.code !== 'ENOENT') {
       console.warn('Failed to read JSON file', file, err);
     }
@@ -210,7 +210,7 @@ async function readLabelsFromDirectory(dir: string): Promise<Set<string>> {
         console.warn('Failed to parse identity label', fullPath, err);
       }
     }
-  } catch (err: any) {
+  } catch (err) {
     if (err.code !== 'ENOENT') {
       console.warn('Failed to read identity directory', dir, err);
     }

--- a/shared/trainingRecords.ts
+++ b/shared/trainingRecords.ts
@@ -303,7 +303,7 @@ export async function readTrainingRecords(): Promise<TrainingRecord[]> {
       .map((line) => line.trim())
       .filter((line) => line.length > 0)
       .map((line) => JSON.parse(line) as TrainingRecord);
-  } catch (err: any) {
+    } catch (err) {
     if (err.code === 'ENOENT') {
       return [];
     }

--- a/shared/worldModel.ts
+++ b/shared/worldModel.ts
@@ -219,7 +219,7 @@ export async function loadWorldModelObservations(
       return entries;
     }
     return entries.filter((entry) => entry.jobId === jobId);
-  } catch (err: any) {
+  } catch (err) {
     if (err.code === 'ENOENT') {
       return [];
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
+    "noImplicitAny": true,
+    "useUnknownInCatchVariables": true,
     "types": ["node", "hardhat"],
     "typeRoots": ["./node_modules/@types", "./scripts/types"],
     "skipLibCheck": true


### PR DESCRIPTION
### Motivation

- Eliminate widespread use of `any` casts and unsafe type assertions to improve runtime safety and enable stronger static checks. 
- Introduce explicit `unknown` handling and typed guards so data parsed from external sources is validated before use. 
- Harden lint and TypeScript configs to prevent regression by surfacing `any` usage and unsafe catch typings. 
- Keep existing behavior unchanged while making the codebase safer and easier to reason about.

### Description

- Replaced `any` and `as any` casts with `unknown`-aware code, typed guards (`isRecord`) and safe conversion helpers across orchestrator, validator, console, onebox, arena and shared modules (examples: `apps/orchestrator/*`, `apps/validator/*`, `apps/console/*`, `services/arena/*`, `shared/*`).
- Tightened runtime parsing and Zod schemas to use `z.unknown()` instead of `z.any()` for input records and payloads (files: `packages/onebox-sdk/src/types.ts`, `packages/onebox-orchestrator/src/ics/schema.ts`, `packages/orchestrator/src/ics.ts`, `services/arena/src/validators.ts`).
- Added small helper types and declarations: `isRecord` guards, `toStringValue`, typed harness interfaces for tests, and EIP-1193 `window.ethereum` typings (`apps/console/src/types/ethereum.d.ts`, `apps/validator-ui/types/ethereum.d.ts`).
- Enforced rules via config changes: `tsconfig.json` (`noImplicitAny`, `useUnknownInCatchVariables`) and `eslint.config.js` (set `@typescript-eslint/no-explicit-any` to `error` globally and permitted `any` in test/demo paths), and minor Solidity cleanup (removed an unused ERC20 import).

### Testing

- Ran `npm run lint:fix` which executed ESLint/Prettier fixes and Solhint (warnings only); the lint fix command completed successfully. 
- Ran TypeScript checks for webapps: `npm run typecheck --prefix apps/console`, `--prefix apps/enterprise-portal`, and `--prefix apps/onebox` and they completed without errors. 
- Ran the test suite via `npm test`; unit and integration suites executed and the Hardhat tests completed (Hardhat run finished with tests passing). 
- All gates requested (`lint:fix`, `typecheck`, and `test`) were exercised and completed successfully in the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615772cb3483339d045a4cdf13a4c2)