### PR TITLE
Seed hardhat demo address book for owner parameter matrix

### DIFF
--- a/scripts/v2/asiGlobalDemo.ts
+++ b/scripts/v2/asiGlobalDemo.ts
@@ -81,6 +81,10 @@ const COMMAND_CENTER_PATH = resolveWithin(REPORT_ROOT, 'ASI_GLOBAL_COMMAND_CENTE
 const PARAMETER_MATRIX_PATH = resolveWithin(REPORT_ROOT, 'ASI_GLOBAL_PARAMETER_MATRIX_PATH', 'parameter-matrix.md');
 const MERMAID_PATH = resolveWithin(REPORT_ROOT, 'ASI_GLOBAL_MERMAID_PATH', 'governance.mmd');
 const MERMAID_MARKDOWN_PATH = resolveWithin(REPORT_ROOT, 'ASI_GLOBAL_MERMAID_MARKDOWN_PATH', 'governance.md');
+const DEMO_ADDRESS_BOOK_PATH = resolvePathFromEnv(
+  'ASI_GLOBAL_OWNER_MATRIX_ADDRESS_BOOK',
+  path.join(ROOT, 'deployment-config', 'generated', 'demo-hardhat-addresses.json')
+);
 const MERMAID_TITLE = process.env.ASI_GLOBAL_MERMAID_TITLE?.trim() || 'Global Autonomous Economic Orchestrator';
 const BUNDLE_NAME = process.env.ASI_GLOBAL_BUNDLE_NAME?.trim() || 'asi-takeoff';
 const KIT_BASENAME = process.env.ASI_GLOBAL_OUTPUT_BASENAME?.trim() || 'asi-global-governance-kit';
@@ -417,6 +421,22 @@ async function main(): Promise<void> {
       ],
     },
     {
+      key: 'owner-matrix-demo-seed',
+      title: 'Seed hardhat owner matrix demo addresses',
+      command: [
+        'npx',
+        'hardhat',
+        'run',
+        '--no-compile',
+        'scripts/v2/demoHardhatOwnerMatrixConfig.ts',
+        '--network',
+        'hardhat',
+      ],
+      env: {
+        OWNER_MATRIX_DEMO_ADDRESS_BOOK: DEMO_ADDRESS_BOOK_PATH,
+      },
+    },
+    {
       key: 'parameter-matrix',
       title: 'Owner parameter matrix',
       command: [
@@ -432,6 +452,9 @@ async function main(): Promise<void> {
         '--out',
         PARAMETER_MATRIX_PATH,
       ],
+      env: {
+        OWNER_MATRIX_DEMO_ADDRESS_BOOK: DEMO_ADDRESS_BOOK_PATH,
+      },
     },
     {
       key: 'governance-mermaid',

--- a/scripts/v2/demoHardhatOwnerMatrixConfig.ts
+++ b/scripts/v2/demoHardhatOwnerMatrixConfig.ts
@@ -1,0 +1,121 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { ethers, network } from 'hardhat';
+
+const LOCAL_NETWORKS = new Set(['hardhat', 'localhost']);
+const DEFAULT_OUTPUT = path.join(
+  process.cwd(),
+  'deployment-config',
+  'generated',
+  'demo-hardhat-addresses.json'
+);
+
+function resolveOutputPath(): string {
+  const override = process.env.OWNER_MATRIX_DEMO_ADDRESS_BOOK;
+  if (!override || override.trim().length === 0) {
+    return DEFAULT_OUTPUT;
+  }
+  const trimmed = override.trim();
+  return path.isAbsolute(trimmed)
+    ? trimmed
+    : path.join(process.cwd(), trimmed);
+}
+
+async function loadThermostatConfig(): Promise<{ temp: bigint; min: bigint; max: bigint }> {
+  const configPath = path.join(process.cwd(), 'config', 'thermodynamics.json');
+  const raw = await fs.readFile(configPath, 'utf8');
+  const parsed = JSON.parse(raw) as Record<string, any>;
+  const thermostat = parsed.thermostat ?? {};
+  const tempRaw = thermostat.systemTemperature ?? thermostat.temperature ?? '1000000000000000000';
+  const bounds = thermostat.bounds ?? {};
+  const minRaw = bounds.min ?? '100000000000000000';
+  const maxRaw = bounds.max ?? '5000000000000000000';
+  return {
+    temp: BigInt(tempRaw),
+    min: BigInt(minRaw),
+    max: BigInt(maxRaw),
+  };
+}
+
+async function main(): Promise<void> {
+  if (!LOCAL_NETWORKS.has(network.name)) {
+    throw new Error(
+      `Demo owner matrix config can only run on local networks (hardhat/localhost). Current: ${network.name}`
+    );
+  }
+
+  const [deployer] = await ethers.getSigners();
+
+  const taxPolicyFactory = await ethers.getContractFactory(
+    'contracts/v2/TaxPolicy.sol:TaxPolicy'
+  );
+  const taxPolicy = await taxPolicyFactory.deploy(
+    'ipfs://demo-tax-policy',
+    'Hardhat demo tax policy acknowledgement.'
+  );
+  await taxPolicy.waitForDeployment();
+
+  const { temp, min, max } = await loadThermostatConfig();
+  const thermostatFactory = await ethers.getContractFactory(
+    'contracts/v2/Thermostat.sol:Thermostat'
+  );
+  const thermostat = await thermostatFactory.deploy(
+    temp,
+    min,
+    max,
+    deployer.address
+  );
+  await thermostat.waitForDeployment();
+
+  const mockFeePoolFactory = await ethers.getContractFactory(
+    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockFeePool'
+  );
+  const mockReputationFactory = await ethers.getContractFactory(
+    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockReputation'
+  );
+  const mockOracleFactory = await ethers.getContractFactory(
+    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockEnergyOracle'
+  );
+
+  const feePool = await mockFeePoolFactory.deploy();
+  const reputation = await mockReputationFactory.deploy();
+  const energyOracle = await mockOracleFactory.deploy();
+
+  await Promise.all([
+    feePool.waitForDeployment(),
+    reputation.waitForDeployment(),
+    energyOracle.waitForDeployment(),
+  ]);
+
+  const rewardEngineFactory = await ethers.getContractFactory(
+    'contracts/v2/RewardEngineMB.sol:RewardEngineMB'
+  );
+  const rewardEngine = await rewardEngineFactory.deploy(
+    await thermostat.getAddress(),
+    await feePool.getAddress(),
+    await reputation.getAddress(),
+    await energyOracle.getAddress(),
+    deployer.address
+  );
+  await rewardEngine.waitForDeployment();
+
+  const outputPath = resolveOutputPath();
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    network: network.name,
+    taxPolicy: await taxPolicy.getAddress(),
+    rewardEngine: await rewardEngine.getAddress(),
+    thermostat: await thermostat.getAddress(),
+  };
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+
+  console.log(`Demo owner matrix address book written to ${outputPath}`);
+  console.table(payload);
+}
+
+main().catch((error) => {
+  console.error('demoHardhatOwnerMatrixConfig failed:', error);
+  process.exitCode = 1;
+});

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { ethers } from 'ethers';
 import {
   loadTokenConfig,
   loadStakeManagerConfig,
@@ -61,6 +62,17 @@ interface SubsystemDescriptor {
   loader: (network?: string) => { config: unknown; path: string };
 }
 
+interface DemoAddressBook {
+  taxPolicy: string;
+  rewardEngine: string;
+  thermostat?: string;
+}
+
+interface DemoConfigOverrides {
+  jobRegistryPath?: string;
+  thermodynamicsPath?: string;
+}
+
 interface MatrixPayload {
   network?: string;
   subsystems: SubsystemMatrix[];
@@ -69,6 +81,8 @@ interface MatrixPayload {
 
 const NEWLINE = '\n';
 const DEFAULT_FORMAT: OutputFormat = 'markdown';
+const LOCAL_NETWORKS = new Set(['hardhat', 'localhost']);
+const DEMO_ADDRESS_BOOK_ENV = 'OWNER_MATRIX_DEMO_ADDRESS_BOOK';
 
 async function resolveHardhatContext(): Promise<HardhatContext> {
   try {
@@ -180,6 +194,107 @@ function toDisplayValue(input: unknown): string {
   return String(input);
 }
 
+function resolveDemoAddressBookPath(): string | undefined {
+  const override = process.env[DEMO_ADDRESS_BOOK_ENV];
+  if (!override || override.trim().length === 0) {
+    return undefined;
+  }
+  const trimmed = override.trim();
+  if (path.isAbsolute(trimmed)) {
+    return trimmed;
+  }
+  return path.join(process.cwd(), trimmed);
+}
+
+function normaliseDemoAddress(value: unknown, label: string): string {
+  if (value === undefined || value === null) {
+    throw new Error(`Demo address book missing ${label}`);
+  }
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    throw new Error(`Demo address book missing ${label}`);
+  }
+  const address = ethers.getAddress(trimmed);
+  if (address === ethers.ZeroAddress) {
+    throw new Error(`Demo address book ${label} cannot be the zero address`);
+  }
+  return address;
+}
+
+async function loadDemoAddressBook(filePath: string): Promise<DemoAddressBook> {
+  const raw = await fs.readFile(filePath, 'utf8');
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  return {
+    taxPolicy: normaliseDemoAddress(parsed.taxPolicy, 'taxPolicy'),
+    rewardEngine: normaliseDemoAddress(parsed.rewardEngine, 'rewardEngine'),
+    thermostat: parsed.thermostat
+      ? normaliseDemoAddress(parsed.thermostat, 'thermostat')
+      : undefined,
+  };
+}
+
+async function writeDemoConfigOverrides(
+  addressBook: DemoAddressBook,
+  network?: string
+): Promise<DemoConfigOverrides> {
+  const outputDir = path.join(
+    process.cwd(),
+    'deployment-config',
+    'generated',
+    'demo-hardhat-owner-matrix'
+  );
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const jobRegistrySource = path.join(process.cwd(), 'config', 'job-registry.json');
+  const jobRegistryRaw = await fs.readFile(jobRegistrySource, 'utf8');
+  const jobRegistryConfig = JSON.parse(jobRegistryRaw) as Record<string, unknown>;
+  jobRegistryConfig.taxPolicy = addressBook.taxPolicy;
+  const jobRegistryPath = path.join(
+    outputDir,
+    `job-registry.${network ?? 'hardhat'}.json`
+  );
+  await fs.writeFile(jobRegistryPath, `${JSON.stringify(jobRegistryConfig, null, 2)}\n`);
+
+  const thermoSource = path.join(process.cwd(), 'config', 'thermodynamics.json');
+  const thermoRaw = await fs.readFile(thermoSource, 'utf8');
+  const thermoConfig = JSON.parse(thermoRaw) as Record<string, any>;
+  const rewardEngineConfig = {
+    ...(thermoConfig.rewardEngine ?? {}),
+    address: addressBook.rewardEngine,
+  };
+  if (addressBook.thermostat) {
+    rewardEngineConfig.thermostat = addressBook.thermostat;
+  }
+  thermoConfig.rewardEngine = rewardEngineConfig;
+  thermoConfig.thermostat = {
+    ...(thermoConfig.thermostat ?? {}),
+    address: addressBook.thermostat ?? rewardEngineConfig.thermostat,
+  };
+  const thermodynamicsPath = path.join(
+    outputDir,
+    `thermodynamics.${network ?? 'hardhat'}.json`
+  );
+  await fs.writeFile(thermodynamicsPath, `${JSON.stringify(thermoConfig, null, 2)}\n`);
+
+  return { jobRegistryPath, thermodynamicsPath };
+}
+
+async function prepareDemoOverrides(
+  network?: string
+): Promise<DemoConfigOverrides | null> {
+  const addressBookPath = resolveDemoAddressBookPath();
+  if (!addressBookPath) {
+    return null;
+  }
+  if (!network || !LOCAL_NETWORKS.has(network)) {
+    throw new Error(
+      `${DEMO_ADDRESS_BOOK_ENV} is only supported on local hardhat networks`
+    );
+  }
+  const addressBook = await loadDemoAddressBook(addressBookPath);
+  return writeDemoConfigOverrides(addressBook, network);
+}
+
 function flattenConfig(value: unknown, prefix = '', rows: MatrixRow[] = [], depth = 0): MatrixRow[] {
   if (rows.length > 256) {
     return rows;
@@ -220,7 +335,10 @@ function flattenConfig(value: unknown, prefix = '', rows: MatrixRow[] = [], dept
   return rows;
 }
 
-async function buildSubsystemMatrices(network?: string): Promise<SubsystemBuildResult[]> {
+async function buildSubsystemMatrices(
+  network?: string,
+  demoOverrides?: DemoConfigOverrides
+): Promise<SubsystemBuildResult[]> {
   const descriptors: SubsystemDescriptor[] = [
     {
       id: 'token',
@@ -263,7 +381,11 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemBuildR
         'npm run owner:verify-control -- --network <network> --modules=jobRegistry',
       ],
       fallbackConfigPath: 'config/job-registry.json',
-      loader: (ctx) => loadJobRegistryConfig({ network: ctx }),
+      loader: (ctx) =>
+        loadJobRegistryConfig({
+          network: ctx,
+          path: demoOverrides?.jobRegistryPath,
+        }),
     },
     {
       id: 'feePool',
@@ -292,7 +414,11 @@ async function buildSubsystemMatrices(network?: string): Promise<SubsystemBuildR
       ],
       verifyCommands: ['npm run owner:verify-control -- --network <network> --modules=rewardEngine,thermostat'],
       fallbackConfigPath: 'config/thermodynamics.json',
-      loader: (ctx) => loadThermodynamicsConfig({ network: ctx }),
+      loader: (ctx) =>
+        loadThermodynamicsConfig({
+          network: ctx,
+          path: demoOverrides?.thermodynamicsPath,
+        }),
     },
     {
       id: 'hamiltonianMonitor',
@@ -520,6 +646,9 @@ async function main(): Promise<void> {
       '  --format <format>      Output format: markdown (default), json, human',
       '  --out <path>           Write to file instead of stdout',
       '  --no-mermaid           Omit Mermaid diagrams in markdown mode',
+      '',
+      `Environment:`,
+      `  ${DEMO_ADDRESS_BOOK_ENV}=<path>  Path to demo address book JSON for hardhat demos.`,
       '  -h, --help             Show this message',
     ].join(NEWLINE);
     process.stdout.write(`${helpText}\n`);
@@ -529,7 +658,8 @@ async function main(): Promise<void> {
   const hardhat = await resolveHardhatContext();
   const selectedNetwork = options.network ?? process.env.HARDHAT_NETWORK ?? hardhat.name;
 
-  const buildResults = await buildSubsystemMatrices(selectedNetwork);
+  const demoOverrides = await prepareDemoOverrides(selectedNetwork);
+  const buildResults = await buildSubsystemMatrices(selectedNetwork, demoOverrides);
   const subsystems = buildResults.map((entry) => entry.matrix);
   const matrix: MatrixPayload = {
     network: selectedNetwork,


### PR DESCRIPTION
### Motivation
- Owner parameter matrix failed in CI because `jobRegistry.taxPolicy` and thermodynamics `rewardEngine` addresses were zero during demo runs. The change ensures demos running on Hardhat provide real deployed addresses. 
- The intent is to keep demo behavior deterministic and self-contained for CI by deploying minimal demo contracts during the Hardhat demo pipeline instead of using zero-address placeholders. 
- The fix must be scoped to local/demo execution and must not weaken production validation rules or hardcode arbitrary non-zero addresses. 
- Provide a reproducible, generated address book that downstream report/verification steps can consume at runtime.

### Description
- Added a Hardhat-only demo deploy script `scripts/v2/demoHardhatOwnerMatrixConfig.ts` that deploys `TaxPolicy`, `Thermostat`, and `RewardEngineMB` (with mock dependencies) and writes a deterministic address book JSON (`deployment-config/generated/demo-hardhat-addresses.json` by default). 
- Updated `scripts/v2/ownerParameterMatrix.ts` to support reading a demo address book via the `OWNER_MATRIX_DEMO_ADDRESS_BOOK` environment variable and to emit per-network override configs under `deployment-config/generated/demo-hardhat-owner-matrix/` so `job-registry` and `thermodynamics` loaders see non-zero addresses during Hardhat runs. 
- Wired the demo seeding step into the ASI global demo flow by adding a `owner-matrix-demo-seed` step to `scripts/v2/asiGlobalDemo.ts` and passing the address-book path into the `ownerParameterMatrix` step (via env `OWNER_MATRIX_DEMO_ADDRESS_BOOK` / runner env `ASI_GLOBAL_OWNER_MATRIX_ADDRESS_BOOK`). 
- The behavior is gated to local networks (`hardhat`/`localhost`) and will throw if the demo seed is attempted on a non-local network, preserving production validations and avoiding hardcoded addresses.

### Testing
- Ran `npm run ci:preflight` which completed successfully. 
- Ran `npm run ci:sync-contexts -- --check`, `npm run ci:verify-contexts`, `npm run ci:verify-companion-contexts`, and `npm run ci:verify-summary-needs`, all of which completed successfully. 
- Attempted `npm run demo:asi-global` and `npm run demo:zenith-hypernova`; the new seeding and parameter-matrix steps run but execution was interrupted/hung during Hardhat compilation in this environment, so the full demo pipeline did not complete here. 
- The change is demo-only and deterministic: demos now deploy local contracts and write a generated address book consumed by later steps rather than relying on zero-address placeholders.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696164167d2c8333ae29522c21b1c561)