### PR TITLE
Bootstrap Hardhat demo configs for owner reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverage.json
 !contracts/coverage/**
 !test/coverage/
 !test/coverage/**
+config/*.hardhat.json
 reports/sbom/
 reports/load-sim/
 reports/python-coverage/

--- a/demo/asi-global/RUNBOOK.md
+++ b/demo/asi-global/RUNBOOK.md
@@ -43,5 +43,9 @@ operators to inspect intermediate states on a local fork.
 - The runbook never modifies production deployments.  It only touches ephemeral local
   chains.
 - All scripts are idempotent; re-running them overwrites previous artefacts.
+- The demo pipeline auto-bootstraps Hardhat thermodynamics + tax policy fixtures by
+  setting `AGJ_DEMO_BOOTSTRAP_HARDHAT=1`, which generates
+  `config/job-registry.hardhat.json` and `config/thermodynamics.hardhat.json` for the
+  report steps.
 - Review `demo/asi-global/project-plan.json` to adapt the scenario with new regions or
   governance policies without changing any code.

--- a/demo/asi-takeoff/RUNBOOK.md
+++ b/demo/asi-takeoff/RUNBOOK.md
@@ -104,6 +104,13 @@ Clear previous artefacts:
 rm -rf reports/localhost/asi-takeoff
 ```
 
+## 8. Notes
+
+- The demo pipeline enables `AGJ_DEMO_BOOTSTRAP_HARDHAT=1` to deploy local
+  TaxPolicy/RewardEngineMB/Thermostat fixtures and generate
+  `config/job-registry.hardhat.json` plus `config/thermodynamics.hardhat.json` for
+  the owner-control report steps.
+
 ---
 
 This runbook, combined with `mission.json`, forms a reproducible dossier demonstrating autonomous multi-sector coordination under owner governance.

--- a/scripts/v2/asiGlobalDemo.ts
+++ b/scripts/v2/asiGlobalDemo.ts
@@ -375,6 +375,7 @@ async function main(): Promise<void> {
       env: {
         THERMODYNAMICS_REPORT_FORMAT: 'json',
         THERMODYNAMICS_REPORT_OUT: THERMODYNAMICS_PATH,
+        AGJ_DEMO_BOOTSTRAP_HARDHAT: '1',
       },
     },
     {
@@ -398,6 +399,9 @@ async function main(): Promise<void> {
         BUNDLE_NAME,
         '--skip-surface',
       ],
+      env: {
+        AGJ_DEMO_BOOTSTRAP_HARDHAT: '1',
+      },
     },
     {
       key: 'command-center',

--- a/scripts/v2/asiTakeoffDemo.ts
+++ b/scripts/v2/asiTakeoffDemo.ts
@@ -323,6 +323,7 @@ async function main(): Promise<void> {
         ...HARDHAT_ENV,
         THERMODYNAMICS_REPORT_FORMAT: 'json',
         THERMODYNAMICS_REPORT_OUT: THERMODYNAMICS_PATH,
+        AGJ_DEMO_BOOTSTRAP_HARDHAT: '1',
       },
     },
     {
@@ -346,6 +347,10 @@ async function main(): Promise<void> {
         'asi-takeoff',
         '--skip-surface',
       ],
+      env: {
+        ...HARDHAT_ENV,
+        AGJ_DEMO_BOOTSTRAP_HARDHAT: '1',
+      },
     },
     {
       key: 'verify-control',

--- a/scripts/v2/lib/hardhatDemoBootstrap.ts
+++ b/scripts/v2/lib/hardhatDemoBootstrap.ts
@@ -1,0 +1,127 @@
+import { promises as fs } from 'fs';
+import fsSync from 'fs';
+import path from 'path';
+import { ethers, network } from 'hardhat';
+
+const DEMO_BOOTSTRAP_ENV =
+  process.env.AGJ_DEMO_BOOTSTRAP_HARDHAT ??
+  process.env.THERMO_REPORT_BOOTSTRAP_HARDHAT ??
+  process.env.THERMODYNAMICS_REPORT_BOOTSTRAP_HARDHAT ??
+  process.env.OWNER_PLAN_BOOTSTRAP_HARDHAT;
+const DEMO_NETWORKS = new Set(['hardhat', 'localhost']);
+
+export async function bootstrapHardhatDemoConfig(
+  configNetwork: string,
+  notes?: string[]
+): Promise<void> {
+  if (!DEMO_BOOTSTRAP_ENV) {
+    return;
+  }
+  if (!DEMO_NETWORKS.has(network.name)) {
+    throw new Error(
+      `Demo bootstrap is only supported on hardhat/localhost (current: ${network.name}).`
+    );
+  }
+
+  const configDir = path.join(process.cwd(), 'config');
+  const baseJobPath = path.join(configDir, 'job-registry.json');
+  const baseThermoPath = path.join(configDir, 'thermodynamics.json');
+  const baseTaxPath = path.join(configDir, 'tax-policy.json');
+
+  const jobConfig = JSON.parse(fsSync.readFileSync(baseJobPath, 'utf8'));
+  const thermoConfig = JSON.parse(fsSync.readFileSync(baseThermoPath, 'utf8'));
+  const taxConfig = JSON.parse(fsSync.readFileSync(baseTaxPath, 'utf8'));
+
+  const [deployer] = await ethers.getSigners();
+
+  const TaxPolicy = await ethers.getContractFactory('TaxPolicy');
+  const policyUri = String(
+    taxConfig?.policyURI ?? 'ipfs://demo-tax-policy'
+  );
+  const acknowledgement = String(
+    taxConfig?.acknowledgement ??
+      'Employers, agents, and validators accept full responsibility for all applicable taxes.'
+  );
+  const taxPolicy = await TaxPolicy.deploy(policyUri, acknowledgement);
+  await taxPolicy.waitForDeployment();
+  const taxPolicyAddress = await taxPolicy.getAddress();
+
+  const thermostatSeed = thermoConfig?.thermostat ?? {};
+  const bounds = thermostatSeed?.bounds ?? {};
+  const systemTemperature = BigInt(
+    thermostatSeed?.systemTemperature ?? '1000000000000000000'
+  );
+  const minTemp = BigInt(bounds?.min ?? '100000000000000000');
+  const maxTemp = BigInt(bounds?.max ?? '5000000000000000000');
+
+  const Thermostat = await ethers.getContractFactory('Thermostat');
+  const thermostat = await Thermostat.deploy(
+    systemTemperature,
+    minTemp,
+    maxTemp,
+    deployer.address
+  );
+  await thermostat.waitForDeployment();
+  const thermostatAddress = await thermostat.getAddress();
+
+  const MockFeePool = await ethers.getContractFactory(
+    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockFeePool'
+  );
+  const MockReputation = await ethers.getContractFactory(
+    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockReputation'
+  );
+  const MockEnergyOracle = await ethers.getContractFactory(
+    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockEnergyOracle'
+  );
+  const mockFeePool = await MockFeePool.deploy();
+  const mockReputation = await MockReputation.deploy();
+  const mockEnergyOracle = await MockEnergyOracle.deploy();
+  await Promise.all([
+    mockFeePool.waitForDeployment(),
+    mockReputation.waitForDeployment(),
+    mockEnergyOracle.waitForDeployment(),
+  ]);
+
+  const RewardEngine = await ethers.getContractFactory('RewardEngineMB');
+  const rewardEngine = await RewardEngine.deploy(
+    thermostatAddress,
+    await mockFeePool.getAddress(),
+    await mockReputation.getAddress(),
+    await mockEnergyOracle.getAddress(),
+    deployer.address
+  );
+  await rewardEngine.waitForDeployment();
+  const rewardEngineAddress = await rewardEngine.getAddress();
+
+  jobConfig.taxPolicy = taxPolicyAddress;
+
+  const rewardConfig = thermoConfig?.rewardEngine ?? {};
+  const nextThermoConfig = {
+    ...thermoConfig,
+    rewardEngine: {
+      ...rewardConfig,
+      address: rewardEngineAddress,
+      thermostat: thermostatAddress,
+    },
+    thermostat: {
+      ...(thermoConfig?.thermostat ?? {}),
+      address: thermostatAddress,
+    },
+  };
+
+  await fs.writeFile(
+    path.join(configDir, `job-registry.${configNetwork}.json`),
+    `${JSON.stringify(jobConfig, null, 2)}\n`
+  );
+  await fs.writeFile(
+    path.join(configDir, `thermodynamics.${configNetwork}.json`),
+    `${JSON.stringify(nextThermoConfig, null, 2)}\n`
+  );
+
+  notes?.push(
+    `Bootstrapped demo contracts: TaxPolicy ${taxPolicyAddress}, Thermostat ${thermostatAddress}, RewardEngineMB ${rewardEngineAddress}.`
+  );
+  notes?.push(
+    `Generated config/job-registry.${configNetwork}.json and config/thermodynamics.${configNetwork}.json for demo runs.`
+  );
+}

--- a/scripts/v2/ownerControlPlan.ts
+++ b/scripts/v2/ownerControlPlan.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { ethers, network } from 'hardhat';
 import {
+  inferNetworkKey,
   loadTokenConfig,
   loadJobRegistryConfig,
   loadStakeManagerConfig,
@@ -23,6 +24,7 @@ import { buildIdentityRegistryPlan } from './lib/identityRegistryPlan';
 import { buildRewardEnginePlan } from './lib/rewardEnginePlan';
 import { buildThermostatPlan } from './lib/thermostatPlan';
 import { buildRandaoCoordinatorPlan } from './lib/randaoCoordinatorPlan';
+import { bootstrapHardhatDemoConfig } from './lib/hardhatDemoBootstrap';
 import { describeArgs, sameAddress } from './lib/utils';
 import type { ModulePlan, PlannedAction } from './lib/types';
 
@@ -447,6 +449,10 @@ async function main() {
       console.warn(error);
     }
   }
+
+  const configNetwork =
+    inferNetworkKey(network.name) || network.name || 'unknown';
+  await bootstrapHardhatDemoConfig(configNetwork);
 
   const tokenResult = loadTokenConfig({
     network: network.name,

--- a/scripts/v2/thermodynamicsReport.ts
+++ b/scripts/v2/thermodynamicsReport.ts
@@ -3,9 +3,9 @@ import fsSync from 'fs';
 import path from 'path';
 import { ethers, network } from 'hardhat';
 import { inferNetworkKey } from '../config';
+import { bootstrapHardhatDemoConfig } from './lib/hardhatDemoBootstrap';
 
 const ZERO_ADDRESS = ethers.ZeroAddress;
-
 const ROLE_KEYS = ['agent', 'validator', 'operator', 'employer'] as const;
 type RoleKey = (typeof ROLE_KEYS)[number];
 const ROLE_LABEL: Record<RoleKey, string> = {
@@ -164,6 +164,8 @@ Environment overrides:
   THERMO_REPORT_OUT             Default output path
   THERMO_REPORT_ADDRESS_BOOK    Override deployment address book path
   THERMO_REPORT_CONFIG_NETWORK  Override config network resolution
+  AGJ_DEMO_BOOTSTRAP_HARDHAT       Deploy demo fixtures + generate hardhat config overrides
+  THERMO_REPORT_BOOTSTRAP_HARDHAT  (alias) Deploy demo fixtures for thermodynamics reports
 `);
 }
 
@@ -583,6 +585,8 @@ async function main(): Promise<void> {
   const notes: string[] = [];
   const configNetwork =
     options.configNetwork || inferNetworkKey(network.name) || network.name || 'unknown';
+
+  await bootstrapHardhatDemoConfig(configNetwork, notes);
 
   const thermoConfigPath = resolveThermodynamicsPath(configNetwork);
   if (!fsSync.existsSync(thermoConfigPath)) {


### PR DESCRIPTION
### Motivation
- Demo owner checks failed because `config/*` contained zero addresses for TaxPolicy and RewardEngine, which the config loaders reject.
- CI/Hardhat demo runs need deterministic, usable contract addresses to pass owner/thermodynamics validations.
- The fix must be scoped to local demo execution and not relax production validations.

### Description
- Add a Hardhat-only bootstrap helper `scripts/v2/lib/hardhatDemoBootstrap.ts` that, when enabled via environment, deploys demo contracts (TaxPolicy, Thermostat, RewardEngineMB + mocks) and writes network-scoped config overrides `config/job-registry.<network>.json` and `config/thermodynamics.<network>.json`.
- Wire the bootstrap into thermodynamics reporting by calling `bootstrapHardhatDemoConfig` from `scripts/v2/thermodynamicsReport.ts` so the report step sources deployed addresses for later checks.
- Invoke the same bootstrap in `scripts/v2/ownerControlPlan.ts` to ensure owner plan generation sees nonzero addresses when running on Hardhat.
- Enable the demo bootstrap for demo pipelines by setting `AGJ_DEMO_BOOTSTRAP_HARDHAT=1` in `scripts/v2/asiGlobalDemo.ts` and `scripts/v2/asiTakeoffDemo.ts`, and also pass it to the mission-control step so all owner reports are consistent.
- Document the behavior in `demo/asi-global/RUNBOOK.md` and `demo/asi-takeoff/RUNBOOK.md` and ignore generated hardhat config files via `.gitignore` (`config/*.hardhat.json`).

### Testing
- Ran `npm run demo:asi-global` and observed thermodynamics and owner parameter/mission reports now source deployed addresses (demo bootstrapped); the previous zero-address errors for RewardEngine and JobRegistry tax policy no longer occurred (thermodynamics report shows matches and notes about bootstrapped contracts). (succeeded)
- Ran `npm run demo:zenith-hypernova` which invokes the ASI global demo and completed the owner/thermodynamics report steps with bootstrap enabled (succeeded).
- Executed CI preflight and context checks: `npm run ci:preflight`, `npm run ci:sync-contexts -- --check`, `npm run ci:verify-contexts`, `npm run ci:verify-companion-contexts`, and `npm run ci:verify-summary-needs` (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696164167d2c8333ae29522c21b1c561)