### PR TITLE
Harden demo owner matrix address book lookup

### DIFF
--- a/scripts/v2/__tests__/ownerParameterMatrix.test.ts
+++ b/scripts/v2/__tests__/ownerParameterMatrix.test.ts
@@ -1,0 +1,48 @@
+import { existsSync, promises as fs } from 'fs';
+import path from 'path';
+
+import { resolveDemoAddressBookPath } from '../ownerParameterMatrix';
+
+describe('resolveDemoAddressBookPath', () => {
+  const envKey = 'OWNER_MATRIX_DEMO_ADDRESS_BOOK';
+  const defaultPath = path.join(
+    process.cwd(),
+    'deployment-config',
+    'generated',
+    'demo-hardhat-addresses.json'
+  );
+  const originalEnv = process.env[envKey];
+
+  afterEach(async () => {
+    if (originalEnv === undefined) {
+      delete process.env[envKey];
+    } else {
+      process.env[envKey] = originalEnv;
+    }
+    if (existsSync(defaultPath)) {
+      await fs.unlink(defaultPath);
+    }
+  });
+
+  it('resolves explicit overrides', () => {
+    process.env[envKey] = 'tmp/demo-owner-matrix.json';
+    const resolved = resolveDemoAddressBookPath('hardhat');
+    expect(resolved).toBe(path.join(process.cwd(), 'tmp', 'demo-owner-matrix.json'));
+  });
+
+  it('uses the default generated address book for local networks', async () => {
+    await fs.mkdir(path.dirname(defaultPath), { recursive: true });
+    await fs.writeFile(defaultPath, '{"taxPolicy":"0x0000000000000000000000000000000000000001","rewardEngine":"0x0000000000000000000000000000000000000002"}');
+
+    const resolved = resolveDemoAddressBookPath('hardhat');
+    expect(resolved).toBe(defaultPath);
+  });
+
+  it('skips the default address book on non-local networks', async () => {
+    await fs.mkdir(path.dirname(defaultPath), { recursive: true });
+    await fs.writeFile(defaultPath, '{"taxPolicy":"0x0000000000000000000000000000000000000001","rewardEngine":"0x0000000000000000000000000000000000000002"}');
+
+    const resolved = resolveDemoAddressBookPath('mainnet');
+    expect(resolved).toBeUndefined();
+  });
+});

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from 'fs';
+import { existsSync, promises as fs } from 'fs';
 import path from 'path';
 import { ethers } from 'ethers';
 import {
@@ -83,6 +83,12 @@ const NEWLINE = '\n';
 const DEFAULT_FORMAT: OutputFormat = 'markdown';
 const LOCAL_NETWORKS = new Set(['hardhat', 'localhost']);
 const DEMO_ADDRESS_BOOK_ENV = 'OWNER_MATRIX_DEMO_ADDRESS_BOOK';
+const DEFAULT_DEMO_ADDRESS_BOOK = path.join(
+  process.cwd(),
+  'deployment-config',
+  'generated',
+  'demo-hardhat-addresses.json'
+);
 
 async function resolveHardhatContext(): Promise<HardhatContext> {
   try {
@@ -194,10 +200,15 @@ function toDisplayValue(input: unknown): string {
   return String(input);
 }
 
-function resolveDemoAddressBookPath(): string | undefined {
+export function resolveDemoAddressBookPath(network?: string): string | undefined {
   const override = process.env[DEMO_ADDRESS_BOOK_ENV];
   if (!override || override.trim().length === 0) {
-    return undefined;
+    if (!network || !LOCAL_NETWORKS.has(network)) {
+      return undefined;
+    }
+    return existsSync(DEFAULT_DEMO_ADDRESS_BOOK)
+      ? DEFAULT_DEMO_ADDRESS_BOOK
+      : undefined;
   }
   const trimmed = override.trim();
   if (path.isAbsolute(trimmed)) {
@@ -282,7 +293,7 @@ async function writeDemoConfigOverrides(
 async function prepareDemoOverrides(
   network?: string
 ): Promise<DemoConfigOverrides | null> {
-  const addressBookPath = resolveDemoAddressBookPath();
+  const addressBookPath = resolveDemoAddressBookPath(network);
   if (!addressBookPath) {
     return null;
   }
@@ -700,7 +711,9 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error) => {
-  console.error('ownerParameterMatrix failed:', error);
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('ownerParameterMatrix failed:', error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
### Motivation
- Owner parameter matrix failed in CI for local demos because config loaders reported zero-address placeholders for `taxPolicy` and `RewardEngine` when no runtime demo address book was provided. 
- Demos produce a generated Hardhat address book at `deployment-config/generated/demo-hardhat-addresses.json`, but the matrix loader only honored an explicit env override and otherwise returned nothing. 
- Keep production validations strict while making demos deterministic: allow the owner matrix to use the generated demo snapshot only when running locally (Hardhat/localhost).
- Prevent the module from performing side effects when imported by tests or other scripts.

### Description
- Add a Hardhat-only fallback to resolve the demo address book by looking for `deployment-config/generated/demo-hardhat-addresses.json` when `OWNER_MATRIX_DEMO_ADDRESS_BOOK` is not set and the network is local, implemented in `resolveDemoAddressBookPath` exported from `scripts/v2/ownerParameterMatrix.ts`.
- Make `resolveDemoAddressBookPath` accept an optional `network` argument and export it so it can be tested.
- Guard automatic execution by wrapping `main()` in `if (require.main === module)` to avoid side effects when the file is imported.
- Add a regression test `scripts/v2/__tests__/ownerParameterMatrix.test.ts` that validates explicit overrides, the local fallback behavior, and that the fallback is not used for non-local networks.

### Testing
- Ran `npx jest scripts/v2/__tests__/ownerParameterMatrix.test.ts` and the new unit tests passed.
- Ran `npm ci` to reproduce the environment prior to demo runs (completed with advisories reported by `npm audit`).
- Attempted `npm run demo:asi-global` to exercise the full demo pipeline; the process began Hardhat compile/download and was interrupted in this environment (demonstrates the original hang point but is not a failure of the patched logic itself).
- The changes are scoped to demo/Hardhat flows only and do not weaken production address validation logic (ensured by only returning the demo snapshot for `hardhat`/`localhost`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961836df7088333bc63c819f9bed7c2)