### PR TITLE
Seed Hardhat demo owner matrix configs and write network-specific overrides

### DIFF
--- a/scripts/v2/__tests__/demoHardhatOwnerMatrixConfig.test.ts
+++ b/scripts/v2/__tests__/demoHardhatOwnerMatrixConfig.test.ts
@@ -1,0 +1,53 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { writeDemoNetworkConfig } from '../demoHardhatOwnerMatrixConfig';
+
+describe('writeDemoNetworkConfig', () => {
+  const networkName = 'hardhat';
+  const configDir = path.join(process.cwd(), 'config');
+  const jobRegistryPath = path.join(
+    configDir,
+    `job-registry.${networkName}.json`
+  );
+  const thermodynamicsPath = path.join(
+    configDir,
+    `thermodynamics.${networkName}.json`
+  );
+
+  afterEach(async () => {
+    await Promise.all(
+      [jobRegistryPath, thermodynamicsPath].map(async (filePath) => {
+        try {
+          await fs.unlink(filePath);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw error;
+          }
+        }
+      })
+    );
+  });
+
+  it('writes network-specific owner control overrides', async () => {
+    const overrides = {
+      taxPolicy: '0x0000000000000000000000000000000000000001',
+      rewardEngine: '0x0000000000000000000000000000000000000002',
+      thermostat: '0x0000000000000000000000000000000000000003',
+    };
+
+    const result = await writeDemoNetworkConfig(networkName, overrides);
+    expect(result.jobRegistryPath).toBe(jobRegistryPath);
+    expect(result.thermodynamicsPath).toBe(thermodynamicsPath);
+
+    const jobRegistryRaw = await fs.readFile(jobRegistryPath, 'utf8');
+    const jobRegistryConfig = JSON.parse(jobRegistryRaw) as Record<string, unknown>;
+    expect(jobRegistryConfig.taxPolicy).toBe(overrides.taxPolicy);
+
+    const thermoRaw = await fs.readFile(thermodynamicsPath, 'utf8');
+    const thermoConfig = JSON.parse(thermoRaw) as Record<string, any>;
+    expect(thermoConfig.rewardEngine.address).toBe(overrides.rewardEngine);
+    expect(thermoConfig.rewardEngine.thermostat).toBe(overrides.thermostat);
+    expect(thermoConfig.thermostat.address).toBe(overrides.thermostat);
+  });
+});

--- a/scripts/v2/demoHardhatOwnerMatrixConfig.ts
+++ b/scripts/v2/demoHardhatOwnerMatrixConfig.ts
@@ -10,6 +10,12 @@ const DEFAULT_OUTPUT = path.join(
   'demo-hardhat-addresses.json'
 );
 
+interface DemoAddressOverrides {
+  taxPolicy: string;
+  rewardEngine: string;
+  thermostat: string;
+}
+
 function resolveOutputPath(): string {
   const override = process.env.OWNER_MATRIX_DEMO_ADDRESS_BOOK;
   if (!override || override.trim().length === 0) {
@@ -35,6 +41,51 @@ async function loadThermostatConfig(): Promise<{ temp: bigint; min: bigint; max:
     min: BigInt(minRaw),
     max: BigInt(maxRaw),
   };
+}
+
+export async function writeDemoNetworkConfig(
+  networkName: string,
+  overrides: DemoAddressOverrides
+): Promise<{ jobRegistryPath: string; thermodynamicsPath: string }> {
+  const configDir = path.join(process.cwd(), 'config');
+  const jobRegistrySource = path.join(configDir, 'job-registry.json');
+  const thermoSource = path.join(configDir, 'thermodynamics.json');
+
+  const jobRegistryRaw = await fs.readFile(jobRegistrySource, 'utf8');
+  const jobRegistryConfig = JSON.parse(jobRegistryRaw) as Record<string, unknown>;
+  jobRegistryConfig.taxPolicy = overrides.taxPolicy;
+
+  const thermoRaw = await fs.readFile(thermoSource, 'utf8');
+  const thermoConfig = JSON.parse(thermoRaw) as Record<string, any>;
+  const rewardEngineConfig = {
+    ...(thermoConfig.rewardEngine ?? {}),
+    address: overrides.rewardEngine,
+    thermostat: overrides.thermostat,
+  };
+  thermoConfig.rewardEngine = rewardEngineConfig;
+  thermoConfig.thermostat = {
+    ...(thermoConfig.thermostat ?? {}),
+    address: overrides.thermostat,
+  };
+
+  const jobRegistryPath = path.join(configDir, `job-registry.${networkName}.json`);
+  const thermodynamicsPath = path.join(
+    configDir,
+    `thermodynamics.${networkName}.json`
+  );
+
+  await fs.writeFile(
+    jobRegistryPath,
+    `${JSON.stringify(jobRegistryConfig, null, 2)}\n`,
+    'utf8'
+  );
+  await fs.writeFile(
+    thermodynamicsPath,
+    `${JSON.stringify(thermoConfig, null, 2)}\n`,
+    'utf8'
+  );
+
+  return { jobRegistryPath, thermodynamicsPath };
 }
 
 async function main(): Promise<void> {
@@ -108,6 +159,12 @@ async function main(): Promise<void> {
     thermostat: await thermostat.getAddress(),
   };
 
+  await writeDemoNetworkConfig(network.name, {
+    taxPolicy: payload.taxPolicy,
+    rewardEngine: payload.rewardEngine,
+    thermostat: payload.thermostat,
+  });
+
   await fs.mkdir(path.dirname(outputPath), { recursive: true });
   await fs.writeFile(outputPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 
@@ -115,7 +172,9 @@ async function main(): Promise<void> {
   console.table(payload);
 }
 
-main().catch((error) => {
-  console.error('demoHardhatOwnerMatrixConfig failed:', error);
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('demoHardhatOwnerMatrixConfig failed:', error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
### Motivation

- The owner parameter matrix demo failed because JobRegistry.taxPolicy and RewardEngine.address were zero in demo configs, causing validation errors during Hardhat demo runs.
- The intent is to ensure demo pipelines produce non-zero addresses that correspond to deployed demo contracts without hardcoding static addresses.
- Changes must be scoped to local Hardhat/demo execution and must not weaken production validations.

### Description

- Exported a new helper `writeDemoNetworkConfig` in `scripts/v2/demoHardhatOwnerMatrixConfig.ts` that writes `config/job-registry.<network>.json` and `config/thermodynamics.<network>.json` with runtime addresses derived from the demo deployments. 
- The demo seeder now calls `writeDemoNetworkConfig` after deploying `TaxPolicy`, `Thermostat`, and `RewardEngineMB` so subsequent owner-matrix steps read non-zero, usable addresses. 
- Guarded the script entrypoint with `if (require.main === module)` so the writer can be imported and unit-tested without executing deployments on import. 
- Added a unit test `scripts/v2/__tests__/demoHardhatOwnerMatrixConfig.test.ts` to verify the override writer produces network-specific config files containing the expected non-zero addresses.

### Testing

- Ran `npm run ci:preflight` which passed successfully. 
- Ran CI context checks `npm run ci:sync-contexts -- --check`, `npm run ci:verify-contexts`, `npm run ci:verify-companion-contexts`, and `npm run ci:verify-summary-needs`, all of which passed. 
- Executed the new unit test with `npx jest scripts/v2/__tests__/demoHardhatOwnerMatrixConfig.test.ts` which passed. 
- Attempted `npm run demo:asi-global` to validate the full demo pipeline, but the compile/demo step hung and was manually interrupted, so end-to-end demo verification remains pending; the changes are nonetheless limited to Hardhat/demo flow and do not alter production validation logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696197fca8508333829df64232921858)