### PR TITLE
Ensure demo owner matrix derives hardhat addresses

### DIFF
--- a/scripts/v2/__tests__/ownerParameterMatrix.test.ts
+++ b/scripts/v2/__tests__/ownerParameterMatrix.test.ts
@@ -60,6 +60,16 @@ describe('prepareDemoOverrides', () => {
     'generated',
     'demo-hardhat-owner-matrix'
   );
+  const hardhatJobRegistryPath = path.join(
+    process.cwd(),
+    'config',
+    'job-registry.hardhat.json'
+  );
+  const hardhatThermoPath = path.join(
+    process.cwd(),
+    'config',
+    'thermodynamics.hardhat.json'
+  );
 
   afterEach(async () => {
     if (existsSync(defaultPath)) {
@@ -67,6 +77,12 @@ describe('prepareDemoOverrides', () => {
     }
     if (existsSync(overridesDir)) {
       await fs.rm(overridesDir, { recursive: true, force: true });
+    }
+    if (existsSync(hardhatJobRegistryPath)) {
+      await fs.unlink(hardhatJobRegistryPath);
+    }
+    if (existsSync(hardhatThermoPath)) {
+      await fs.unlink(hardhatThermoPath);
     }
   });
 
@@ -97,5 +113,47 @@ describe('prepareDemoOverrides', () => {
     const thermo = JSON.parse(thermoRaw);
     expect(thermo.rewardEngine.address).toBe('0x0000000000000000000000000000000000000002');
     expect(thermo.rewardEngine.thermostat).toBe('0x0000000000000000000000000000000000000003');
+  });
+
+  it('derives demo overrides from hardhat config files when the address book is missing', async () => {
+    await fs.mkdir(path.dirname(hardhatJobRegistryPath), { recursive: true });
+    await fs.writeFile(
+      hardhatJobRegistryPath,
+      JSON.stringify(
+        {
+          taxPolicy: '0x0000000000000000000000000000000000000004',
+        },
+        null,
+        2
+      )
+    );
+    await fs.writeFile(
+      hardhatThermoPath,
+      JSON.stringify(
+        {
+          rewardEngine: {
+            address: '0x0000000000000000000000000000000000000005',
+          },
+          thermostat: {
+            address: '0x0000000000000000000000000000000000000006',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const overrides = await prepareDemoOverrides('hardhat');
+    expect(overrides?.jobRegistryPath).toBeDefined();
+    expect(overrides?.thermodynamicsPath).toBeDefined();
+
+    const jobRegistryRaw = await fs.readFile(overrides!.jobRegistryPath!, 'utf8');
+    const jobRegistry = JSON.parse(jobRegistryRaw);
+    expect(jobRegistry.taxPolicy).toBe('0x0000000000000000000000000000000000000004');
+
+    const thermoRaw = await fs.readFile(overrides!.thermodynamicsPath!, 'utf8');
+    const thermo = JSON.parse(thermoRaw);
+    expect(thermo.rewardEngine.address).toBe('0x0000000000000000000000000000000000000005');
+    expect(thermo.thermostat.address).toBe('0x0000000000000000000000000000000000000006');
   });
 });

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -244,6 +244,45 @@ async function loadDemoAddressBook(filePath: string): Promise<DemoAddressBook> {
   };
 }
 
+async function deriveDemoAddressBookFromConfigs(
+  network: string
+): Promise<DemoAddressBook | null> {
+  const configDir = path.join(process.cwd(), 'config');
+  const jobRegistryPath = path.join(configDir, `job-registry.${network}.json`);
+  const thermodynamicsPath = path.join(configDir, `thermodynamics.${network}.json`);
+
+  if (!existsSync(jobRegistryPath) || !existsSync(thermodynamicsPath)) {
+    return null;
+  }
+
+  try {
+    const jobRegistryRaw = await fs.readFile(jobRegistryPath, 'utf8');
+    const jobRegistryConfig = JSON.parse(jobRegistryRaw) as Record<string, unknown>;
+    const thermodynamicsRaw = await fs.readFile(thermodynamicsPath, 'utf8');
+    const thermodynamicsConfig = JSON.parse(thermodynamicsRaw) as Record<string, any>;
+
+    const thermostatCandidate =
+      thermodynamicsConfig?.thermostat?.address ??
+      thermodynamicsConfig?.rewardEngine?.thermostat;
+
+    return {
+      taxPolicy: normaliseDemoAddress(jobRegistryConfig.taxPolicy, 'taxPolicy'),
+      rewardEngine: normaliseDemoAddress(
+        thermodynamicsConfig?.rewardEngine?.address,
+        'rewardEngine'
+      ),
+      thermostat: thermostatCandidate
+        ? normaliseDemoAddress(thermostatCandidate, 'thermostat')
+        : undefined,
+    };
+  } catch (error) {
+    if (process.env.DEBUG_OWNER_MATRIX) {
+      console.warn('Failed to derive demo address book from configs:', error);
+    }
+    return null;
+  }
+}
+
 async function writeDemoConfigOverrides(
   addressBook: DemoAddressBook,
   network?: string
@@ -294,15 +333,27 @@ export async function prepareDemoOverrides(
   network?: string
 ): Promise<DemoConfigOverrides | null> {
   const addressBookPath = resolveDemoAddressBookPath(network);
-  if (!addressBookPath) {
-    return null;
-  }
   if (!network || !LOCAL_NETWORKS.has(network)) {
     throw new Error(
       `${DEMO_ADDRESS_BOOK_ENV} is only supported on local hardhat networks`
     );
   }
-  const addressBook = await loadDemoAddressBook(addressBookPath);
+  let addressBook: DemoAddressBook | null = null;
+  if (addressBookPath) {
+    try {
+      addressBook = await loadDemoAddressBook(addressBookPath);
+    } catch (error) {
+      if (process.env.DEBUG_OWNER_MATRIX) {
+        console.warn('Failed to load demo address book, falling back:', error);
+      }
+    }
+  }
+  if (!addressBook) {
+    addressBook = await deriveDemoAddressBookFromConfigs(network);
+  }
+  if (!addressBook) {
+    return null;
+  }
   return writeDemoConfigOverrides(addressBook, network);
 }
 


### PR DESCRIPTION
### Motivation
- Local demo runs (Hardhat) were failing because owner parameter loaders saw zero-address placeholders for TaxPolicy and RewardEngine, causing the owner matrix step to exit non‑zero.
- The root cause was a missing/invalid demo address book file so later loaders picked up the default config values containing `0x0000...` placeholders.
- The fix must be scoped to local demo execution and not relax production validations. 
- The change should make demos deterministic in CI by sourcing addresses from Hardhat-generated configs produced during demo bootstrap.

### Description
- Add `deriveDemoAddressBookFromConfigs` to `scripts/v2/ownerParameterMatrix.ts` to read `config/job-registry.<network>.json` and `config/thermodynamics.<network>.json` and normalise addresses for `taxPolicy`, `rewardEngine`, and `thermostat`.
- Update `prepareDemoOverrides` to first attempt loading the demo address book, then fall back to deriving addresses from the hardhat config outputs, and finally write per-network override files via `writeDemoConfigOverrides` when available.
- Extend `scripts/v2/__tests__/ownerParameterMatrix.test.ts` with a new test that verifies the fallback path by writing `job-registry.hardhat.json` and `thermodynamics.hardhat.json` fixtures and asserting overrides are generated.
- The changes are local/demo-only (guarded by `LOCAL_NETWORKS` and the existing `OWNER_MATRIX_DEMO_ADDRESS_BOOK` semantics) and do not alter production validations which still reject zero addresses.

### Testing
- Unit test: ran `npx jest scripts/v2/__tests__/ownerParameterMatrix.test.ts` and all tests passed.
- Demo flows: ran `npm run demo:asi-global`, `npm run demo:zenith-hypernova`, and `npm run demo:aurora:local`, and the owner matrix / thermodynamics steps completed without the previous zero-address failures.
- CI checks: ran `npm run ci:preflight`, `npm run ci:sync-contexts -- --check`, `npm run ci:verify-contexts`, and `npm run ci:verify-companion-contexts`, and they succeeded.
- Additional verification: ran `npm run ci:verify-summary-needs` and confirmed coverage for demo jobs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961bb643228833398b95cd6a226f725)