### PR TITLE
Bootstrap Hardhat owner-matrix addresses when missing

### DIFF
--- a/scripts/v2/__tests__/ownerParameterMatrix.test.ts
+++ b/scripts/v2/__tests__/ownerParameterMatrix.test.ts
@@ -1,5 +1,13 @@
+import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
 import { existsSync, promises as fs } from 'fs';
 import path from 'path';
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(() => {
+    throw new Error('spawn not mocked');
+  }),
+}));
 
 import { prepareDemoOverrides, resolveDemoAddressBookPath } from '../ownerParameterMatrix';
 
@@ -72,6 +80,12 @@ describe('prepareDemoOverrides', () => {
   );
 
   afterEach(async () => {
+    delete process.env.AGJ_DEMO_BOOTSTRAP_HARDHAT;
+    const mockedSpawn = spawn as jest.Mock;
+    mockedSpawn.mockReset();
+    mockedSpawn.mockImplementation(() => {
+      throw new Error('spawn not mocked');
+    });
     if (existsSync(defaultPath)) {
       await fs.unlink(defaultPath);
     }
@@ -155,5 +169,38 @@ describe('prepareDemoOverrides', () => {
     const thermo = JSON.parse(thermoRaw);
     expect(thermo.rewardEngine.address).toBe('0x0000000000000000000000000000000000000005');
     expect(thermo.thermostat.address).toBe('0x0000000000000000000000000000000000000006');
+  });
+
+  it('bootstraps demo overrides when bootstrap is enabled and addresses are missing', async () => {
+    process.env.AGJ_DEMO_BOOTSTRAP_HARDHAT = '1';
+    const mockedSpawn = spawn as jest.Mock;
+    mockedSpawn.mockImplementation(() => {
+      const emitter = new EventEmitter();
+      void (async () => {
+        await fs.mkdir(path.dirname(defaultPath), { recursive: true });
+        await fs.writeFile(
+          defaultPath,
+          JSON.stringify(
+            {
+              taxPolicy: '0x0000000000000000000000000000000000000007',
+              rewardEngine: '0x0000000000000000000000000000000000000008',
+              thermostat: '0x0000000000000000000000000000000000000009',
+            },
+            null,
+            2
+          )
+        );
+        emitter.emit('close', 0);
+      })();
+      return emitter;
+    });
+
+    const overrides = await prepareDemoOverrides('hardhat');
+    expect(mockedSpawn).toHaveBeenCalled();
+    expect(overrides?.jobRegistryPath).toBeDefined();
+
+    const jobRegistryRaw = await fs.readFile(overrides!.jobRegistryPath!, 'utf8');
+    const jobRegistry = JSON.parse(jobRegistryRaw);
+    expect(jobRegistry.taxPolicy).toBe('0x0000000000000000000000000000000000000007');
   });
 });

--- a/scripts/v2/asiGlobalDemo.ts
+++ b/scripts/v2/asiGlobalDemo.ts
@@ -438,6 +438,7 @@ async function main(): Promise<void> {
       ],
       env: {
         OWNER_MATRIX_DEMO_ADDRESS_BOOK: DEMO_ADDRESS_BOOK_PATH,
+        AGJ_DEMO_BOOTSTRAP_HARDHAT: '1',
       },
     },
     {
@@ -458,6 +459,7 @@ async function main(): Promise<void> {
       ],
       env: {
         OWNER_MATRIX_DEMO_ADDRESS_BOOK: DEMO_ADDRESS_BOOK_PATH,
+        AGJ_DEMO_BOOTSTRAP_HARDHAT: '1',
       },
     },
     {

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'child_process';
 import { existsSync, promises as fs } from 'fs';
 import path from 'path';
 import { ethers } from 'ethers';
@@ -88,6 +89,14 @@ const DEFAULT_DEMO_ADDRESS_BOOK = path.join(
   'deployment-config',
   'generated',
   'demo-hardhat-addresses.json'
+);
+const OWNER_MATRIX_BOOTSTRAP_ENV = 'OWNER_MATRIX_BOOTSTRAP_HARDHAT';
+const DEMO_BOOTSTRAP_ENV = 'AGJ_DEMO_BOOTSTRAP_HARDHAT';
+const DEMO_BOOTSTRAP_SCRIPT = path.join(
+  process.cwd(),
+  'scripts',
+  'v2',
+  'demoHardhatOwnerMatrixConfig.ts'
 );
 
 async function resolveHardhatContext(): Promise<HardhatContext> {
@@ -215,6 +224,61 @@ export function resolveDemoAddressBookPath(network?: string): string | undefined
     return trimmed;
   }
   return path.join(process.cwd(), trimmed);
+}
+
+function shouldBootstrapDemo(): boolean {
+  const explicit = process.env[OWNER_MATRIX_BOOTSTRAP_ENV];
+  if (explicit !== undefined) {
+    return explicit.trim() !== '' && explicit !== '0';
+  }
+  const fallback = process.env[DEMO_BOOTSTRAP_ENV];
+  return fallback !== undefined && fallback.trim() !== '' && fallback !== '0';
+}
+
+function resolveBootstrapAddressBookPath(
+  network: string,
+  resolvedPath?: string
+): string | undefined {
+  if (!LOCAL_NETWORKS.has(network)) {
+    return undefined;
+  }
+  return resolvedPath ?? DEFAULT_DEMO_ADDRESS_BOOK;
+}
+
+async function runDemoBootstrap(
+  network: string,
+  addressBookPath?: string
+): Promise<void> {
+  const outputPath = resolveBootstrapAddressBookPath(network, addressBookPath);
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      'npx',
+      [
+        'hardhat',
+        'run',
+        '--no-compile',
+        DEMO_BOOTSTRAP_SCRIPT,
+        '--network',
+        network,
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          ...(outputPath ? { [DEMO_ADDRESS_BOOK_ENV]: outputPath } : {}),
+        },
+        stdio: 'inherit',
+      }
+    );
+    child.on('error', (error) => reject(error));
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Demo bootstrap exited with code ${code ?? 'unknown'}`));
+      }
+    });
+  });
 }
 
 function normaliseDemoAddress(value: unknown, label: string): string {
@@ -350,6 +414,19 @@ export async function prepareDemoOverrides(
   }
   if (!addressBook) {
     addressBook = await deriveDemoAddressBookFromConfigs(network);
+  }
+  if (!addressBook && network && LOCAL_NETWORKS.has(network) && shouldBootstrapDemo()) {
+    const bootstrapPath = resolveBootstrapAddressBookPath(network, addressBookPath);
+    await runDemoBootstrap(network, bootstrapPath);
+    try {
+      if (bootstrapPath) {
+        addressBook = await loadDemoAddressBook(bootstrapPath);
+      }
+    } catch (error) {
+      if (process.env.DEBUG_OWNER_MATRIX) {
+        console.warn('Failed to load demo address book after bootstrap:', error);
+      }
+    }
   }
   if (!addressBook) {
     return null;
@@ -758,6 +835,8 @@ async function main(): Promise<void> {
       '',
       `Environment:`,
       `  ${DEMO_ADDRESS_BOOK_ENV}=<path>  Path to demo address book JSON for hardhat demos.`,
+      `  ${OWNER_MATRIX_BOOTSTRAP_ENV}=1  Auto-deploy demo contracts when addresses are missing (hardhat only).`,
+      `  ${DEMO_BOOTSTRAP_ENV}=1         Alias to bootstrap local demo contracts.`,
       '  -h, --help             Show this message',
     ].join(NEWLINE);
     process.stdout.write(`${helpText}\n`);


### PR DESCRIPTION
### Motivation
- Owner parameter matrix demo steps were failing because JobRegistry `taxPolicy` and Thermodynamics `rewardEngine` were left as the zero address in local demo configs.
- The intended behavior for CI/Hardhat demos is to produce deterministic, usable local contract addresses rather than hardcoding nonzero placeholders or weakening validation.
- Provide a scoped Hardhat-only fallback that deploys minimal demo fixtures and writes a transient demo address book so the owner matrix can read real addresses during demo runs.
- Keep production validations unchanged and confine the new behavior to local demo/CI runs.

### Description
- Add a Hardhat-only bootstrap flow to `scripts/v2/ownerParameterMatrix.ts` that runs `npx hardhat run --no-compile scripts/v2/demoHardhatOwnerMatrixConfig.ts --network <network>` (via `runDemoBootstrap`) when local demo addresses are missing and `OWNER_MATRIX_BOOTSTRAP_HARDHAT` or `AGJ_DEMO_BOOTSTRAP_HARDHAT` is set.
- Add helper functions `shouldBootstrapDemo`, `resolveBootstrapAddressBookPath`, and `runDemoBootstrap`, and update help text to document `OWNER_MATRIX_BOOTSTRAP_HARDHAT`/`AGJ_DEMO_BOOTSTRAP_HARDHAT` and demo address book behavior.
- Wire `AGJ_DEMO_BOOTSTRAP_HARDHAT=1` into the ASI global demo (`scripts/v2/asiGlobalDemo.ts`) for both the seed and parameter-matrix steps so the demo pipeline will auto-bootstrap on Hardhat in CI/demo runs.
- Extend `scripts/v2/__tests__/ownerParameterMatrix.test.ts` to mock `child_process.spawn` and add a test that exercises the bootstrap path and verifies the generated overrides are written and consumed.

### Testing
- Ran `npx jest scripts/v2/__tests__/ownerParameterMatrix.test.ts`; the test suite passed (covering resolve, derive, and bootstrap behaviors).
- Ran `npm run ci:preflight`; preflight toolchain/lock checks passed.
- Ran `npm run ci:sync-contexts -- --check`, `npm run ci:verify-contexts`, `npm run ci:verify-companion-contexts`, and `npm run ci:verify-summary-needs`; all context/verifier checks passed.
- Attempted demo runs (`npm run demo:asi-global`, `npm run demo:zenith-hypernova`, `npm run demo:aurora:local`) to exercise the full bootstrap + compile flow, but Hardhat compilation/demo processes did not complete within the local run (long-running compile/Hardhat activity); the bootstrap code is exercised by unit tests and the demo env wiring is in place for CI runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625a02e5e88333ac865c4fe5e0d18f)