### PR TITLE
Fix demo workflows: bootstrap hardhat owner-matrix addresses in CI

### DIFF
--- a/scripts/v2/__tests__/ownerParameterMatrix.test.ts
+++ b/scripts/v2/__tests__/ownerParameterMatrix.test.ts
@@ -78,9 +78,15 @@ describe('prepareDemoOverrides', () => {
     'config',
     'thermodynamics.hardhat.json'
   );
+  const originalCi = process.env.CI;
 
   afterEach(async () => {
     delete process.env.AGJ_DEMO_BOOTSTRAP_HARDHAT;
+    if (originalCi === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCi;
+    }
     const mockedSpawn = spawn as jest.Mock;
     mockedSpawn.mockReset();
     mockedSpawn.mockImplementation(() => {
@@ -202,5 +208,38 @@ describe('prepareDemoOverrides', () => {
     const jobRegistryRaw = await fs.readFile(overrides!.jobRegistryPath!, 'utf8');
     const jobRegistry = JSON.parse(jobRegistryRaw);
     expect(jobRegistry.taxPolicy).toBe('0x0000000000000000000000000000000000000007');
+  });
+
+  it('bootstraps demo overrides in CI without explicit env', async () => {
+    process.env.CI = 'true';
+    const mockedSpawn = spawn as jest.Mock;
+    mockedSpawn.mockImplementation(() => {
+      const emitter = new EventEmitter();
+      void (async () => {
+        await fs.mkdir(path.dirname(defaultPath), { recursive: true });
+        await fs.writeFile(
+          defaultPath,
+          JSON.stringify(
+            {
+              taxPolicy: '0x0000000000000000000000000000000000000010',
+              rewardEngine: '0x0000000000000000000000000000000000000011',
+              thermostat: '0x0000000000000000000000000000000000000012',
+            },
+            null,
+            2
+          )
+        );
+        emitter.emit('close', 0);
+      })();
+      return emitter;
+    });
+
+    const overrides = await prepareDemoOverrides('hardhat');
+    expect(mockedSpawn).toHaveBeenCalled();
+    expect(overrides?.jobRegistryPath).toBeDefined();
+
+    const jobRegistryRaw = await fs.readFile(overrides!.jobRegistryPath!, 'utf8');
+    const jobRegistry = JSON.parse(jobRegistryRaw);
+    expect(jobRegistry.taxPolicy).toBe('0x0000000000000000000000000000000000000010');
   });
 });

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -402,6 +402,7 @@ export async function prepareDemoOverrides(
       `${DEMO_ADDRESS_BOOK_ENV} is only supported on local hardhat networks`
     );
   }
+  const bootstrapEnabled = shouldBootstrapDemo() || process.env.CI === 'true';
   let addressBook: DemoAddressBook | null = null;
   if (addressBookPath) {
     try {
@@ -415,7 +416,7 @@ export async function prepareDemoOverrides(
   if (!addressBook) {
     addressBook = await deriveDemoAddressBookFromConfigs(network);
   }
-  if (!addressBook && network && LOCAL_NETWORKS.has(network) && shouldBootstrapDemo()) {
+  if (!addressBook && network && LOCAL_NETWORKS.has(network) && bootstrapEnabled) {
     const bootstrapPath = resolveBootstrapAddressBookPath(network, addressBookPath);
     await runDemoBootstrap(network, bootstrapPath);
     try {


### PR DESCRIPTION
### Motivation
- CI demo runs were failing during the Owner parameter matrix step because `taxPolicy` and `rewardEngine` addresses were resolving to the zero address when the local demo address book was absent. 
- The intent is to ensure Hardhat demo bootstrapping runs deterministically in CI so owner-parameter validation sees non-zero addresses, without weakening production validations. 
- Bootstrapping should remain hardhat/local-only and deterministic (no secrets, deploy minimal mocks), and should not commit ephemeral addresses into persistent config. 
- A minimal, centralized change is preferred so all demo scripts benefit and regressions are covered by tests. 

### Description
- Detect CI and enable the existing hardhat demo bootstrap in `prepareDemoOverrides` by setting `bootstrapEnabled = shouldBootstrapDemo() || process.env.CI === 'true'` and use that flag to run `runDemoBootstrap`. 
- Leave validation logic intact; the change only enables the existing Hardhat bootstrap path in CI when overrides are missing. 
- Add a unit test case that simulates CI (`process.env.CI = 'true'`) to verify the bootstrap path is invoked and writes demo overrides, and ensure test suite restores the original `CI` environment after each test. 
- Changes are limited to `scripts/v2/ownerParameterMatrix.ts` and `scripts/v2/__tests__/ownerParameterMatrix.test.ts`. 

### Testing
- Updated unit tests: `scripts/v2/__tests__/ownerParameterMatrix.test.ts` now includes a CI-bootstrap test scenario covering the new behavior. (This test was added/modified in the patch.)
- Existing unit tests that exercise demo address book derivation and bootstrap behavior were left intact and extended to restore `CI` env state between tests. 
- No automated test suite was executed as part of this change (tests were not run locally in this patch). 
- The change is strictly hardhat/CI-scoped and does not modify production validation paths; CI workflows should now trigger the deterministic Hardhat bootstrap when address overrides are missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627046a8e083338261fd76128bf0bf)