### PR TITLE
Fix demo workflows: bootstrap hardhat owner-matrix addresses

### DIFF
--- a/scripts/v2/__tests__/ownerParameterMatrix.test.ts
+++ b/scripts/v2/__tests__/ownerParameterMatrix.test.ts
@@ -171,8 +171,7 @@ describe('prepareDemoOverrides', () => {
     expect(thermo.thermostat.address).toBe('0x0000000000000000000000000000000000000006');
   });
 
-  it('bootstraps demo overrides when bootstrap is enabled and addresses are missing', async () => {
-    process.env.AGJ_DEMO_BOOTSTRAP_HARDHAT = '1';
+  it('bootstraps demo overrides on local networks when addresses are missing', async () => {
     const mockedSpawn = spawn as jest.Mock;
     mockedSpawn.mockImplementation(() => {
       const emitter = new EventEmitter();
@@ -202,5 +201,11 @@ describe('prepareDemoOverrides', () => {
     const jobRegistryRaw = await fs.readFile(overrides!.jobRegistryPath!, 'utf8');
     const jobRegistry = JSON.parse(jobRegistryRaw);
     expect(jobRegistry.taxPolicy).toBe('0x0000000000000000000000000000000000000007');
+  });
+
+  it('rejects demo overrides on non-local networks', async () => {
+    await expect(prepareDemoOverrides('mainnet')).rejects.toThrow(
+      /only supported on local hardhat networks/
+    );
   });
 });

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -226,13 +226,16 @@ export function resolveDemoAddressBookPath(network?: string): string | undefined
   return path.join(process.cwd(), trimmed);
 }
 
-function shouldBootstrapDemo(): boolean {
+function shouldBootstrapDemo(network?: string): boolean {
   const explicit = process.env[OWNER_MATRIX_BOOTSTRAP_ENV];
   if (explicit !== undefined) {
     return explicit.trim() !== '' && explicit !== '0';
   }
   const fallback = process.env[DEMO_BOOTSTRAP_ENV];
-  return fallback !== undefined && fallback.trim() !== '' && fallback !== '0';
+  if (fallback !== undefined) {
+    return fallback.trim() !== '' && fallback !== '0';
+  }
+  return Boolean(network && LOCAL_NETWORKS.has(network));
 }
 
 function resolveBootstrapAddressBookPath(
@@ -415,7 +418,7 @@ export async function prepareDemoOverrides(
   if (!addressBook) {
     addressBook = await deriveDemoAddressBookFromConfigs(network);
   }
-  if (!addressBook && network && LOCAL_NETWORKS.has(network) && shouldBootstrapDemo()) {
+  if (!addressBook && network && LOCAL_NETWORKS.has(network) && shouldBootstrapDemo(network)) {
     const bootstrapPath = resolveBootstrapAddressBookPath(network, addressBookPath);
     await runDemoBootstrap(network, bootstrapPath);
     try {


### PR DESCRIPTION
### Motivation

- Owner parameter matrix validation failed in CI because config files on local Hardhat runs contained zero-address placeholders for `JobRegistry.taxPolicy` and `Thermodynamics.rewardEngine`, causing demos to error out before demos could bootstrap contracts.
- The bootstrap step only ran when an explicit env flag was set, so CI/demo runs without a generated demo address book still failed deterministically on Hardhat.
- The intent is to ensure demos auto-provision minimal non-zero demo contracts on local Hardhat/localhost to pass owner-parameter validation while preserving strict behavior for non-local networks.

### Description

- Defaulted the demo bootstrap decision to enable auto-bootstrap on local Hardhat/`localhost` networks by changing `shouldBootstrapDemo` to accept a `network` parameter and return true for local networks when no explicit flags are set (file `scripts/v2/ownerParameterMatrix.ts`).
- Hooked the network-aware bootstrap decision into `prepareDemoOverrides` so missing demo addresses on local runs trigger the deterministic Hardhat bootstrap path that deploys demo contracts and writes a generated address book (file `scripts/v2/ownerParameterMatrix.ts`).
- Added/updated unit tests in `scripts/v2/__tests__/ownerParameterMatrix.test.ts` to cover default local bootstrap behavior and to assert non-local networks still reject demo overrides unless explicitly configured.
- Kept the bootstrap gated to local networks only and preserved explicit env flags (`OWNER_MATRIX_BOOTSTRAP_HARDHAT` / `AGJ_DEMO_BOOTSTRAP_HARDHAT`) semantics so production/testnet behavior remains strict.

### Testing

- Ran the updated unit test suite with `npx jest scripts/v2/__tests__/ownerParameterMatrix.test.ts`, and all tests passed.
- Started a `npm run demo:asi-global` run to exercise the full demo path and observed the process reach the Hardhat compile/run stage; the run was long-running in this environment and was manually interrupted (not completed here).
- Verified the changes by committing the two modified files `scripts/v2/ownerParameterMatrix.ts` and `scripts/v2/__tests__/ownerParameterMatrix.test.ts` and creating the PR.
- The change is scoped to demo bootstrapping logic and tests; non-local networks retain existing validation and will still error if required addresses are missing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627046a8e083338261fd76128bf0bf)