### PR TITLE
Fix demo workflows: bootstrap hardhat owner-matrix addresses

### DIFF
--- a/scripts/v2/__tests__/ownerParameterMatrix.test.ts
+++ b/scripts/v2/__tests__/ownerParameterMatrix.test.ts
@@ -1,15 +1,12 @@
-import { spawn } from 'child_process';
-import { EventEmitter } from 'events';
 import { existsSync, promises as fs } from 'fs';
 import path from 'path';
 
-jest.mock('child_process', () => ({
-  spawn: jest.fn(() => {
-    throw new Error('spawn not mocked');
-  }),
+jest.mock('../lib/hardhatOwnerMatrixBootstrap', () => ({
+  bootstrapHardhatOwnerMatrix: jest.fn(),
 }));
 
 import { prepareDemoOverrides, resolveDemoAddressBookPath } from '../ownerParameterMatrix';
+import { bootstrapHardhatOwnerMatrix } from '../lib/hardhatOwnerMatrixBootstrap';
 
 describe('resolveDemoAddressBookPath', () => {
   const envKey = 'OWNER_MATRIX_DEMO_ADDRESS_BOOK';
@@ -81,11 +78,7 @@ describe('prepareDemoOverrides', () => {
 
   afterEach(async () => {
     delete process.env.AGJ_DEMO_BOOTSTRAP_HARDHAT;
-    const mockedSpawn = spawn as jest.Mock;
-    mockedSpawn.mockReset();
-    mockedSpawn.mockImplementation(() => {
-      throw new Error('spawn not mocked');
-    });
+    (bootstrapHardhatOwnerMatrix as jest.Mock).mockReset();
     if (existsSync(defaultPath)) {
       await fs.unlink(defaultPath);
     }
@@ -172,13 +165,11 @@ describe('prepareDemoOverrides', () => {
   });
 
   it('bootstraps demo overrides on local networks when addresses are missing', async () => {
-    const mockedSpawn = spawn as jest.Mock;
-    mockedSpawn.mockImplementation(() => {
-      const emitter = new EventEmitter();
-      void (async () => {
+    (bootstrapHardhatOwnerMatrix as jest.Mock).mockImplementation(
+      async (outputPath?: string) => {
         await fs.mkdir(path.dirname(defaultPath), { recursive: true });
         await fs.writeFile(
-          defaultPath,
+          outputPath ?? defaultPath,
           JSON.stringify(
             {
               taxPolicy: '0x0000000000000000000000000000000000000007',
@@ -189,13 +180,18 @@ describe('prepareDemoOverrides', () => {
             2
           )
         );
-        emitter.emit('close', 0);
-      })();
-      return emitter;
-    });
+        return {
+          generatedAt: new Date().toISOString(),
+          network: 'hardhat',
+          taxPolicy: '0x0000000000000000000000000000000000000007',
+          rewardEngine: '0x0000000000000000000000000000000000000008',
+          thermostat: '0x0000000000000000000000000000000000000009',
+        };
+      }
+    );
 
     const overrides = await prepareDemoOverrides('hardhat');
-    expect(mockedSpawn).toHaveBeenCalled();
+    expect(bootstrapHardhatOwnerMatrix).toHaveBeenCalled();
     expect(overrides?.jobRegistryPath).toBeDefined();
 
     const jobRegistryRaw = await fs.readFile(overrides!.jobRegistryPath!, 'utf8');

--- a/scripts/v2/demoHardhatOwnerMatrixConfig.ts
+++ b/scripts/v2/demoHardhatOwnerMatrixConfig.ts
@@ -1,32 +1,14 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { ethers, network } from 'hardhat';
-import {
-  resolveDemoAddressBookOutputPath,
-  writeDemoAddressBook,
-} from './lib/demoAddressBook';
+import { network } from 'hardhat';
+import { resolveDemoAddressBookOutputPath } from './lib/demoAddressBook';
+import { bootstrapHardhatOwnerMatrix } from './lib/hardhatOwnerMatrixBootstrap';
 
 const LOCAL_NETWORKS = new Set(['hardhat', 'localhost']);
 interface DemoAddressOverrides {
   taxPolicy: string;
   rewardEngine: string;
   thermostat: string;
-}
-
-async function loadThermostatConfig(): Promise<{ temp: bigint; min: bigint; max: bigint }> {
-  const configPath = path.join(process.cwd(), 'config', 'thermodynamics.json');
-  const raw = await fs.readFile(configPath, 'utf8');
-  const parsed = JSON.parse(raw) as Record<string, any>;
-  const thermostat = parsed.thermostat ?? {};
-  const tempRaw = thermostat.systemTemperature ?? thermostat.temperature ?? '1000000000000000000';
-  const bounds = thermostat.bounds ?? {};
-  const minRaw = bounds.min ?? '100000000000000000';
-  const maxRaw = bounds.max ?? '5000000000000000000';
-  return {
-    temp: BigInt(tempRaw),
-    min: BigInt(minRaw),
-    max: BigInt(maxRaw),
-  };
 }
 
 export async function writeDemoNetworkConfig(
@@ -81,77 +63,14 @@ async function main(): Promise<void> {
     );
   }
 
-  const [deployer] = await ethers.getSigners();
-
-  const taxPolicyFactory = await ethers.getContractFactory(
-    'contracts/v2/TaxPolicy.sol:TaxPolicy'
-  );
-  const taxPolicy = await taxPolicyFactory.deploy(
-    'ipfs://demo-tax-policy',
-    'Hardhat demo tax policy acknowledgement.'
-  );
-  await taxPolicy.waitForDeployment();
-
-  const { temp, min, max } = await loadThermostatConfig();
-  const thermostatFactory = await ethers.getContractFactory(
-    'contracts/v2/Thermostat.sol:Thermostat'
-  );
-  const thermostat = await thermostatFactory.deploy(
-    temp,
-    min,
-    max,
-    deployer.address
-  );
-  await thermostat.waitForDeployment();
-
-  const mockFeePoolFactory = await ethers.getContractFactory(
-    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockFeePool'
-  );
-  const mockReputationFactory = await ethers.getContractFactory(
-    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockReputation'
-  );
-  const mockOracleFactory = await ethers.getContractFactory(
-    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockEnergyOracle'
-  );
-
-  const feePool = await mockFeePoolFactory.deploy();
-  const reputation = await mockReputationFactory.deploy();
-  const energyOracle = await mockOracleFactory.deploy();
-
-  await Promise.all([
-    feePool.waitForDeployment(),
-    reputation.waitForDeployment(),
-    energyOracle.waitForDeployment(),
-  ]);
-
-  const rewardEngineFactory = await ethers.getContractFactory(
-    'contracts/v2/RewardEngineMB.sol:RewardEngineMB'
-  );
-  const rewardEngine = await rewardEngineFactory.deploy(
-    await thermostat.getAddress(),
-    await feePool.getAddress(),
-    await reputation.getAddress(),
-    await energyOracle.getAddress(),
-    deployer.address
-  );
-  await rewardEngine.waitForDeployment();
-
-  const payload = {
-    generatedAt: new Date().toISOString(),
-    network: network.name,
-    taxPolicy: await taxPolicy.getAddress(),
-    rewardEngine: await rewardEngine.getAddress(),
-    thermostat: await thermostat.getAddress(),
-  };
+  const outputPath = resolveDemoAddressBookOutputPath();
+  const payload = await bootstrapHardhatOwnerMatrix(outputPath);
 
   await writeDemoNetworkConfig(network.name, {
     taxPolicy: payload.taxPolicy,
     rewardEngine: payload.rewardEngine,
     thermostat: payload.thermostat,
   });
-
-  const outputPath = resolveDemoAddressBookOutputPath();
-  await writeDemoAddressBook(payload, outputPath);
 
   console.log(`Demo owner matrix address book written to ${outputPath}`);
   console.table(payload);

--- a/scripts/v2/lib/hardhatOwnerMatrixBootstrap.ts
+++ b/scripts/v2/lib/hardhatOwnerMatrixBootstrap.ts
@@ -1,0 +1,117 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { ethers, network } from 'hardhat';
+import { resolveDemoAddressBookOutputPath, writeDemoAddressBook } from './demoAddressBook';
+
+const LOCAL_NETWORKS = new Set(['hardhat', 'localhost']);
+
+export interface DemoAddressOverrides {
+  taxPolicy: string;
+  rewardEngine: string;
+  thermostat: string;
+}
+
+export interface DemoAddressBookPayload {
+  generatedAt: string;
+  network: string;
+  taxPolicy: string;
+  rewardEngine: string;
+  thermostat: string;
+}
+
+async function loadThermostatConfig(): Promise<{ temp: bigint; min: bigint; max: bigint }> {
+  const configPath = path.join(process.cwd(), 'config', 'thermodynamics.json');
+  const raw = await fs.readFile(configPath, 'utf8');
+  const parsed = JSON.parse(raw) as Record<string, any>;
+  const thermostat = parsed.thermostat ?? {};
+  const tempRaw = thermostat.systemTemperature ?? thermostat.temperature ?? '1000000000000000000';
+  const bounds = thermostat.bounds ?? {};
+  const minRaw = bounds.min ?? '100000000000000000';
+  const maxRaw = bounds.max ?? '5000000000000000000';
+  return {
+    temp: BigInt(tempRaw),
+    min: BigInt(minRaw),
+    max: BigInt(maxRaw),
+  };
+}
+
+export async function deployHardhatOwnerMatrixContracts(): Promise<DemoAddressOverrides> {
+  const [deployer] = await ethers.getSigners();
+
+  const taxPolicyFactory = await ethers.getContractFactory(
+    'contracts/v2/TaxPolicy.sol:TaxPolicy'
+  );
+  const taxPolicy = await taxPolicyFactory.deploy(
+    'ipfs://demo-tax-policy',
+    'Hardhat demo tax policy acknowledgement.'
+  );
+  await taxPolicy.waitForDeployment();
+
+  const { temp, min, max } = await loadThermostatConfig();
+  const thermostatFactory = await ethers.getContractFactory(
+    'contracts/v2/Thermostat.sol:Thermostat'
+  );
+  const thermostat = await thermostatFactory.deploy(temp, min, max, deployer.address);
+  await thermostat.waitForDeployment();
+
+  const mockFeePoolFactory = await ethers.getContractFactory(
+    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockFeePool'
+  );
+  const mockReputationFactory = await ethers.getContractFactory(
+    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockReputation'
+  );
+  const mockOracleFactory = await ethers.getContractFactory(
+    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockEnergyOracle'
+  );
+
+  const feePool = await mockFeePoolFactory.deploy();
+  const reputation = await mockReputationFactory.deploy();
+  const energyOracle = await mockOracleFactory.deploy();
+
+  await Promise.all([
+    feePool.waitForDeployment(),
+    reputation.waitForDeployment(),
+    energyOracle.waitForDeployment(),
+  ]);
+
+  const rewardEngineFactory = await ethers.getContractFactory(
+    'contracts/v2/RewardEngineMB.sol:RewardEngineMB'
+  );
+  const rewardEngine = await rewardEngineFactory.deploy(
+    await thermostat.getAddress(),
+    await feePool.getAddress(),
+    await reputation.getAddress(),
+    await energyOracle.getAddress(),
+    deployer.address
+  );
+  await rewardEngine.waitForDeployment();
+
+  return {
+    taxPolicy: await taxPolicy.getAddress(),
+    rewardEngine: await rewardEngine.getAddress(),
+    thermostat: await thermostat.getAddress(),
+  };
+}
+
+export async function bootstrapHardhatOwnerMatrix(
+  addressBookPath?: string
+): Promise<DemoAddressBookPayload> {
+  if (!LOCAL_NETWORKS.has(network.name)) {
+    throw new Error(
+      `Demo owner matrix bootstrap can only run on local networks (hardhat/localhost). Current: ${network.name}`
+    );
+  }
+
+  const overrides = await deployHardhatOwnerMatrixContracts();
+  const payload: DemoAddressBookPayload = {
+    generatedAt: new Date().toISOString(),
+    network: network.name,
+    taxPolicy: overrides.taxPolicy,
+    rewardEngine: overrides.rewardEngine,
+    thermostat: overrides.thermostat,
+  };
+
+  const outputPath = addressBookPath ?? resolveDemoAddressBookOutputPath();
+  await writeDemoAddressBook(payload, outputPath);
+  return payload;
+}

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -1,4 +1,3 @@
-import { spawn } from 'child_process';
 import { existsSync, promises as fs } from 'fs';
 import path from 'path';
 import { ethers } from 'ethers';
@@ -14,6 +13,7 @@ import {
   loadPlatformIncentivesConfig,
   loadIdentityRegistryConfig,
 } from '../config';
+import { bootstrapHardhatOwnerMatrix } from './lib/hardhatOwnerMatrixBootstrap';
 
 interface CliOptions {
   network?: string;
@@ -92,12 +92,6 @@ const DEFAULT_DEMO_ADDRESS_BOOK = path.join(
 );
 const OWNER_MATRIX_BOOTSTRAP_ENV = 'OWNER_MATRIX_BOOTSTRAP_HARDHAT';
 const DEMO_BOOTSTRAP_ENV = 'AGJ_DEMO_BOOTSTRAP_HARDHAT';
-const DEMO_BOOTSTRAP_SCRIPT = path.join(
-  process.cwd(),
-  'scripts',
-  'v2',
-  'demoHardhatOwnerMatrixConfig.ts'
-);
 
 async function resolveHardhatContext(): Promise<HardhatContext> {
   try {
@@ -226,7 +220,29 @@ export function resolveDemoAddressBookPath(network?: string): string | undefined
   return path.join(process.cwd(), trimmed);
 }
 
-function shouldBootstrapDemo(network?: string): boolean {
+function isHardhatNetwork(
+  network?: string,
+  context?: HardhatContext
+): boolean {
+  if (network && network.toLowerCase() === 'hardhat') {
+    return true;
+  }
+  if (context?.name && context.name.toLowerCase() === 'hardhat') {
+    return true;
+  }
+  if (context?.chainId === 31337) {
+    return true;
+  }
+  return false;
+}
+
+function shouldBootstrapDemo(
+  network?: string,
+  context?: HardhatContext
+): boolean {
+  if (!isHardhatNetwork(network, context)) {
+    return false;
+  }
   const explicit = process.env[OWNER_MATRIX_BOOTSTRAP_ENV];
   if (explicit !== undefined) {
     return explicit.trim() !== '' && explicit !== '0';
@@ -251,37 +267,14 @@ function resolveBootstrapAddressBookPath(
 async function runDemoBootstrap(
   network: string,
   addressBookPath?: string
-): Promise<void> {
+): Promise<DemoAddressBook> {
   const outputPath = resolveBootstrapAddressBookPath(network, addressBookPath);
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(
-      'npx',
-      [
-        'hardhat',
-        'run',
-        '--no-compile',
-        DEMO_BOOTSTRAP_SCRIPT,
-        '--network',
-        network,
-      ],
-      {
-        cwd: process.cwd(),
-        env: {
-          ...process.env,
-          ...(outputPath ? { [DEMO_ADDRESS_BOOK_ENV]: outputPath } : {}),
-        },
-        stdio: 'inherit',
-      }
-    );
-    child.on('error', (error) => reject(error));
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`Demo bootstrap exited with code ${code ?? 'unknown'}`));
-      }
-    });
-  });
+  const payload = await bootstrapHardhatOwnerMatrix(outputPath);
+  return {
+    taxPolicy: payload.taxPolicy,
+    rewardEngine: payload.rewardEngine,
+    thermostat: payload.thermostat,
+  };
 }
 
 function normaliseDemoAddress(value: unknown, label: string): string {
@@ -396,8 +389,24 @@ async function writeDemoConfigOverrides(
   return { jobRegistryPath, thermodynamicsPath };
 }
 
+async function demoAddressesHaveCode(
+  addressBook: DemoAddressBook
+): Promise<boolean> {
+  const hardhat = await import('hardhat');
+  const addresses = [
+    addressBook.taxPolicy,
+    addressBook.rewardEngine,
+    addressBook.thermostat,
+  ].filter((value): value is string => Boolean(value));
+  const codes = await Promise.all(
+    addresses.map((address) => hardhat.ethers.provider.getCode(address))
+  );
+  return codes.every((code) => code && code !== '0x');
+}
+
 export async function prepareDemoOverrides(
-  network?: string
+  network?: string,
+  hardhatContext?: HardhatContext
 ): Promise<DemoConfigOverrides | null> {
   const addressBookPath = resolveDemoAddressBookPath(network);
   if (!network || !LOCAL_NETWORKS.has(network)) {
@@ -405,6 +414,8 @@ export async function prepareDemoOverrides(
       `${DEMO_ADDRESS_BOOK_ENV} is only supported on local hardhat networks`
     );
   }
+  const canBootstrap = shouldBootstrapDemo(network, hardhatContext);
+  const shouldCheckChain = canBootstrap && Boolean(hardhatContext?.chainId || hardhatContext?.name);
   let addressBook: DemoAddressBook | null = null;
   if (addressBookPath) {
     try {
@@ -418,18 +429,15 @@ export async function prepareDemoOverrides(
   if (!addressBook) {
     addressBook = await deriveDemoAddressBookFromConfigs(network);
   }
-  if (!addressBook && network && LOCAL_NETWORKS.has(network) && shouldBootstrapDemo(network)) {
-    const bootstrapPath = resolveBootstrapAddressBookPath(network, addressBookPath);
-    await runDemoBootstrap(network, bootstrapPath);
-    try {
-      if (bootstrapPath) {
-        addressBook = await loadDemoAddressBook(bootstrapPath);
-      }
-    } catch (error) {
-      if (process.env.DEBUG_OWNER_MATRIX) {
-        console.warn('Failed to load demo address book after bootstrap:', error);
-      }
+  if (addressBook && shouldCheckChain) {
+    const hasCode = await demoAddressesHaveCode(addressBook);
+    if (!hasCode) {
+      addressBook = null;
     }
+  }
+  if (!addressBook && network && LOCAL_NETWORKS.has(network) && canBootstrap) {
+    const bootstrapPath = resolveBootstrapAddressBookPath(network, addressBookPath);
+    addressBook = await runDemoBootstrap(network, bootstrapPath);
   }
   if (!addressBook) {
     return null;
@@ -501,7 +509,8 @@ function flattenConfig(value: unknown, prefix = '', rows: MatrixRow[] = [], dept
 
 async function buildSubsystemMatrices(
   network?: string,
-  demoOverrides?: DemoConfigOverrides
+  demoOverrides?: DemoConfigOverrides,
+  hardhatContext?: HardhatContext
 ): Promise<SubsystemBuildResult[]> {
   let resolvedOverrides = demoOverrides;
   const descriptors: SubsystemDescriptor[] = [
@@ -666,7 +675,7 @@ async function buildSubsystemMatrices(
       });
     } catch (error) {
       if (shouldRetryWithDemoOverrides(descriptor.id, error, network, resolvedOverrides)) {
-        const overrides = await prepareDemoOverrides(network);
+        const overrides = await prepareDemoOverrides(network, hardhatContext);
         if (overrides) {
           resolvedOverrides = overrides;
           try {
@@ -849,8 +858,8 @@ async function main(): Promise<void> {
   const hardhat = await resolveHardhatContext();
   const selectedNetwork = options.network ?? process.env.HARDHAT_NETWORK ?? hardhat.name;
 
-  const demoOverrides = await prepareDemoOverrides(selectedNetwork);
-  const buildResults = await buildSubsystemMatrices(selectedNetwork, demoOverrides);
+  const demoOverrides = await prepareDemoOverrides(selectedNetwork, hardhat);
+  const buildResults = await buildSubsystemMatrices(selectedNetwork, demoOverrides, hardhat);
   const subsystems = buildResults.map((entry) => entry.matrix);
   const matrix: MatrixPayload = {
     network: selectedNetwork,


### PR DESCRIPTION
### Motivation

- Demo runs in CI were failing because the Owner parameter matrix step validated zero addresses for `JobRegistry.taxPolicy` and `RewardEngine.address`. 
- The owner-matrix generation must remain strict for real networks but provide deterministic, non-zero, on-chain addresses for Hardhat demos. 
- Provide a centralized, deterministic Hardhat-only bootstrap to deploy minimal/mock contracts and produce an address book used by the owner-parameter matrix. 

### Description

- Added `scripts/v2/lib/hardhatOwnerMatrixBootstrap.ts` which deploys minimal demo contracts on Hardhat (TaxPolicy, Thermostat, Mock FeePool/Reputation/EnergyOracle and `RewardEngineMB`) and writes a demo address book. 
- Updated `scripts/v2/ownerParameterMatrix.ts` to detect Hardhat context (`chainId`/network name), verify that candidate demo addresses have on-chain code, and invoke the bootstrap helper when addresses are missing or invalid; bootstrapped addresses are written to config overrides that the matrix loaders consume. 
- Replaced in-file deployment plumbing in `scripts/v2/demoHardhatOwnerMatrixConfig.ts` with calls to the new centralized bootstrap helper. 
- Adjusted `scripts/v2/__tests__/ownerParameterMatrix.test.ts` to mock `bootstrapHardhatOwnerMatrix` and assert the prepare/override flow; tests were updated to reflect the new bootstrapping path. 

### Testing

- Unit tests updated: `scripts/v2/__tests__/ownerParameterMatrix.test.ts` now mocks `bootstrapHardhatOwnerMatrix` and validates override file generation (tests modified but not executed in this patch). 
- No demo or CI workflows were executed as part of this change (no `npm run demo:*` or `npm run ci:*` was run locally). 
- Recommend running `npm run demo:asi-global` / `npm run demo:zenith-hypernova` and the CI preflight suite (`npm run ci:preflight`, `npm run ci:verify-toolchain`, `npm run ci:sync-contexts -- --check`, etc.) to verify end-to-end behaviour in a Hardhat environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627d51304c83339b1ed614c1ecad71)