### PR TITLE
Fix demo workflows: bootstrap hardhat owner-matrix addresses

### DIFF
--- a/scripts/v2/__tests__/ownerParameterMatrix.test.ts
+++ b/scripts/v2/__tests__/ownerParameterMatrix.test.ts
@@ -203,6 +203,50 @@ describe('prepareDemoOverrides', () => {
     expect(jobRegistry.taxPolicy).toBe('0x0000000000000000000000000000000000000007');
   });
 
+  it('bootstraps demo overrides when local configs contain zero addresses', async () => {
+    await fs.mkdir(path.dirname(hardhatJobRegistryPath), { recursive: true });
+    await fs.writeFile(
+      hardhatJobRegistryPath,
+      JSON.stringify({ taxPolicy: '0x0000000000000000000000000000000000000000' }, null, 2)
+    );
+    await fs.writeFile(
+      hardhatThermoPath,
+      JSON.stringify(
+        { rewardEngine: { address: '0x0000000000000000000000000000000000000000' } },
+        null,
+        2
+      )
+    );
+
+    const mockedSpawn = spawn as jest.Mock;
+    mockedSpawn.mockImplementation(() => {
+      const emitter = new EventEmitter();
+      void (async () => {
+        await fs.mkdir(path.dirname(defaultPath), { recursive: true });
+        await fs.writeFile(
+          defaultPath,
+          JSON.stringify(
+            {
+              taxPolicy: '0x0000000000000000000000000000000000000011',
+              rewardEngine: '0x0000000000000000000000000000000000000022',
+              thermostat: '0x0000000000000000000000000000000000000033',
+            },
+            null,
+            2
+          )
+        );
+        emitter.emit('close', 0);
+      })();
+      return emitter;
+    });
+
+    const overrides = await prepareDemoOverrides('hardhat');
+    expect(mockedSpawn).toHaveBeenCalled();
+    const jobRegistryRaw = await fs.readFile(overrides!.jobRegistryPath!, 'utf8');
+    const jobRegistry = JSON.parse(jobRegistryRaw);
+    expect(jobRegistry.taxPolicy).toBe('0x0000000000000000000000000000000000000011');
+  });
+
   it('rejects demo overrides on non-local networks', async () => {
     await expect(prepareDemoOverrides('mainnet')).rejects.toThrow(
       /only supported on local hardhat networks/

--- a/scripts/v2/demoHardhatOwnerMatrixConfig.ts
+++ b/scripts/v2/demoHardhatOwnerMatrixConfig.ts
@@ -1,78 +1,9 @@
 import { promises as fs } from 'fs';
-import path from 'path';
-import { ethers, network } from 'hardhat';
-import {
-  resolveDemoAddressBookOutputPath,
-  writeDemoAddressBook,
-} from './lib/demoAddressBook';
+import { network } from 'hardhat';
+import { resolveDemoAddressBookOutputPath } from './lib/demoAddressBook';
+import { bootstrapHardhatDemoConfig } from './lib/hardhatDemoBootstrap';
 
 const LOCAL_NETWORKS = new Set(['hardhat', 'localhost']);
-interface DemoAddressOverrides {
-  taxPolicy: string;
-  rewardEngine: string;
-  thermostat: string;
-}
-
-async function loadThermostatConfig(): Promise<{ temp: bigint; min: bigint; max: bigint }> {
-  const configPath = path.join(process.cwd(), 'config', 'thermodynamics.json');
-  const raw = await fs.readFile(configPath, 'utf8');
-  const parsed = JSON.parse(raw) as Record<string, any>;
-  const thermostat = parsed.thermostat ?? {};
-  const tempRaw = thermostat.systemTemperature ?? thermostat.temperature ?? '1000000000000000000';
-  const bounds = thermostat.bounds ?? {};
-  const minRaw = bounds.min ?? '100000000000000000';
-  const maxRaw = bounds.max ?? '5000000000000000000';
-  return {
-    temp: BigInt(tempRaw),
-    min: BigInt(minRaw),
-    max: BigInt(maxRaw),
-  };
-}
-
-export async function writeDemoNetworkConfig(
-  networkName: string,
-  overrides: DemoAddressOverrides
-): Promise<{ jobRegistryPath: string; thermodynamicsPath: string }> {
-  const configDir = path.join(process.cwd(), 'config');
-  const jobRegistrySource = path.join(configDir, 'job-registry.json');
-  const thermoSource = path.join(configDir, 'thermodynamics.json');
-
-  const jobRegistryRaw = await fs.readFile(jobRegistrySource, 'utf8');
-  const jobRegistryConfig = JSON.parse(jobRegistryRaw) as Record<string, unknown>;
-  jobRegistryConfig.taxPolicy = overrides.taxPolicy;
-
-  const thermoRaw = await fs.readFile(thermoSource, 'utf8');
-  const thermoConfig = JSON.parse(thermoRaw) as Record<string, any>;
-  const rewardEngineConfig = {
-    ...(thermoConfig.rewardEngine ?? {}),
-    address: overrides.rewardEngine,
-    thermostat: overrides.thermostat,
-  };
-  thermoConfig.rewardEngine = rewardEngineConfig;
-  thermoConfig.thermostat = {
-    ...(thermoConfig.thermostat ?? {}),
-    address: overrides.thermostat,
-  };
-
-  const jobRegistryPath = path.join(configDir, `job-registry.${networkName}.json`);
-  const thermodynamicsPath = path.join(
-    configDir,
-    `thermodynamics.${networkName}.json`
-  );
-
-  await fs.writeFile(
-    jobRegistryPath,
-    `${JSON.stringify(jobRegistryConfig, null, 2)}\n`,
-    'utf8'
-  );
-  await fs.writeFile(
-    thermodynamicsPath,
-    `${JSON.stringify(thermoConfig, null, 2)}\n`,
-    'utf8'
-  );
-
-  return { jobRegistryPath, thermodynamicsPath };
-}
 
 async function main(): Promise<void> {
   if (!LOCAL_NETWORKS.has(network.name)) {
@@ -81,78 +12,10 @@ async function main(): Promise<void> {
     );
   }
 
-  const [deployer] = await ethers.getSigners();
-
-  const taxPolicyFactory = await ethers.getContractFactory(
-    'contracts/v2/TaxPolicy.sol:TaxPolicy'
-  );
-  const taxPolicy = await taxPolicyFactory.deploy(
-    'ipfs://demo-tax-policy',
-    'Hardhat demo tax policy acknowledgement.'
-  );
-  await taxPolicy.waitForDeployment();
-
-  const { temp, min, max } = await loadThermostatConfig();
-  const thermostatFactory = await ethers.getContractFactory(
-    'contracts/v2/Thermostat.sol:Thermostat'
-  );
-  const thermostat = await thermostatFactory.deploy(
-    temp,
-    min,
-    max,
-    deployer.address
-  );
-  await thermostat.waitForDeployment();
-
-  const mockFeePoolFactory = await ethers.getContractFactory(
-    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockFeePool'
-  );
-  const mockReputationFactory = await ethers.getContractFactory(
-    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockReputation'
-  );
-  const mockOracleFactory = await ethers.getContractFactory(
-    'contracts/v2/mocks/RewardEngineMBMocks.sol:MockEnergyOracle'
-  );
-
-  const feePool = await mockFeePoolFactory.deploy();
-  const reputation = await mockReputationFactory.deploy();
-  const energyOracle = await mockOracleFactory.deploy();
-
-  await Promise.all([
-    feePool.waitForDeployment(),
-    reputation.waitForDeployment(),
-    energyOracle.waitForDeployment(),
-  ]);
-
-  const rewardEngineFactory = await ethers.getContractFactory(
-    'contracts/v2/RewardEngineMB.sol:RewardEngineMB'
-  );
-  const rewardEngine = await rewardEngineFactory.deploy(
-    await thermostat.getAddress(),
-    await feePool.getAddress(),
-    await reputation.getAddress(),
-    await energyOracle.getAddress(),
-    deployer.address
-  );
-  await rewardEngine.waitForDeployment();
-
-  const payload = {
-    generatedAt: new Date().toISOString(),
-    network: network.name,
-    taxPolicy: await taxPolicy.getAddress(),
-    rewardEngine: await rewardEngine.getAddress(),
-    thermostat: await thermostat.getAddress(),
-  };
-
-  await writeDemoNetworkConfig(network.name, {
-    taxPolicy: payload.taxPolicy,
-    rewardEngine: payload.rewardEngine,
-    thermostat: payload.thermostat,
-  });
-
+  await bootstrapHardhatDemoConfig(network.name, undefined, { force: true });
   const outputPath = resolveDemoAddressBookOutputPath();
-  await writeDemoAddressBook(payload, outputPath);
-
+  const raw = await fs.readFile(outputPath, 'utf8');
+  const payload = JSON.parse(raw) as Record<string, unknown>;
   console.log(`Demo owner matrix address book written to ${outputPath}`);
   console.table(payload);
 }

--- a/scripts/v2/lib/hardhatDemoBootstrap.ts
+++ b/scripts/v2/lib/hardhatDemoBootstrap.ts
@@ -13,9 +13,10 @@ const DEMO_NETWORKS = new Set(['hardhat', 'localhost']);
 
 export async function bootstrapHardhatDemoConfig(
   configNetwork: string,
-  notes?: string[]
+  notes?: string[],
+  options: { force?: boolean } = {}
 ): Promise<void> {
-  if (!DEMO_BOOTSTRAP_ENV) {
+  if (!options.force && !DEMO_BOOTSTRAP_ENV) {
     return;
   }
   if (!DEMO_NETWORKS.has(network.name)) {

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -248,6 +248,68 @@ function resolveBootstrapAddressBookPath(
   return resolvedPath ?? DEFAULT_DEMO_ADDRESS_BOOK;
 }
 
+async function readJsonIfExists(filePath?: string): Promise<Record<string, any> | null> {
+  if (!filePath || !existsSync(filePath)) {
+    return null;
+  }
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as Record<string, any>;
+  } catch (error) {
+    if (process.env.DEBUG_OWNER_MATRIX) {
+      console.warn(`Failed to read demo config ${filePath}:`, error);
+    }
+    return null;
+  }
+}
+
+function hasNonZeroAddress(value: unknown): boolean {
+  if (!value) {
+    return false;
+  }
+  try {
+    const address = ethers.getAddress(String(value).trim());
+    return address !== ethers.ZeroAddress;
+  } catch (_) {
+    return false;
+  }
+}
+
+function resolveConfigCandidates(baseName: string, network: string): string[] {
+  const configDir = path.join(process.cwd(), 'config');
+  return [
+    path.join(configDir, `${baseName}.${network}.json`),
+    path.join(configDir, `${baseName}.json`),
+  ];
+}
+
+async function demoConfigsHaveAddresses(network: string): Promise<boolean> {
+  const [jobNetworkPath, jobDefaultPath] = resolveConfigCandidates('job-registry', network);
+  const jobConfig = (await readJsonIfExists(jobNetworkPath)) ?? (await readJsonIfExists(jobDefaultPath));
+  if (!jobConfig || !hasNonZeroAddress(jobConfig.taxPolicy)) {
+    return false;
+  }
+
+  const [thermoNetworkPath, thermoDefaultPath] = resolveConfigCandidates('thermodynamics', network);
+  const thermoConfig =
+    (await readJsonIfExists(thermoNetworkPath)) ?? (await readJsonIfExists(thermoDefaultPath));
+  const rewardEngineAddress = thermoConfig?.rewardEngine?.address;
+  if (!hasNonZeroAddress(rewardEngineAddress)) {
+    return false;
+  }
+  return true;
+}
+
+async function demoAddressBookHasAddresses(addressBookPath?: string): Promise<boolean> {
+  const addressBook = await readJsonIfExists(addressBookPath);
+  if (!addressBook) {
+    return false;
+  }
+  return (
+    hasNonZeroAddress(addressBook.taxPolicy) && hasNonZeroAddress(addressBook.rewardEngine)
+  );
+}
+
 async function runDemoBootstrap(
   network: string,
   addressBookPath?: string
@@ -415,11 +477,39 @@ export async function prepareDemoOverrides(
       }
     }
   }
+  let bootstrapped = false;
+  const bootstrapPath =
+    network && LOCAL_NETWORKS.has(network)
+      ? resolveBootstrapAddressBookPath(network, addressBookPath)
+      : undefined;
+  if (network && LOCAL_NETWORKS.has(network) && shouldBootstrapDemo(network)) {
+    const addressBookReady =
+      (await demoAddressBookHasAddresses(addressBookPath)) ||
+      (await demoConfigsHaveAddresses(network));
+    if (!addressBookReady) {
+      await runDemoBootstrap(network, bootstrapPath);
+      bootstrapped = true;
+    }
+  }
   if (!addressBook) {
     addressBook = await deriveDemoAddressBookFromConfigs(network);
   }
-  if (!addressBook && network && LOCAL_NETWORKS.has(network) && shouldBootstrapDemo(network)) {
-    const bootstrapPath = resolveBootstrapAddressBookPath(network, addressBookPath);
+  if (!addressBook && bootstrapped && bootstrapPath) {
+    try {
+      addressBook = await loadDemoAddressBook(bootstrapPath);
+    } catch (error) {
+      if (process.env.DEBUG_OWNER_MATRIX) {
+        console.warn('Failed to load demo address book after bootstrap:', error);
+      }
+    }
+  }
+  if (
+    !addressBook &&
+    !bootstrapped &&
+    network &&
+    LOCAL_NETWORKS.has(network) &&
+    shouldBootstrapDemo(network)
+  ) {
     await runDemoBootstrap(network, bootstrapPath);
     try {
       if (bootstrapPath) {


### PR DESCRIPTION
### Motivation

- Owner parameter matrix failing when `taxPolicy` or `rewardEngine` addresses are zero in local (Hardhat) runs caused demo workflows to exit with validation errors.  
- The intent is to deterministically provision minimal demo contracts on Hardhat so the owner-matrix validations pass without weakening real-network checks.  
- Centralize a Hardhat-only bootstrap so all demos share the same deterministic seeding behavior and avoid per-demo copy/paste fixes.  
- Add regression coverage so this bootstrapping behavior is protected by tests.

### Description

- Add Hardhat-only pre-bootstrap detection and helpers in `scripts/v2/ownerParameterMatrix.ts` that detect missing/zero addresses (`readJsonIfExists`, `hasNonZeroAddress`, `demoConfigsHaveAddresses`, `demoAddressBookHasAddresses`) and trigger the demo bootstrap before validation.  
- Reuse the shared bootstrap helper by adding a `force` option to `bootstrapHardhatDemoConfig` in `scripts/v2/lib/hardhatDemoBootstrap.ts` and call it from the owner-matrix seed script `scripts/v2/demoHardhatOwnerMatrixConfig.ts`.  
- Ensure generated non-zero addresses are written into `config/job-registry.<network>.json`, `config/thermodynamics.<network>.json`, and `deployment-config/generated/demo-hardhat-addresses.json` for the owner parameter matrix to consume at runtime.  
- Add/expand unit tests in `scripts/v2/__tests__/ownerParameterMatrix.test.ts` to cover the bootstrap path including the case where local configs contain explicit zero addresses.

### Testing

- Ran unit tests: `npx jest scripts/v2/__tests__/ownerParameterMatrix.test.ts`, all tests passed.  
- Ran CI preflight checks: `npm run ci:preflight` and `npm run ci:verify-toolchain`, both succeeded.  
- Executed key demo scripts to validate the end-to-end fix: `npm run demo:asi-global` and `npm run demo:zenith-hypernova`, both completed without owner-matrix validation failures.  
- Verified owner-matrix bootstrap behavior via the new test cases that simulate missing/zero addresses and confirmed the bootstrap was invoked and produced non-zero addresses (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627d51304c83339b1ed614c1ecad71)