### PR TITLE
Fix demo workflows: bootstrap hardhat owner-matrix addresses

### DIFF
--- a/scripts/config/__tests__/networkAliases.test.ts
+++ b/scripts/config/__tests__/networkAliases.test.ts
@@ -1,0 +1,65 @@
+import { existsSync, promises as fs } from 'fs';
+import path from 'path';
+
+const { loadJobRegistryConfig, loadThermodynamicsConfig } = require('../index.js');
+
+describe('config network aliases', () => {
+  const configDir = path.join(process.cwd(), 'config');
+  const hardhatJobRegistryPath = path.join(configDir, 'job-registry.hardhat.json');
+  const localhostThermoPath = path.join(configDir, 'thermodynamics.localhost.json');
+
+  afterEach(async () => {
+    if (existsSync(hardhatJobRegistryPath)) {
+      await fs.unlink(hardhatJobRegistryPath);
+    }
+    if (existsSync(localhostThermoPath)) {
+      await fs.unlink(localhostThermoPath);
+    }
+  });
+
+  it('loads hardhat-specific configs when network is hardhat', async () => {
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(
+      hardhatJobRegistryPath,
+      JSON.stringify(
+        {
+          taxPolicy: '0x0000000000000000000000000000000000000001',
+        },
+        null,
+        2
+      )
+    );
+
+    const { config, path: resolvedPath } = loadJobRegistryConfig({ network: 'hardhat' });
+    expect(resolvedPath).toBe(hardhatJobRegistryPath);
+    expect(config.taxPolicy).toBe('0x0000000000000000000000000000000000000001');
+  });
+
+  it('loads localhost-specific configs when network is localhost', async () => {
+    await fs.mkdir(configDir, { recursive: true });
+    await fs.writeFile(
+      localhostThermoPath,
+      JSON.stringify(
+        {
+          rewardEngine: {
+            address: '0x0000000000000000000000000000000000000002',
+            thermostat: '0x0000000000000000000000000000000000000003',
+          },
+          thermostat: {
+            address: '0x0000000000000000000000000000000000000003',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const { config, path: resolvedPath } = loadThermodynamicsConfig({
+      network: 'localhost',
+    });
+    expect(resolvedPath).toBe(localhostThermoPath);
+    expect(config.rewardEngine.address).toBe(
+      '0x0000000000000000000000000000000000000002'
+    );
+  });
+});

--- a/scripts/config/index.js
+++ b/scripts/config/index.js
@@ -25,6 +25,10 @@ const NETWORK_ALIASES = new Map([
   ['sep', 'sepolia'],
   ['11155111', 'sepolia'],
   ['0xaa36a7', 'sepolia'],
+  ['hardhat', 'hardhat'],
+  ['localhost', 'localhost'],
+  ['31337', 'hardhat'],
+  ['0x7a69', 'hardhat'],
 ]);
 
 const DEFAULT_ENS_NAMES = {


### PR DESCRIPTION
### Motivation
- Owner parameter matrix demos were failing because local Hardhat/localhost network names were not recognized by the config loader, causing fallback to zero-address defaults for JobRegistry/RewardEngine.
- The failure manifested as "JobRegistry tax policy cannot be the zero address" and "RewardEngine address cannot be the zero address" during demo runs.
- The intent is to make demos deterministic in CI by ensuring local demo config overrides (*.hardhat.json / *.localhost.json) are discovered and used.
- Keep all strict validations for non-local networks while enabling deterministic Hardhat-only behavior.

### Description
- Added local network aliases for `hardhat` and `localhost` (including chainId keys `31337` and `0x7a69`) to the config loader so network-specific config files like `job-registry.hardhat.json` and `thermodynamics.localhost.json` are selected.【F:scripts/config/index.js†L17-L32】
- Added a unit test file that asserts hardhat/localhost-specific config selection for `loadJobRegistryConfig` and `loadThermodynamicsConfig` to prevent regressions.【A:scripts/config/__tests__/networkAliases.test.ts】
- No production runtime validation was weakened; the change only augments network alias resolution used when resolving config filenames.
- Changes are minimal and focused on config resolution so the existing Hardhat bootstrap and demo bootstrapping code remain usable.

### Testing
- Ran the new unit test: `npx jest scripts/config/__tests__/networkAliases.test.ts` and it passed (2 tests, 0 failures).
- The test verifies that `loadJobRegistryConfig({ network: 'hardhat' })` resolves `config/job-registry.hardhat.json` and that `loadThermodynamicsConfig({ network: 'localhost' })` resolves `config/thermodynamics.localhost.json`.
- The new test is included in the repository to guard against future regressions of network alias handling.
- No changes were made to demo bootstrap contracts or persistent config files; tests exercise only config selection logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696297032cb08333b34477b9e379bd77)