### PR TITLE
Fix demo workflows: honor demo bootstrap flag for owner-matrix

### DIFF
--- a/scripts/v2/__tests__/ownerParameterMatrix.test.ts
+++ b/scripts/v2/__tests__/ownerParameterMatrix.test.ts
@@ -81,6 +81,7 @@ describe('prepareDemoOverrides', () => {
 
   afterEach(async () => {
     delete process.env.AGJ_DEMO_BOOTSTRAP_HARDHAT;
+    delete process.env.OWNER_MATRIX_BOOTSTRAP_HARDHAT;
     const mockedSpawn = spawn as jest.Mock;
     mockedSpawn.mockReset();
     mockedSpawn.mockImplementation(() => {
@@ -201,6 +202,36 @@ describe('prepareDemoOverrides', () => {
     const jobRegistryRaw = await fs.readFile(overrides!.jobRegistryPath!, 'utf8');
     const jobRegistry = JSON.parse(jobRegistryRaw);
     expect(jobRegistry.taxPolicy).toBe('0x0000000000000000000000000000000000000007');
+  });
+
+  it('prefers the demo bootstrap flag over explicit owner-matrix disablement', async () => {
+    process.env.OWNER_MATRIX_BOOTSTRAP_HARDHAT = '0';
+    process.env.AGJ_DEMO_BOOTSTRAP_HARDHAT = '1';
+    const mockedSpawn = spawn as jest.Mock;
+    mockedSpawn.mockImplementation(() => {
+      const emitter = new EventEmitter();
+      void (async () => {
+        await fs.mkdir(path.dirname(defaultPath), { recursive: true });
+        await fs.writeFile(
+          defaultPath,
+          JSON.stringify(
+            {
+              taxPolicy: '0x00000000000000000000000000000000000000aa',
+              rewardEngine: '0x00000000000000000000000000000000000000bb',
+              thermostat: '0x00000000000000000000000000000000000000cc',
+            },
+            null,
+            2
+          )
+        );
+        emitter.emit('close', 0);
+      })();
+      return emitter;
+    });
+
+    const overrides = await prepareDemoOverrides('hardhat');
+    expect(mockedSpawn).toHaveBeenCalled();
+    expect(overrides?.jobRegistryPath).toBeDefined();
   });
 
   it('bootstraps demo overrides when local configs contain zero addresses', async () => {

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -227,13 +227,13 @@ export function resolveDemoAddressBookPath(network?: string): string | undefined
 }
 
 function shouldBootstrapDemo(network?: string): boolean {
-  const explicit = process.env[OWNER_MATRIX_BOOTSTRAP_ENV];
-  if (explicit !== undefined) {
-    return explicit.trim() !== '' && explicit !== '0';
-  }
   const fallback = process.env[DEMO_BOOTSTRAP_ENV];
   if (fallback !== undefined) {
     return fallback.trim() !== '' && fallback !== '0';
+  }
+  const explicit = process.env[OWNER_MATRIX_BOOTSTRAP_ENV];
+  if (explicit !== undefined) {
+    return explicit.trim() !== '' && explicit !== '0';
   }
   return Boolean(network && LOCAL_NETWORKS.has(network));
 }


### PR DESCRIPTION
### Motivation
- Owner parameter matrix runs in CI were failing because demo bootstrapping was not consistently triggered, leaving `taxPolicy` and `rewardEngine` configured as the zero address for local Hardhat demos. 
- The intent is to ensure demo bootstrap behavior is deterministic in Hardhat CI runs without weakening validation for real networks. 
- Make the demo bootstrap environment flag reliably take effect so the owner parameter matrix step can obtain non-zero addresses on local networks. 

### Description
- Change `shouldBootstrapDemo` behavior in `scripts/v2/ownerParameterMatrix.ts` to prefer the generic demo bootstrap environment (`AGJ_DEMO_BOOTSTRAP_HARDHAT`) when deciding to run the Hardhat demo bootstrap before checking the explicit owner-matrix flag. 
- Add a regression test in `scripts/v2/__tests__/ownerParameterMatrix.test.ts` that asserts the demo bootstrap flag triggers bootstrapping even when `OWNER_MATRIX_BOOTSTRAP_HARDHAT` is explicitly set to `0`. 
- Clean up test environment handling by removing `OWNER_MATRIX_BOOTSTRAP_HARDHAT` in the test `afterEach` to avoid leakage between tests. 

### Testing
- Ran the modified unit tests with `npx jest scripts/v2/__tests__/ownerParameterMatrix.test.ts` and all tests passed locally. 
- The test suite exercised the new precedence case and validated that demo bootstrapping is invoked when `AGJ_DEMO_BOOTSTRAP_HARDHAT=1` even if `OWNER_MATRIX_BOOTSTRAP_HARDHAT=0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a2ce84848333abdf68e77ed258f7)