### PR TITLE
owner-parameter-matrix: skip Hardhat demo bootstrap on non-local networks

### DIFF
--- a/scripts/v2/__tests__/ownerParameterMatrix.test.ts
+++ b/scripts/v2/__tests__/ownerParameterMatrix.test.ts
@@ -247,7 +247,12 @@ describe('prepareDemoOverrides', () => {
     expect(jobRegistry.taxPolicy).toBe('0x0000000000000000000000000000000000000011');
   });
 
-  it('rejects demo overrides on non-local networks', async () => {
+  it('skips demo overrides on non-local networks when no override is set', async () => {
+    await expect(prepareDemoOverrides('mainnet')).resolves.toBeNull();
+  });
+
+  it('rejects explicit demo overrides on non-local networks', async () => {
+    process.env.OWNER_MATRIX_DEMO_ADDRESS_BOOK = 'tmp/demo-owner-matrix.json';
     await expect(prepareDemoOverrides('mainnet')).rejects.toThrow(
       /only supported on local hardhat networks/
     );

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -463,9 +463,12 @@ export async function prepareDemoOverrides(
 ): Promise<DemoConfigOverrides | null> {
   const addressBookPath = resolveDemoAddressBookPath(network);
   if (!network || !LOCAL_NETWORKS.has(network)) {
-    throw new Error(
-      `${DEMO_ADDRESS_BOOK_ENV} is only supported on local hardhat networks`
-    );
+    if (process.env[DEMO_ADDRESS_BOOK_ENV]) {
+      throw new Error(
+        `${DEMO_ADDRESS_BOOK_ENV} is only supported on local hardhat networks`
+      );
+    }
+    return null;
   }
   let addressBook: DemoAddressBook | null = null;
   if (addressBookPath) {


### PR DESCRIPTION
### Motivation
- The owner parameter matrix step was failing when demo bootstrapping attempted to run on non-local networks due to zero-address placeholders in configs.
- The intent is to keep demo bootstrapping deterministic and scoped to Hardhat/localhost while preserving strict validation on real networks.
- Avoid globally disabling the owner parameter matrix or weakening production validation; only change Hardhat/demo bootstrapping behavior.

### Description
- Change `prepareDemoOverrides` in `scripts/v2/ownerParameterMatrix.ts` to return `null` (skip demo bootstrap) for non-local networks unless an explicit demo address book is provided via `OWNER_MATRIX_DEMO_ADDRESS_BOOK`.
- Preserve the existing Hardhat bootstrap path so demos still deploy minimal `TaxPolicy`, `Thermostat`, and `RewardEngineMB` mocks on local runs.
- Update tests in `scripts/v2/__tests__/ownerParameterMatrix.test.ts` to cover the new behavior (skip on non-local when no override, but reject explicit overrides on non-local).
- No production validation logic was loosened; this only affects demo/Hardhat bootstrap control flow.

### Testing
- Ran `npx jest scripts/v2/__tests__/ownerParameterMatrix.test.ts` and the test suite passed.
- Executed demo runs `npm run demo:asi-global`, `npm run demo:zenith-hypernova`, `npm run demo:asi-takeoff`, `npm run demo:zenith-sapience-initiative`, `npm run demo:zenith-sapience-omnidominion`, and `npm run demo:zenith-sapience-celestial-archon`, and they completed successfully in the local environment.
- Ran CI preflight and context checks `npm run ci:preflight`, `npm run ci:verify-toolchain`, `npm run ci:sync-contexts -- --check`, `npm run ci:verify-contexts`, `npm run ci:verify-companion-contexts`, and `npm run ci:verify-summary-needs`, and they succeeded locally.
- Note: `npm run demo:aurora` is not defined in `package.json` and failed with a missing-script error (unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a2ce84848333abdf68e77ed258f7)