### PR TITLE
Fix demo workflows: refresh hardhat owner-matrix bootstrap

### DIFF
--- a/scripts/v2/__tests__/ownerParameterMatrix.test.ts
+++ b/scripts/v2/__tests__/ownerParameterMatrix.test.ts
@@ -234,6 +234,51 @@ describe('prepareDemoOverrides', () => {
     expect(overrides?.jobRegistryPath).toBeDefined();
   });
 
+  it('re-runs the demo bootstrap when explicitly enabled even if an address book exists', async () => {
+    process.env.AGJ_DEMO_BOOTSTRAP_HARDHAT = '1';
+    await fs.mkdir(path.dirname(defaultPath), { recursive: true });
+    await fs.writeFile(
+      defaultPath,
+      JSON.stringify(
+        {
+          taxPolicy: '0x0000000000000000000000000000000000000001',
+          rewardEngine: '0x0000000000000000000000000000000000000002',
+          thermostat: '0x0000000000000000000000000000000000000003',
+        },
+        null,
+        2
+      )
+    );
+
+    const mockedSpawn = spawn as jest.Mock;
+    mockedSpawn.mockImplementation(() => {
+      const emitter = new EventEmitter();
+      void (async () => {
+        await fs.writeFile(
+          defaultPath,
+          JSON.stringify(
+            {
+              taxPolicy: '0x00000000000000000000000000000000000000aa',
+              rewardEngine: '0x00000000000000000000000000000000000000bb',
+              thermostat: '0x00000000000000000000000000000000000000cc',
+            },
+            null,
+            2
+          )
+        );
+        emitter.emit('close', 0);
+      })();
+      return emitter;
+    });
+
+    const overrides = await prepareDemoOverrides('hardhat');
+    expect(mockedSpawn).toHaveBeenCalled();
+
+    const jobRegistryRaw = await fs.readFile(overrides!.jobRegistryPath!, 'utf8');
+    const jobRegistry = JSON.parse(jobRegistryRaw);
+    expect(jobRegistry.taxPolicy).toBe('0x00000000000000000000000000000000000000AA');
+  });
+
   it('bootstraps demo overrides when local configs contain zero addresses', async () => {
     await fs.mkdir(path.dirname(hardhatJobRegistryPath), { recursive: true });
     await fs.writeFile(

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -227,6 +227,13 @@ export function resolveDemoAddressBookPath(network?: string): string | undefined
 }
 
 function shouldBootstrapDemo(network?: string): boolean {
+  if (hasExplicitBootstrapFlag()) {
+    return true;
+  }
+  return Boolean(network && LOCAL_NETWORKS.has(network));
+}
+
+function hasExplicitBootstrapFlag(): boolean {
   const fallback = process.env[DEMO_BOOTSTRAP_ENV];
   if (fallback !== undefined) {
     return fallback.trim() !== '' && fallback !== '0';
@@ -235,7 +242,7 @@ function shouldBootstrapDemo(network?: string): boolean {
   if (explicit !== undefined) {
     return explicit.trim() !== '' && explicit !== '0';
   }
-  return Boolean(network && LOCAL_NETWORKS.has(network));
+  return false;
 }
 
 function resolveBootstrapAddressBookPath(
@@ -486,18 +493,24 @@ export async function prepareDemoOverrides(
       ? resolveBootstrapAddressBookPath(network, addressBookPath)
       : undefined;
   if (network && LOCAL_NETWORKS.has(network) && shouldBootstrapDemo(network)) {
-    const addressBookReady =
-      (await demoAddressBookHasAddresses(addressBookPath)) ||
-      (await demoConfigsHaveAddresses(network));
-    if (!addressBookReady) {
+    const shouldForceBootstrap = hasExplicitBootstrapFlag();
+    if (shouldForceBootstrap) {
       await runDemoBootstrap(network, bootstrapPath);
       bootstrapped = true;
+    } else {
+      const addressBookReady =
+        (await demoAddressBookHasAddresses(addressBookPath)) ||
+        (await demoConfigsHaveAddresses(network));
+      if (!addressBookReady) {
+        await runDemoBootstrap(network, bootstrapPath);
+        bootstrapped = true;
+      }
     }
   }
   if (!addressBook) {
     addressBook = await deriveDemoAddressBookFromConfigs(network);
   }
-  if (!addressBook && bootstrapped && bootstrapPath) {
+  if (bootstrapped && bootstrapPath) {
     try {
       addressBook = await loadDemoAddressBook(bootstrapPath);
     } catch (error) {


### PR DESCRIPTION
### Motivation

- CI demo runs could hit the owner parameter matrix with stale or missing hardhat demo address books, leaving `taxPolicy` / `rewardEngine` set to the zero address and failing strict validation. 
- The goal is to deterministically ensure demos on Hardhat have non-zero, deployed demo contracts wired into the owner matrix without weakening validations for real networks.

### Description

- Change `shouldBootstrapDemo` and add `hasExplicitBootstrapFlag` so an explicit demo-bootstrap env flag forces a bootstrap run (`AGJ_DEMO_BOOTSTRAP_HARDHAT` / `OWNER_MATRIX_BOOTSTRAP_HARDHAT`).
- Update `prepareDemoOverrides` to re-run the Hardhat demo bootstrap when explicitly enabled (even if an address book already exists) and to reload the generated demo address book after bootstrapping.
- Keep behavior scoped to local networks (`hardhat` / `localhost`) so non-local networks preserve strict validation and no dummy addresses are introduced.
- Add a unit test to `scripts/v2/__tests__/ownerParameterMatrix.test.ts` that verifies the bootstrap is re-run when explicitly enabled and that the address book is refreshed.

### Testing

- Ran the updated unit tests with `npx jest scripts/v2/__tests__/ownerParameterMatrix.test.ts` and all tests passed.
- The change is limited to the Hardhat/local demo bootstrap path and does not alter non-local validation logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cabcf468833397fc986440f3a299)