### PR TITLE
Fix console Docker build context and GHCR owner handling; add actionlint and local demo fixes

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,22 @@
+name: actionlint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.10

--- a/.github/workflows/apps-images.yml
+++ b/.github/workflows/apps-images.yml
@@ -26,7 +26,14 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       digest: ${{ steps.get_digest.outputs.digest }}
+      registry_owner: ${{ steps.registry_owner.outputs.value }}
     steps:
+      - name: Set registry owner
+        id: registry_owner
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "value=$owner" >> "$GITHUB_OUTPUT"
+          echo "REGISTRY_OWNER=$owner" >> "$GITHUB_ENV"
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
@@ -44,14 +51,14 @@ jobs:
         id: build_console
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
-          context: .
-          file: apps/console/Dockerfile
+          context: apps/console
+          file: Dockerfile
           platforms: linux/amd64
           push: ${{ github.ref == 'refs/heads/main' }}
           load: ${{ github.ref != 'refs/heads/main' }}
           tags: |
-            ghcr.io/${{ toLower(github.repository_owner) }}/owner-console:${{ github.sha }}
-            ghcr.io/${{ toLower(github.repository_owner) }}/owner-console:latest
+            ghcr.io/${{ env.REGISTRY_OWNER }}/owner-console:${{ github.sha }}
+            ghcr.io/${{ env.REGISTRY_OWNER }}/owner-console:latest
           provenance: false
           sbom: false
           outputs: type=docker
@@ -60,7 +67,7 @@ jobs:
         id: get_digest
         if: github.ref == 'refs/heads/main'
         run: |
-          REF="ghcr.io/${{ toLower(github.repository_owner) }}/owner-console:${{ github.sha }}"
+          REF="ghcr.io/${{ env.REGISTRY_OWNER }}/owner-console:${{ github.sha }}"
           DIGEST=$(docker buildx imagetools inspect "$REF" | awk -F'[: ]+' '/Digest:/ {print $2; exit}')
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
@@ -72,7 +79,7 @@ jobs:
               --vuln-type os \
               --severity HIGH,CRITICAL \
               --exit-code 1 \
-              ghcr.io/${{ toLower(github.repository_owner) }}/owner-console:${{ github.sha }}
+              ghcr.io/${{ env.REGISTRY_OWNER }}/owner-console:${{ github.sha }}
 
       - name: Trivy (libraries – audit only)
         continue-on-error: true
@@ -83,13 +90,20 @@ jobs:
               --vuln-type library \
               --severity HIGH,CRITICAL \
               --exit-code 0 \
-              ghcr.io/${{ toLower(github.repository_owner) }}/owner-console:${{ github.sha }}
+              ghcr.io/${{ env.REGISTRY_OWNER }}/owner-console:${{ github.sha }}
 
   portal:
     runs-on: ubuntu-24.04
     outputs:
       digest: ${{ steps.get_digest.outputs.digest }}
+      registry_owner: ${{ steps.registry_owner.outputs.value }}
     steps:
+      - name: Set registry owner
+        id: registry_owner
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "value=$owner" >> "$GITHUB_OUTPUT"
+          echo "REGISTRY_OWNER=$owner" >> "$GITHUB_ENV"
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
@@ -125,8 +139,8 @@ jobs:
           push: ${{ github.ref == 'refs/heads/main' }}
           load: ${{ github.ref != 'refs/heads/main' }}
           tags: |
-            ghcr.io/${{ toLower(github.repository_owner) }}/webapp:${{ github.sha }}
-            ghcr.io/${{ toLower(github.repository_owner) }}/webapp:latest
+            ghcr.io/${{ env.REGISTRY_OWNER }}/webapp:${{ github.sha }}
+            ghcr.io/${{ env.REGISTRY_OWNER }}/webapp:latest
           provenance: false
           sbom: false
           outputs: type=docker
@@ -135,7 +149,7 @@ jobs:
         id: get_digest
         if: github.ref == 'refs/heads/main'
         run: |
-          REF="ghcr.io/${{ toLower(github.repository_owner) }}/webapp:${{ github.sha }}"
+          REF="ghcr.io/${{ env.REGISTRY_OWNER }}/webapp:${{ github.sha }}"
           DIGEST=$(docker buildx imagetools inspect "$REF" | awk -F'[: ]+' '/Digest:/ {print $2; exit}')
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
@@ -147,7 +161,7 @@ jobs:
               --vuln-type os \
               --severity HIGH,CRITICAL \
               --exit-code 1 \
-              ghcr.io/${{ toLower(github.repository_owner) }}/webapp:${{ github.sha }}
+              ghcr.io/${{ env.REGISTRY_OWNER }}/webapp:${{ github.sha }}
 
       - name: Trivy (libraries – audit only)
         continue-on-error: true
@@ -158,7 +172,7 @@ jobs:
               --vuln-type library \
               --severity HIGH,CRITICAL \
               --exit-code 0 \
-              ghcr.io/${{ toLower(github.repository_owner) }}/webapp:${{ github.sha }}
+              ghcr.io/${{ env.REGISTRY_OWNER }}/webapp:${{ github.sha }}
 
   provenance-console:
     if: github.ref == 'refs/heads/main'
@@ -169,7 +183,7 @@ jobs:
       contents: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
-      base64-subjects: ${{ toJson(format('ghcr.io/{0}/owner-console@{1}', toLower(github.repository_owner), needs.console.outputs.digest)) }}
+      base64-subjects: ${{ toJson(format('ghcr.io/{0}/owner-console@{1}', needs.console.outputs.registry_owner, needs.console.outputs.digest)) }}
 
   provenance-portal:
     if: github.ref == 'refs/heads/main'
@@ -180,4 +194,4 @@ jobs:
       contents: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
-      base64-subjects: ${{ toJson(format('ghcr.io/{0}/webapp@{1}', toLower(github.repository_owner), needs.portal.outputs.digest)) }}
+      base64-subjects: ${{ toJson(format('ghcr.io/{0}/webapp@{1}', needs.portal.outputs.registry_owner, needs.portal.outputs.digest)) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -726,11 +726,11 @@ jobs:
         run: npm run demo:zenith-sapience-initiative
       - name: Run Zenith Sapience local rehearsal
         env:
-          PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: npm run demo:zenith-sapience-initiative:local
@@ -814,13 +814,13 @@ jobs:
         run: npm run ci:preflight
       - name: Install server dependencies
         working-directory: demo/sovereign-mesh/server
-        run: $GITHUB_WORKSPACE/scripts/ci/npm-ci.sh --no-audit --prefer-offline --progress=false
+        run: "${GITHUB_WORKSPACE}/scripts/ci/npm-ci.sh" --no-audit --prefer-offline --progress=false
       - name: Build orchestrator server
         working-directory: demo/sovereign-mesh/server
         run: npm run build
       - name: Install app dependencies
         working-directory: demo/sovereign-mesh/app
-        run: $GITHUB_WORKSPACE/scripts/ci/npm-ci.sh --no-audit --prefer-offline --progress=false
+        run: "${GITHUB_WORKSPACE}/scripts/ci/npm-ci.sh" --no-audit --prefer-offline --progress=false
       - name: Build React console
         working-directory: demo/sovereign-mesh/app
         run: npm run build
@@ -852,13 +852,13 @@ jobs:
         run: npm run ci:preflight
       - name: Install server dependencies
         working-directory: demo/sovereign-constellation/server
-        run: $GITHUB_WORKSPACE/scripts/ci/npm-ci.sh --no-audit --prefer-offline --progress=false
+        run: "${GITHUB_WORKSPACE}/scripts/ci/npm-ci.sh" --no-audit --prefer-offline --progress=false
       - name: Build orchestrator server
         working-directory: demo/sovereign-constellation/server
         run: npm run build
       - name: Install app dependencies
         working-directory: demo/sovereign-constellation/app
-        run: $GITHUB_WORKSPACE/scripts/ci/npm-ci.sh --no-audit --prefer-offline --progress=false
+        run: "${GITHUB_WORKSPACE}/scripts/ci/npm-ci.sh" --no-audit --prefer-offline --progress=false
       - name: Build React console
         working-directory: demo/sovereign-constellation/app
         run: npm run build
@@ -900,11 +900,11 @@ jobs:
         run: npm run demo:zenith-sapience-celestial-archon
       - name: Run Celestial Archon local rehearsal
         env:
-          PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: npm run demo:zenith-sapience-celestial-archon:local
@@ -955,11 +955,11 @@ jobs:
         run: npm run demo:zenith-hypernova
       - name: Run Hypernova local rehearsal
         env:
-          PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: npm run demo:zenith-hypernova:local
@@ -980,7 +980,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      administration: read
     steps:
       - name: Detect fork context
         id: fork_context

--- a/.github/workflows/culture-ci.yml
+++ b/.github/workflows/culture-ci.yml
@@ -272,6 +272,7 @@ jobs:
           docker compose up -d culture-orchestrator culture-indexer culture-studio
       - name: Wait for readiness
         run: |
+          # shellcheck disable=SC2034
           for attempt in {1..40}; do
             if curl -fsS -X POST http://localhost:8545 \
               -H 'Content-Type: application/json' \

--- a/.github/workflows/demo-asi-global.yml
+++ b/.github/workflows/demo-asi-global.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
-          version: '1.4.0'
+          version: 'v1.4.4'
 
       - name: Run ASI Global demo (deterministic kit)
         run: npm run demo:asi-global
@@ -69,10 +69,10 @@ jobs:
       - name: Run ASI Global demo (local rehearsal)
         env:
           PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: npm run demo:asi-global:local

--- a/.github/workflows/demo-asi-takeoff.yml
+++ b/.github/workflows/demo-asi-takeoff.yml
@@ -51,18 +51,18 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
-          version: '1.4.0'
+          version: 'v1.4.4'
 
       - name: Run ASI Take-Off demo (deterministic kit)
         run: npm run demo:asi-takeoff
 
       - name: Run ASI Take-Off demo (local)
         env:
-          PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: npm run demo:asi-takeoff:local

--- a/.github/workflows/demo-aurora.yml
+++ b/.github/workflows/demo-aurora.yml
@@ -51,15 +51,15 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
-          version: '1.4.0'
+          version: 'v1.4.4'
 
       - name: Run AURORA demo (local)
         env:
-          PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: bash demo/aurora/bin/aurora-local.sh

--- a/.github/workflows/demo-huxley-godel-machine.yml
+++ b/.github/workflows/demo-huxley-godel-machine.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run demo with fast overrides
         run: |
           python demo/Huxley-Godel-Machine-v0/run_demo.py \
-            --set simulation.evaluation_latency=[0.0,0.0] \
-            --set simulation.expansion_latency=[0.0,0.0] \
+            --set "simulation.evaluation_latency=[0.0,0.0]" \
+            --set "simulation.expansion_latency=[0.0,0.0]" \
             --output-dir demo/Huxley-Godel-Machine-v0/artifacts-ci
           cat demo/Huxley-Godel-Machine-v0/artifacts-ci/summary.txt

--- a/.github/workflows/demo-zenith-hypernova.yml
+++ b/.github/workflows/demo-zenith-hypernova.yml
@@ -65,18 +65,18 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
-          version: '1.4.0'
+          version: 'v1.4.4'
 
       - name: Run Hypernova deterministic kit
         run: npm run demo:zenith-hypernova
 
       - name: Run Hypernova local rehearsal
         env:
-          PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: npm run demo:zenith-hypernova:local

--- a/.github/workflows/demo-zenith-sapience-celestial-archon.yml
+++ b/.github/workflows/demo-zenith-sapience-celestial-archon.yml
@@ -65,18 +65,18 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
-          version: '1.4.0'
+          version: 'v1.4.4'
 
       - name: Run Celestial Archon deterministic kit
         run: npm run demo:zenith-sapience-celestial-archon
 
       - name: Run Celestial Archon local rehearsal
         env:
-          PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: npm run demo:zenith-sapience-celestial-archon:local

--- a/.github/workflows/demo-zenith-sapience-initiative.yml
+++ b/.github/workflows/demo-zenith-sapience-initiative.yml
@@ -65,18 +65,18 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
-          version: '1.4.0'
+          version: 'v1.4.4'
 
       - name: Run Zenith Sapience deterministic kit
         run: npm run demo:zenith-sapience-initiative
 
       - name: Run Zenith Sapience local rehearsal
         env:
-          PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: npm run demo:zenith-sapience-initiative:local

--- a/.github/workflows/demo-zenith-sapience-omnidominion.yml
+++ b/.github/workflows/demo-zenith-sapience-omnidominion.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
-          version: '1.4.0'
+          version: 'v1.4.4'
 
       - name: Run OmniDominion deterministic kit
         run: npm run demo:zenith-sapience-omnidominion
@@ -73,10 +73,10 @@ jobs:
       - name: Run OmniDominion local rehearsal
         env:
           PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: npm run demo:zenith-sapience-omnidominion:local

--- a/.github/workflows/demo-zenith-sapience-planetary-os.yml
+++ b/.github/workflows/demo-zenith-sapience-planetary-os.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
-          version: '1.4.0'
+          version: 'v1.4.4'
 
       - name: Run Zenith Sapience Planetary OS deterministic kit
         run: npm run demo:zenith-sapience-planetary-os
@@ -73,10 +73,10 @@ jobs:
       - name: Run Zenith Sapience Planetary OS local rehearsal
         env:
           PRIVATE_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
-          AURORA_WORKER_KEY: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-          AURORA_VALIDATOR1_KEY: 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
-          AURORA_VALIDATOR2_KEY: 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
-          AURORA_VALIDATOR3_KEY: 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a
+          AURORA_WORKER_KEY: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d'
+          AURORA_VALIDATOR1_KEY: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a'
+          AURORA_VALIDATOR2_KEY: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6'
+          AURORA_VALIDATOR3_KEY: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a'
           RPC_URL: http://127.0.0.1:8545
           CHAIN_ID: '31337'
         run: npm run demo:zenith-sapience-planetary-os:local

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,8 +356,6 @@ jobs:
     needs: prepare
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    env:
-      REGISTRY_OWNER: ${{ toLower(github.repository_owner) }}
     strategy:
       fail-fast: false
       matrix:
@@ -376,12 +374,14 @@ jobs:
             dockerfile: apps/enterprise-portal/Dockerfile
           - name: owner-console
             context: apps/console
-            dockerfile: apps/console/Dockerfile
+            dockerfile: Dockerfile
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a
         with:
           egress-policy: audit
+      - name: Set registry owner
+        run: echo "REGISTRY_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:

--- a/scripts/v2/deployDefaults.ts
+++ b/scripts/v2/deployDefaults.ts
@@ -101,7 +101,13 @@ async function ensureAgialphaToken(): Promise<void> {
     AGIALPHA
   );
   const mintAmount = ethers.parseUnits('1000000', AGIALPHA_DECIMALS);
-  await token.mint(defaultSigner.address, mintAmount);
+  const latestBlock = await ethers.provider.getBlock('latest');
+  const blockGasLimit = latestBlock?.gasLimit;
+  const gasLimitOverride =
+    blockGasLimit && blockGasLimit > 1n ? blockGasLimit - 1n : undefined;
+  await token.mint(defaultSigner.address, mintAmount, {
+    ...(gasLimitOverride ? { gasLimit: gasLimitOverride } : {}),
+  });
   console.log(
     `🔧 Provisioned LocalAgialpha stub at ${AGIALPHA} with ${ethers.formatUnits(
       mintAmount,
@@ -114,6 +120,19 @@ const MAX_UINT96 = (1n << 96n) - 1n;
 const DEFAULT_TAX_URI = 'ipfs://policy';
 const DEFAULT_TAX_DESCRIPTION =
   'All taxes on participants; contract and owner exempt';
+const LOCAL_NETWORKS = new Set(['hardhat', 'localhost', 'anvil']);
+
+async function getLocalGasLimitOverride(): Promise<bigint | undefined> {
+  if (!LOCAL_NETWORKS.has(network.name)) {
+    return undefined;
+  }
+  const latestBlock = await ethers.provider.getBlock('latest');
+  const blockGasLimit = latestBlock?.gasLimit;
+  if (!blockGasLimit || blockGasLimit <= 1n) {
+    return undefined;
+  }
+  return blockGasLimit - 1n;
+}
 
 function parseArgs(argv: string[]): CliArgs {
   const args: CliArgs = {};
@@ -540,21 +559,26 @@ async function main() {
 
   await ensureAgialphaToken();
 
+  const gasLimitOverride = await getLocalGasLimitOverride();
+  const txOverrides = gasLimitOverride ? { gasLimit: gasLimitOverride } : {};
+
   const Deployer = await ethers.getContractFactory(
     'contracts/v2/Deployer.sol:Deployer'
   );
-  const deployer = await Deployer.deploy();
+  const deployer = await Deployer.deploy({
+    ...txOverrides,
+  });
   await deployer.waitForDeployment();
   const deployerAddress = await deployer.getAddress();
   console.log('Deployer deployed at', deployerAddress);
 
   const tx = withTax
     ? hasEconOverrides
-      ? await deployer.deploy(econ, identity, governance)
-      : await deployer.deployDefaults(identity, governance)
+      ? await deployer.deploy(econ, identity, governance, txOverrides)
+      : await deployer.deployDefaults(identity, governance, txOverrides)
     : hasEconOverrides
-    ? await deployer.deployWithoutTaxPolicy(econ, identity, governance)
-    : await deployer.deployDefaultsWithoutTaxPolicy(identity, governance);
+    ? await deployer.deployWithoutTaxPolicy(econ, identity, governance, txOverrides)
+    : await deployer.deployDefaultsWithoutTaxPolicy(identity, governance, txOverrides);
 
   const receipt = await tx.wait();
   const deployLog = receipt.logs.find((log) => log.address === deployerAddress);

--- a/scripts/v2/ownerParameterMatrix.ts
+++ b/scripts/v2/ownerParameterMatrix.ts
@@ -13,6 +13,7 @@ import {
   loadTaxPolicyConfig,
   loadPlatformIncentivesConfig,
   loadIdentityRegistryConfig,
+  inferNetworkKey,
 } from '../config';
 
 interface CliOptions {
@@ -956,7 +957,17 @@ async function main(): Promise<void> {
   }
 
   const hardhat = await resolveHardhatContext();
-  const selectedNetwork = options.network ?? process.env.HARDHAT_NETWORK ?? hardhat.name;
+  const inferredFromHardhat =
+    hardhat.chainId !== undefined ? inferNetworkKey(String(hardhat.chainId)) : undefined;
+  const inferredFromEnv = process.env.CHAIN_ID
+    ? inferNetworkKey(process.env.CHAIN_ID)
+    : undefined;
+  const selectedNetwork =
+    options.network ??
+    process.env.HARDHAT_NETWORK ??
+    hardhat.name ??
+    inferredFromHardhat ??
+    inferredFromEnv;
 
   const demoOverrides = await prepareDemoOverrides(selectedNetwork);
   const buildResults = await buildSubsystemMatrices(selectedNetwork, demoOverrides);

--- a/test/v2/DemoOwnerMatrixBootstrap.test.js
+++ b/test/v2/DemoOwnerMatrixBootstrap.test.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const path = require('path');
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+const { bootstrapHardhatDemoConfig } = require('../../scripts/v2/lib/hardhatDemoBootstrap');
+
+describe('Demo owner matrix bootstrap', function () {
+  this.timeout(60000);
+
+  const jobRegistryPath = path.join(process.cwd(), 'config', 'job-registry.hardhat.json');
+  const thermodynamicsPath = path.join(process.cwd(), 'config', 'thermodynamics.hardhat.json');
+  const addressBookPath = path.join(
+    process.cwd(),
+    'deployment-config',
+    'generated',
+    'demo-hardhat-addresses.json'
+  );
+
+  let backup = {};
+
+  before(() => {
+    const readIfExists = (filePath) => {
+      if (!fs.existsSync(filePath)) {
+        return null;
+      }
+      return fs.readFileSync(filePath, 'utf8');
+    };
+    backup = {
+      jobRegistry: readIfExists(jobRegistryPath),
+      thermodynamics: readIfExists(thermodynamicsPath),
+      addressBook: readIfExists(addressBookPath),
+    };
+  });
+
+  after(() => {
+    const restore = (filePath, contents) => {
+      if (contents === null || contents === undefined) {
+        if (fs.existsSync(filePath)) {
+          fs.unlinkSync(filePath);
+        }
+        return;
+      }
+      fs.writeFileSync(filePath, contents);
+    };
+    restore(jobRegistryPath, backup.jobRegistry);
+    restore(thermodynamicsPath, backup.thermodynamics);
+    restore(addressBookPath, backup.addressBook);
+  });
+
+  it('writes non-zero demo addresses for hardhat configs', async () => {
+    await bootstrapHardhatDemoConfig('hardhat', [], { force: true });
+
+    const jobConfig = JSON.parse(fs.readFileSync(jobRegistryPath, 'utf8'));
+    const thermoConfig = JSON.parse(fs.readFileSync(thermodynamicsPath, 'utf8'));
+    const addressBook = JSON.parse(fs.readFileSync(addressBookPath, 'utf8'));
+
+    expect(jobConfig.taxPolicy).to.be.a('string');
+    expect(jobConfig.taxPolicy).to.not.equal(ethers.ZeroAddress);
+
+    expect(thermoConfig.rewardEngine).to.exist;
+    expect(thermoConfig.rewardEngine.address).to.not.equal(ethers.ZeroAddress);
+
+    expect(addressBook.taxPolicy).to.not.equal(ethers.ZeroAddress);
+    expect(addressBook.rewardEngine).to.not.equal(ethers.ZeroAddress);
+  });
+});


### PR DESCRIPTION
### Motivation
- Fix failing image builds where `apps/console/Dockerfile` expected `nginx.conf` at the repo root by using the correct build context.  
- Ensure GHCR image tags and provenance subjects use a lower-cased registry owner to avoid invalid tag errors from `docker/build-push-action`.  
- Prevent local demo deployment failures caused by transactions exceeding local provider gas limits and avoid generating zero-address demo components.  
- Add workflow validation to catch workflow/YAML issues earlier using `actionlint`.

### Description
- Update `.github/workflows/apps-images.yml` and `.github/workflows/release.yml` to build the console image with `context: apps/console` and `file: Dockerfile`, and add a `REGISTRY_OWNER` (lower-cased) environment value and outputs used in tags and provenance.  
- Add `.github/workflows/actionlint.yml` to run `rhysd/actionlint@v1.7.10` and quote hex env vars and script invocations across CI/demo workflows to fix shell/parsing issues.  
- Bump Foundry toolchain references and update various demo workflows to quote hex keys and other CLI args for robust parsing.  
- Add local network gas handling in `scripts/v2/deployDefaults.ts` (`LOCAL_NETWORKS`, `getLocalGasLimitOverride`) and thread `txOverrides` into contract deploy calls, improve network inference in `scripts/v2/ownerParameterMatrix.ts` using `inferNetworkKey`/`CHAIN_ID`, and add `test/v2/DemoOwnerMatrixBootstrap.test.js` to assert non-zero demo addresses after bootstrap.

### Testing
- No automated CI tests were executed in this environment because Docker was not available to run `docker buildx build`.  
- The `actionlint` workflow was added to the repository but was not executed as part of this rollout.  
- The new unit/integration test `test/v2/DemoOwnerMatrixBootstrap.test.js` was added but was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962f205ae088333a57dbbea482a4963)