### PR TITLE
CI: fix coverage enforcement, artifact pinning, and ICS fixture linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Export unit coverage data
         run: |
           mkdir -p reports/python-coverage
-          coverage xml --rcfile=.coveragerc -o reports/python-coverage/unit.xml
+          coverage xml --rcfile=.coveragerc --fail-under=0 -o reports/python-coverage/unit.xml
       - name: Upload unit coverage artefacts
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -207,7 +207,7 @@ jobs:
       - name: Export integration coverage data
         run: |
           mkdir -p reports/python-coverage
-          coverage xml --rcfile=.coveragerc -o reports/python-coverage/integration.xml
+          coverage xml --rcfile=.coveragerc --fail-under=0 -o reports/python-coverage/integration.xml
       - name: Upload integration coverage artefacts
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -325,12 +325,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install coverage==7.6.4
       - name: Download unit coverage data
-        uses: actions/download-artifact@11b4b7b450363a5e5f998efa20d2b6c9e9c03989
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
         with:
           name: python-coverage-unit
           path: coverage-data/unit
       - name: Download integration coverage data
-        uses: actions/download-artifact@11b4b7b450363a5e5f998efa20d2b6c9e9c03989
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
         with:
           name: python-coverage-integration
           path: coverage-data/integration
@@ -340,8 +340,8 @@ jobs:
       - name: Enforce Python coverage threshold
         run: |
           mkdir -p reports/python-coverage
-          coverage report --rcfile=.coveragerc
-          coverage xml --rcfile=.coveragerc -o reports/python-coverage/combined.xml
+          coverage report --rcfile=.coveragerc --fail-under=85
+          coverage xml --rcfile=.coveragerc --fail-under=85 -o reports/python-coverage/combined.xml
       - name: Upload combined coverage artefacts
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/culture-ci.yml
+++ b/.github/workflows/culture-ci.yml
@@ -189,12 +189,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Download contract coverage artifact
-        uses: actions/download-artifact@11b4b7b450363a5e5f998efa20d2b6c9e9c03989
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
         with:
           name: culture-contract-coverage
           path: demo/CULTURE-v0
       - name: Download service coverage artifact
-        uses: actions/download-artifact@11b4b7b450363a5e5f998efa20d2b6c9e9c03989
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
         with:
           name: culture-service-coverage
           path: demo/CULTURE-v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
           unset SECRET_VALUE
 
       - name: Download release bundle
-        uses: actions/download-artifact@4cb1d0de87d15f5f9492c2ab5a8c5e2d06cc1f6d
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
         with:
           name: release-prep
           path: reports/prep
@@ -465,7 +465,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download release preparation artefacts
-        uses: actions/download-artifact@71f31b0d0be45612bc1db53de9b1aa6dc10e30f2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
         with:
           name: release-prep
           path: release-prep

--- a/scripts/ci/validate-ics-fixture.mjs
+++ b/scripts/ci/validate-ics-fixture.mjs
@@ -22,19 +22,26 @@ const icsModuleUrl = pathToFileURL(
   join(process.cwd(), 'packages', 'orchestrator', 'src', 'ics.ts')
 ).href;
 
-const fixturePayload = await readFile(fixturePath, 'utf8');
-const module = await import(icsModuleUrl);
-const validate = module.validateICS ?? module.default?.validateICS;
+const run = async () => {
+  const fixturePayload = await readFile(fixturePath, 'utf8');
+  const module = await import(icsModuleUrl);
+  const validate = module.validateICS ?? module.default?.validateICS;
 
-if (!validate) {
-  throw new Error(
-    'validateICS export not found in packages/orchestrator/src/ics.ts'
-  );
-}
+  if (!validate) {
+    throw new Error(
+      'validateICS export not found in packages/orchestrator/src/ics.ts'
+    );
+  }
 
-try {
-  validate(fixturePayload);
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  throw new Error(`validateICS rejected fixture payload: ${message}`);
-}
+  try {
+    validate(fixturePayload);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`validateICS rejected fixture payload: ${message}`);
+  }
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- CI was failing due to per-job coverage enforcement causing the unit job to fail when combined coverage dipped below the threshold. 
- Workflows referenced a missing/invalid `actions/download-artifact` SHA which made artifact downloads fail. 
- The Node-side ICS fixture validator used top-level `await` and triggered an ESLint parse error. 
- Changes are scoped to restore separations between Python and Node responsibilities and make CI deterministic without adding secrets.

### Description
- Adjusted Python coverage export steps in `.github/workflows/ci.yml` to produce XML without failing per-suite by adding `--fail-under=0` during unit/integration XML export and moved the 85% enforcement into the combined `python_coverage` job with `coverage report --fail-under=85` and `coverage xml --fail-under=85`.
- Replaced invalid `actions/download-artifact` pins across `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `.github/workflows/culture-ci.yml` with a valid v4.1.7 SHA to ensure artifact download steps succeed.
- Fixed `scripts/ci/validate-ics-fixture.mjs` by wrapping the async work in an `async` runner (no top-level `await`) so ESLint no longer errors while preserving Node-based ICS validation.
- Regenerated the CI required-contexts manifest by running the repository synchronizer so the `CI summary` and branch-protection manifests remain in sync (file updated: `ci/required-contexts.json`).

### Testing
- Ran `npm run ci:sync-contexts` to regenerate `ci/required-contexts.json` and the command completed successfully. 
- Ran `npm run ci:verify-summary-needs` to validate the workflow summary needs and it reported full coverage of non-summary jobs. 
- Lint check: ESLint no longer reports the `await outside async` error for `scripts/ci/validate-ics-fixture.mjs`. 
- Verified workflow file edits to ensure coverage artefacts are uploaded and the combined enforcement job downloads and combines them (manual verification via `npm run ci:verify-summary-needs`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963c7674d948333bee121985501e58b)