### PR TITLE
Rename ICS golden fixture test for clarity

### DIFF
--- a/test/orchestrator/test_ics_golden.py
+++ b/test/orchestrator/test_ics_golden.py
@@ -7,7 +7,7 @@ from orchestrator.models import PlanIn
 FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
 
 
-def test_create_job_ics_matches_fixture(monkeypatch):
+def test_create_job_ics_fixture_matches_golden(monkeypatch):
     monkeypatch.setattr(
         planner,
         "_generate_trace_id",


### PR DESCRIPTION
### Motivation
- Make the Python golden test name reflect its narrowed scope as a fixture-equality check only.
- This clarifies design intent as ICS validation is being handled by a dedicated Node/TypeScript CI job.
- A clearer name prevents accidental reintroduction of Node/ts-node subprocesses inside Python unit tests.

### Description
- Rename the test function in `test/orchestrator/test_ics_golden.py` from `test_create_job_ics_matches_fixture` to `test_create_job_ics_fixture_matches_golden`.
- No behavioral changes to the test logic or other code; the test still asserts `plan.ics` equals the JSON fixture.
- Change is a single small, focused commit that improves test semantics and readability.

### Testing
- Ran the Python unit and integration suites under coverage with `coverage run --rcfile=.coveragerc -m pytest -m "not requires_torch"` and the suites completed successfully.
- Executed `npm ci` and the Node check `npm run demo:phase8:ci` and both succeeded in this environment.
- Attempted the Foundry step (`forge test ...`) but the `forge` binary is not available in this execution environment, so Foundry tests could not be run here.
- No other automated checks were altered by this change and the rename is safe and non-disruptive to CI orchestration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963f022c4bc8333bda3db4dd54a7694)