### PR TITLE
Fix Foundry blockhash handling and clear compiler cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,8 @@ jobs:
           else
             echo 'forge-std already present; skipping install.';
           fi
+      - name: Clear Foundry compiler cache
+        run: rm -f cache/solidity-files-cache.json || true
       - name: Foundry tests
         run: forge test --ffi --fuzz-runs 128
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -92,6 +92,9 @@ jobs:
         with:
           version: 'v1.4.4'
 
+      - name: Clear Foundry compiler cache
+        run: rm -f cache/solidity-files-cache.json || true
+
       - name: Foundry tests
         run: forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -70,6 +70,9 @@ jobs:
           npx ts-node --compiler-options '{"module":"commonjs"}' scripts/generate-constants.ts
           npx hardhat compile
 
+      - name: Clear Foundry compiler cache
+        run: rm -f cache/solidity-files-cache.json || true
+
       - name: Foundry fuzz tests
         env:
           FOUNDRY_PROFILE: default

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,5 @@
 [profile.default]
 solc_version = "0.8.25"
-forge_version = "1.4.4"
 src = 'contracts/v2'
 test = 'test/v2'
 libs = ['lib', 'node_modules']
@@ -18,4 +17,3 @@ remappings = ['@openzeppelin/contracts=node_modules/@openzeppelin/contracts']
 via_ir = true
 optimizer = true
 optimizer_runs = 200
-forge_version = "1.4.4"

--- a/test/v2/ValidatorStakeLock.t.sol
+++ b/test/v2/ValidatorStakeLock.t.sol
@@ -89,6 +89,13 @@ contract ValidatorStakeLockTest is Test {
         return ITaxPolicy(address(0));
     }
 
+    function _rollPastAndSetBlockhash(uint256 n, bytes32 h) internal {
+        if (block.number <= n) {
+            vm.roll(n + 1);
+        }
+        vm.setBlockhash(n, h);
+    }
+
     function _prepareJob(uint256 jobId) internal returns (address[] memory selected) {
         MockJobRegistry.LegacyJob memory job;
         job.employer = employer;
@@ -105,12 +112,10 @@ contract ValidatorStakeLockTest is Test {
         vm.prank(address(jobRegistry));
         validation.start(jobId, 0);
         uint256 targetBlock = block.number + 1;
-        vm.roll(targetBlock);
-        vm.setBlockhash(
+        _rollPastAndSetBlockhash(
             targetBlock,
             keccak256(abi.encodePacked(jobId, burnTxHash, targetBlock))
         );
-        vm.roll(targetBlock + 1);
         vm.prevrandao(uint256(keccak256(abi.encodePacked(jobId, targetBlock))));
         selected = validation.selectValidators(jobId, 0);
     }


### PR DESCRIPTION
### Motivation
- Foundry fuzz tests were failing because `vm.setBlockhash` was being called for blocks in the future, producing "block number must be less than or equal to the current block number" errors.
- CI surfaced warnings from unsupported `forge_version` keys in `foundry.toml` that should not be declared in profiles.
- A `foundry_compilers::cache` deserialization error suggested a stale/corrupted incremental compiler cache file was being restored in CI.
- Test invocation snippets referenced non-portable paths (e.g., `/root/.foundry/bin`) that break in different runner/home environments.

### Description
- Added `_rollPastAndSetBlockhash(uint256, bytes32)` helper to `test/v2/ValidatorStakeLock.t.sol` and replaced the direct `vm.setBlockhash` call so the test always rolls past the target block before setting the blockhash.
- Removed `forge_version` entries from `foundry.toml` to eliminate the Foundry profile warnings.
- Added `rm -f cache/solidity-files-cache.json || true` steps to the Foundry CI jobs (`.github/workflows/ci.yml`, `contracts.yml`, and `fuzz.yml`) so stale compiler cache files are removed before running `forge test`.
- Kept the prior CI refactor intact and avoided changing unrelated test runners or Python/torch defaults.

### Testing
- No automated tests were executed within this workspace as part of the change; CI will run the existing Foundry jobs to verify behavior.
- Recommended local verification commands are `forge test --match-path test/v2/ValidatorStakeLock.t.sol -vvvv` and `forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'`.
- The three previously failing tests (`testSlashingSucceedsWithShortUnbondingPeriod`, `testValidatorCannotFinalizeWithdrawalWhileAssigned`, and `testValidatorWithdrawStakeRevertsDuringActiveJob`) are expected to pass when running the above Foundry commands.
- After these changes CI Foundry jobs should be quieter and avoid the `foundry_compilers::cache` deserialization noise once workflows run on the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696437d75964833392e26a8bf049f1fd)