### PR TITLE
CI: fix Foundry fuzz blockhash ordering, stabilize caches, and unblock assurance/coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,12 +353,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install coverage==7.6.4
       - name: Download unit coverage data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: python-coverage-unit
           path: coverage-data/unit
       - name: Download integration coverage data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: python-coverage-integration
           path: coverage-data/integration
@@ -451,6 +451,10 @@ jobs:
         run: npm run ci:preflight
       - name: Install dependencies
         run: ./scripts/ci/npm-ci.sh --no-audit --prefer-offline --progress=false
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
+        with:
+          version: 'v1.4.4'
       - name: Generate owner control assurance reports
         run: |
           mkdir -p reports/owner-control
@@ -511,15 +515,8 @@ jobs:
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
           version: 'v1.4.4'
-      - name: Cache Foundry build artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: |
-            ~/.foundry/cache
-            ~/.cache/foundry
-          key: foundry-${{ runner.os }}-${{ hashFiles('foundry.toml') }}
-          restore-keys: |
-            foundry-${{ runner.os }}-
+      - name: Purge Foundry compiler cache
+        run: rm -rf ~/.foundry/cache ~/.cache/foundry
       - name: Ensure forge-std dependency
         run: |
           if [ ! -d lib/forge-std ]; then
@@ -1222,15 +1219,8 @@ jobs:
         uses: foundry-rs/foundry-toolchain@50d5a8956f2e319df19e6b57539d7e2acb9f8c1e
         with:
           version: 'v1.4.4'
-      - name: Cache Foundry build artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: |
-            ~/.foundry/cache
-            ~/.cache/foundry
-          key: foundry-invariant-${{ runner.os }}-${{ hashFiles('foundry.toml', 'test/v2/invariant/**/*.sol') }}
-          restore-keys: |
-            foundry-invariant-${{ runner.os }}-
+      - name: Purge Foundry compiler cache
+        run: rm -rf ~/.foundry/cache ~/.cache/foundry
       - name: Ensure forge-std dependency
         run: |
           if [ ! -d lib/forge-std ]; then

--- a/.github/workflows/culture-ci.yml
+++ b/.github/workflows/culture-ci.yml
@@ -189,12 +189,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Download contract coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: culture-contract-coverage
           path: demo/CULTURE-v0
       - name: Download service coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: culture-service-coverage
           path: demo/CULTURE-v0

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           version: 'v1.4.4'
 
+      - name: Purge Foundry compiler cache
+        run: rm -rf ~/.foundry/cache ~/.cache/foundry
+
       - name: Cache forge libraries
         id: cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
           unset SECRET_VALUE
 
       - name: Download release bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: release-prep
           path: reports/prep
@@ -465,7 +465,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download release preparation artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: release-prep
           path: release-prep

--- a/scripts/ci/validate-ics-fixture.mjs
+++ b/scripts/ci/validate-ics-fixture.mjs
@@ -2,22 +2,25 @@ import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const compilerOptions = {
-  module: 'esnext',
-  moduleResolution: 'node',
-};
+async function main() {
+  const compilerOptions = {
+    module: 'esnext',
+    moduleResolution: 'node',
+  };
 
-if (!process.env.TS_NODE_COMPILER_OPTIONS) {
-  process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify(compilerOptions);
-}
+  if (!process.env.TS_NODE_COMPILER_OPTIONS) {
+    process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify(compilerOptions);
+  }
 
-const fixturesDir = join(process.cwd(), 'test', 'orchestrator', 'fixtures');
-const icsModuleUrl = pathToFileURL(
-  join(process.cwd(), 'packages', 'orchestrator', 'src', 'ics.ts')
-).href;
+  const fixturesDir = join(process.cwd(), 'test', 'orchestrator', 'fixtures');
+  const icsModuleUrl = pathToFileURL(
+    join(process.cwd(), 'packages', 'orchestrator', 'src', 'ics.ts')
+  ).href;
 
-async function loadValidator() {
-  const module = await import(icsModuleUrl);
+  const [fixtureNames, module] = await Promise.all([
+    readdir(fixturesDir),
+    import(icsModuleUrl),
+  ]);
   const validate = module.validateICS ?? module.default?.validateICS;
 
   if (!validate) {
@@ -25,15 +28,6 @@ async function loadValidator() {
       'validateICS export not found in packages/orchestrator/src/ics.ts'
     );
   }
-
-  return validate;
-}
-
-async function main() {
-  const [fixtureNames, validate] = await Promise.all([
-    readdir(fixturesDir),
-    loadValidator(),
-  ]);
   const jsonFixtures = fixtureNames.filter((name) => name.endsWith('.json'));
 
   if (jsonFixtures.length === 0) {

--- a/test/v2/ValidatorStakeLock.t.sol
+++ b/test/v2/ValidatorStakeLock.t.sol
@@ -104,13 +104,20 @@ contract ValidatorStakeLockTest is Test {
 
         vm.prank(address(jobRegistry));
         validation.start(jobId, 0);
-        uint256 targetBlock = block.number + 1;
-        vm.roll(targetBlock);
+        uint256 targetBlock = validation.selectionBlock(jobId);
+        if (targetBlock == 0) {
+            targetBlock = block.number + 1;
+        }
+        if (targetBlock > block.number) {
+            vm.roll(targetBlock);
+        }
         vm.setBlockhash(
             targetBlock,
             keccak256(abi.encodePacked(jobId, burnTxHash, targetBlock))
         );
-        vm.roll(targetBlock + 1);
+        if (block.number <= targetBlock) {
+            vm.roll(targetBlock + 1);
+        }
         vm.prevrandao(uint256(keccak256(abi.encodePacked(jobId, targetBlock))));
         selected = validation.selectValidators(jobId, 0);
     }


### PR DESCRIPTION
### Motivation
- Foundry fuzz tests were failing because tests called `vm.setBlockhash(...)` for future block numbers, triggering "block number must be <= current block number" errors during fuzz runs.
- Foundry compiler cache restores caused `foundry_compilers::cache invalid type` parse errors when cache format changed across Foundry versions.
- The Owner control assurance step tried to run `forge` in an environment where Foundry was not installed, causing hard failures instead of producing owner reports.
- ESLint/Node parsing failed on `scripts/ci/validate-ics-fixture.mjs` because of top-level `await`-style usage not wrapped in an async main, and coverage/artifact downloads used an unpinned `actions/download-artifact` reference.

### Description
- Reordered the `vm.roll` / `vm.setBlockhash` sequence in `test/v2/ValidatorStakeLock.t.sol` to compute `selectionBlock`, roll to it when needed, set the blockhash only for a non-future block, and advance safely before selection.
- Rewrote `scripts/ci/validate-ics-fixture.mjs` to run inside an `async function main()` and perform the dynamic `import(...)` from within that function to avoid top-level-await parse issues.
- Updated CI workflows to install Foundry in the owner-assurance job, and added explicit `rm -rf ~/.foundry/cache ~/.cache/foundry` purge steps (and removed/avoided restoring Foundry compiler cache) to prevent incompatible cache restores.
- Pinned `actions/download-artifact` usages to the verified `v4` SHA (`d3f86a...`) in workflows and added a Foundry cache purge to the `fuzz` job to stabilize artifact/coverage download and Foundry runs.

### Testing
- No automated tests were executed locally as part of this change; the patch is intended to be verified by CI where the following automated jobs will run: `npm run lint:ci`, `npm run ci:validate-ics-fixture`, `forge test --ffi --fuzz-runs ...`, and the coverage pipeline.
- CI should now avoid `foundry_compilers::cache` parse errors due to the purge step and should have Foundry available in the owner assurance job so `forge`-based checks can run (verification occurs in CI runs).
- The `ValidatorStakeLock` changes are targeted at fuzz/forge failures and are safe (only test helper sequencing changed); full fuzz runs will be exercised by CI `forge` jobs.
- The `validate-ics-fixture` script change resolves the ESLint parse error by removing top-level await patterns so the Node/TS validator job can run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696452c6b8888333b49a699866c19b20)