### PR TITLE
Add AGIJobManager v1 mainnet deployment & security overview and local test-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ The loop above is enforced in automation: CI v2 verifies the owner authority man
 
 The repository’s manuals, runbooks, and subsystem READMEs are catalogued in [`docs/readme-catalog.md`](docs/readme-catalog.md). The inventory spans 169 markdown guides (129 READMEs, 40 runbooks) so release captains can locate operator instructions, demo briefings, and subsystem diagrams without spelunking through the tree. Every document is synchronised with the repository tree; CI fails fast if a referenced README is missing, keeping the narrative aligned with the code that powers it.【F:docs/readme-catalog.md†L1-L71】【F:docs/readme-catalog.md†L73-L169】【F:.github/workflows/ci.yml†L34-L1181】
 
+### Documentation
+
+- [AGIJobManager v1 mainnet deployment & security overview](docs/security/mainnet-deployment-and-trust-model.md)
+- [Local Truffle test status](docs/test-status.md)
+
 ```mermaid
 mindmap
   root((Knowledge lattice))

--- a/docs/readme-catalog.md
+++ b/docs/readme-catalog.md
@@ -206,6 +206,8 @@ briefings, and subsystem manuals when coordinating releases or audits.
 | `docs/production/mainnet-etherscan-runbook.md` | AGI Jobs v2 — Mainnet Etherscan Deployment & Owner Control Runbook | RUNBOOK |
 | `docs/sre-runbooks.md` | SRE Runbooks | RUNBOOK |
 | `docs/user-guides/README.md` | AGI Jobs v0 (v2) — Docs → User Guides | README |
+| `docs/security/mainnet-deployment-and-trust-model.md` | AGIJobManager v1 — Mainnet Deployment & Security Overview | DOC |
+| `docs/test-status.md` | Test Status (Local Truffle) | DOC |
 
 ## internal_docs
 
@@ -253,4 +255,3 @@ briefings, and subsystem manuals when coordinating releases or audits.
 | `services/culture-graph-indexer/README.md` | AGI Jobs v0 (v2) — Services → Culture Graph Indexer | README |
 | `services/sentinel/README.md` | AGI Jobs v0 (v2) — Sentinel Monitor | README |
 | `services/thermostat/README.md` | AGI Jobs v0 (v2) — Thermostat Service | README |
-

--- a/docs/security/mainnet-deployment-and-trust-model.md
+++ b/docs/security/mainnet-deployment-and-trust-model.md
@@ -1,0 +1,176 @@
+# AGIJobManager v1 — Mainnet Deployment & Security Overview
+
+> **Scope:** This document describes the **mainnet AGIJobManager v1** contract as verified on-chain at `0x0178b6bad606aaf908f72135b8ec32fc1d5ba477`. The Solidity source is **not** stored in this repo; operational behavior here is derived from the verified on-chain source and the repository’s Truffle build configuration. Treat this as a business-operated escrow + settlement engine, not a decentralized governance system.
+
+## 1) Executive summary
+
+AGIJobManager v1 is a **business-operated on-chain job escrow and settlement engine** with an integrated ERC‑721 receipt + marketplace flow. Employers escrow AGI tokens, agents deliver work, validators vote, and the contract pays out and mints an ERC‑721 receipt for the employer. It is **not** a DAO, **not** a trustless arbitration system, and **not** upgradeable via proxy. Control is centralized in an on-chain **owner** and a **moderator** set.
+
+What it **is**:
+- A single, owner‑operated contract that escrows ERC‑20 payments for jobs.
+- A validator‑assisted approval/disapproval flow (with a moderator‑driven dispute override).
+- An ERC‑721 receipt minted to the employer plus a built‑in NFT listing + purchase flow.
+
+What it **is not**:
+- A DAO or on‑chain governance system.
+- A trustless arbitration mechanism (moderators decide disputes).
+- An upgradeable proxy contract.
+
+## 2) Trust model & roles
+
+**Owner (centralized operator)**
+- Pause/unpause the contract.
+- Update token address, base IPFS URL, and platform copy strings.
+- Set validator approval/disapproval thresholds, reputation thresholds, reward percentages, and job limits.
+- Add/remove moderators.
+- Add/remove additional agents/validators (allowlist bypass for ENS + Merkle checks).
+- Blacklist agents/validators (no dedicated blacklist events).
+- Withdraw any AGI balance via `withdrawAGI` (no escrow hard‑lock).
+- Delist unassigned jobs on behalf of the employer.
+- Configure per‑NFT payout percentages via `addAGIType`.
+
+**Moderators**
+- Resolve disputes via `resolveDispute(jobId, resolution)`.
+- Outcomes are **string‑based** and binary: only the exact strings `"agent win"` or `"employer win"` trigger a payout path.
+
+**Users**
+- **Employer**: `createJob`, `cancelJob` (before assignment), `disputeJob`, and receives an ERC‑721 receipt on completion.
+- **Agent**: `applyForJob`, `requestJobCompletion` (must be within job duration).
+- **Validator**: `validateJob` or `disapproveJob` (ENS + Merkle‑gated unless allowlisted by owner).
+
+## 3) Job lifecycle / state machine
+
+**Key on‑chain fields** in the `Job` struct:
+- `assignedAgent` (address)
+- `assignedAt` (timestamp)
+- `completed` (bool)
+- `completionRequested` (bool)
+- `validatorApprovals` / `validatorDisapprovals` (uint)
+- `disputed` (bool)
+- `validators` (address[])
+
+### Happy path
+1. **Create**: Employer calls `createJob`, escrowing `_payout` into the contract.
+2. **Assign**: Agent calls `applyForJob`; contract records `assignedAgent` + `assignedAt`.
+3. **Submit**: Agent calls `requestJobCompletion` (must be before `assignedAt + duration`).
+4. **Validate**: Validators call `validateJob` until `validatorApprovals >= requiredValidatorApprovals`.
+5. **Complete**: `_completeJob` pays the agent + validators, mints an ERC‑721 to the employer, and emits `JobCompleted`.
+
+### Dispute path
+- Validators can push the job into dispute by reaching `requiredValidatorDisapprovals` (which sets `disputed = true`), or the employer/agent can call `disputeJob`.
+- A moderator calls `resolveDispute` with `"agent win"` or `"employer win"`.
+  - **Agent win** triggers `_completeJob`.
+  - **Employer win** returns the escrow to the employer.
+
+### Timeouts & liveness
+- **No `expireJob` / `finalizeJob` equivalents exist.** There is no on‑chain timeout or forced settlement path.
+- The only explicit time check is in `requestJobCompletion` (must occur before `assignedAt + duration`).
+- If the job expires or a dispute is never resolved, funds can remain stuck unless the owner intervenes with `withdrawAGI` (which is not escrow‑aware).
+
+## 4) Treasury vs escrow separation (hard invariant)
+
+**There is no `lockedEscrow` or `withdrawableAGI()` in v1.** The contract holds escrow and any other deposits in a single ERC‑20 balance. This means:
+- The contract has **no on‑chain invariant** protecting active escrow from owner withdrawals.
+- `withdrawAGI` can move **any** balance, even if jobs are active.
+
+What becomes de‑facto treasury:
+- Any remainder not paid to agents/validators (e.g., if agent payout % + validator reward % < 100).
+- Any rounding dust from integer division.
+- Direct `contributeToRewardPool` deposits (not segregated).
+
+**Operational guidance:** treat treasury management as an **off‑chain policy**; the contract itself does not enforce escrow separation.
+
+## 5) Identity wiring lock (`lockIdentityConfig`) — what it freezes and what it does not
+
+`lockIdentityConfig` **does not exist** in AGIJobManager v1. Identity wiring is **implicitly locked by design** because:
+- ENS + NameWrapper addresses, root nodes, and Merkle roots are set **only in the constructor**.
+- There are **no setters** for those fields after deployment.
+
+What remains adjustable:
+- Owner‑managed allowlists (`addAdditionalAgent`, `addAdditionalValidator`).
+- Blacklists, pause controls, economic parameters, and payout configuration.
+
+**Recommended procedure**
+1. Deploy with correct ENS registry, NameWrapper, and root/merkle configuration.
+2. Smoke‑test `applyForJob` and `validateJob` using real subdomains.
+3. Lock in operational access by adding/removing allowlisted actors as needed.
+
+## 6) Pause semantics (exact behavior)
+
+**Blocked while paused** (uses `whenNotPaused`):
+- `createJob`
+- `applyForJob`
+- `requestJobCompletion`
+- `validateJob`
+- `disapproveJob`
+- `disputeJob`
+- `contributeToRewardPool`
+
+**Allowed while paused** (not pause‑gated):
+- `cancelJob`
+- `delistJob` (owner)
+- `resolveDispute` (moderator)
+- `listNFT` / `purchaseNFT` / `delistNFT`
+- `withdrawAGI` (owner)
+- Blacklists, allowlist updates, and parameter setters
+
+## 7) Security posture (operationally useful, non‑audit)
+
+- **ReentrancyGuard** is applied to most external entrypoints that move funds (e.g., `createJob`, `applyForJob`, `validateJob`, `disapproveJob`, `disputeJob`, `cancelJob`, `resolveDispute`, `withdrawAGI`, `contributeToRewardPool`).
+- **ERC‑20 transfers are raw** (`transfer`/`transferFrom`) with no `SafeERC20`; fee‑on‑transfer tokens may behave unexpectedly.
+- **Validator payout loop is unbounded** (no explicit cap on the number of validators added to a job).
+- **ENS/NameWrapper checks** are wrapped in `try/catch` and are view‑only.
+- **Dispute outcomes are binary** and rely on exact string matching.
+- **Centralized operator risk:** owner can withdraw escrow, change parameters, and pause/unpause at any time.
+
+## 8) EIP‑170 bytecode size & build reproducibility
+
+- **EIP‑170 runtime code limit**: 24,576 bytes.
+- **No bytecode‑size guard** exists in this repo for AGIJobManager v1.
+
+**Truffle compiler settings (repo):**
+- `solc` **0.8.25**
+- Optimizer **enabled** with **200 runs**
+- `viaIR` **enabled**
+
+**How to measure size locally (if you compile v1):**
+```bash
+jq -r '.deployedBytecode' build/contracts/AGIJobManager.json | wc -c
+```
+
+## 9) Verification & deployment guide (Truffle‑first)
+
+**Mainnet deployment checklist:**
+1. Confirm Truffle compiler settings match `truffle-config.js` (see above).
+2. Compile and test (see Test Status below).
+3. Record constructor args (token, ENS, NameWrapper, root nodes, Merkle roots, base IPFS URL).
+4. Deploy via a multisig‑controlled account where possible.
+5. Verify on Etherscan with the **exact** compiler version, optimizer runs, and constructor args.
+
+**Repository scripts:**
+- The `migrations/` scripts in this repo target the **v2 modular suite** and do **not** deploy AGIJobManager v1.
+- For v1, use an **Etherscan deploy** or a custom Truffle migration that points at the verified v1 source.
+
+## 10) Monitoring / alerting checklist
+
+Index and alert on these events:
+- `JobCreated`, `JobApplied`, `JobCompletionRequested`
+- `JobValidated`, `JobDisapproved`, `JobDisputed`, `DisputeResolved`
+- `JobCompleted`, `JobCancelled`
+- `NFTIssued`, `NFTListed`, `NFTPurchased`, `NFTDelisted`
+- `RewardPoolContribution`, `ReputationUpdated`
+- `OwnershipVerified`, `RecoveryInitiated` (ENS/NameWrapper checks)
+- `Paused`, `Unpaused` (from OpenZeppelin `Pausable`)
+
+**Solvency invariant (operational):**
+- There is **no on‑chain `lockedEscrow` invariant**. Operators should monitor whether the contract’s AGI balance covers the sum of open job payouts.
+
+## 11) Known gaps / future work (non‑binding)
+
+- **`additionalAgentPayoutPercentage` does not exist in v1**; payouts depend on `AGIType` configuration and can be 0 if no matching NFT is held.
+- **Reward pool naming caveat:** `contributeToRewardPool` deposits are not segregated; they become part of the general balance.
+- **Blacklist events:** blacklisting has no dedicated events; consider adding them in a future revision for monitoring parity.
+
+## Test status
+
+See [docs/test-status.md](../test-status.md) for the latest local Truffle compile/test results.

--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -1,0 +1,41 @@
+# Test status (local)
+
+This file records the most recent local Truffle compile/test results for this repo.
+
+## Environment
+- Node: v20.19.6
+- Truffle: v5.11.5
+- Solidity (solc-js): 0.8.25
+
+## Reproduction
+
+```bash
+npm ci
+npx truffle version
+npx truffle compile
+npx truffle test
+```
+
+## Current failure
+
+`npx truffle compile` **fails** with a solc-js runtime error:
+
+```
+RuntimeError: memory access out of bounds
+    at null.<anonymous> (wasm://wasm/053f8e02:1:173647)
+    at null.<anonymous> (wasm://wasm/053f8e02:1:20368885)
+    ...
+```
+
+`npx truffle test` also fails because compilation aborts with the same error.
+
+## Interpretation
+
+This is a compiler/runtime failure from the solc-js WASM build while compiling the full contract tree (including v2 modules). It is **not** a failing test assertion—tests do not run because compilation fails.
+
+## Smallest next fix
+
+- Use a **native solc 0.8.25 binary** instead of the solc-js WASM build (Truffle supports setting the compiler version to a local solc binary path).
+- Alternatively, split the compile scope or run on a machine with more memory so the solc-js WASM compiler can complete.
+
+Once compilation succeeds, rerun `npx truffle test` to surface any actual test failures.


### PR DESCRIPTION
### Motivation

- Provide an authoritative, mainnet-focused deployment and security overview for the verified AGIJobManager v1 contract (0x0178…a477) that is truthful to on-chain code and repo build settings.
- Surface and document an actionable local Truffle compile/test failure so operators know how to reproduce and remediate before running CI or deployments. 
- Minimise repo changes by adding focused docs and linking them from existing indexes without modifying runtime contract logic.

### Description

- Added `docs/security/mainnet-deployment-and-trust-model.md` containing: executive summary, trust model & roles, precise job lifecycle/state fields, pause semantics (exact functions blocked/allowed), treasury vs escrow note (no `lockedEscrow` present), identity wiring facts (no `lockIdentityConfig` setter), security posture notes, EIP‑170/build settings, monitoring event checklist, and known gaps. 
- Added `docs/test-status.md` recording local reproduction steps and the current `solc-js` compile failure (WASM memory error) and smallest next fixes (use native solc or larger memory/split compile). 
- Updated `README.md` and `docs/readme-catalog.md` to link the new overview and test-status docs so operators can find them from the repository index. 
- All documentation content was verified against the checked contract sources and the repository `truffle-config.js` (notably `solc: 0.8.25`, optimizer on, runs=200, `viaIR=true`) and the extracted AGIJobManager v1 source to avoid overstating behaviors (e.g., no escrow-lock, no dedicated blacklist events, ENS+NameWrapper+Merkle verification behavior, moderator string-based dispute resolution).

### Testing

- `npm ci` — completed successfully (packages installed; audit warnings reported but install succeeded).  
- `npx truffle version` — printed Truffle v5.11.5 / Solc 0.8.25 (solc-js) and environment info.  
- `npx truffle compile` — failed with a solc-js runtime error (`RuntimeError: memory access out of bounds`) while compiling the full contract tree; compilation did not complete.  
- `npx truffle test` — did not run successfully because compilation aborted with the same solc-js WASM runtime error.  

Reproduction (local):
```
npm ci
npx truffle version
npx truffle compile
npx truffle test
```

Observed failure meaning and smallest next fix: the failure is a solc-js WASM runtime (memory) error when compiling the large contract tree; it is not a failing test assertion. The smallest practical remediations are to compile with a native `solc` 0.8.25 binary (configure Truffle to use a local compiler binary) or compile on a machine with more memory or split the compile scope so the solc-js WASM compiler can complete; after successful compilation, re-run `npx truffle test` to surface any test failures.

Files added/updated
- Added: `docs/security/mainnet-deployment-and-trust-model.md`, `docs/test-status.md`.
- Updated: `README.md`, `docs/readme-catalog.md`.

Commands run (local)
- `npm ci` (success)
- `npx truffle version` (success)
- `npx truffle compile` (failed: solc-js memory error)
- `npx truffle test` (not run due to compile failure)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69838b94384883339cad3d4d16b3f85b)