### PR TITLE
ci: harden Foundry library setup and improve validator fuzz failure diagnostics

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -95,6 +95,14 @@ jobs:
       - name: Purge Foundry compiler cache
         run: rm -rf ~/.foundry/cache ~/.cache/foundry
 
+      - name: Ensure forge-std dependency
+        run: |
+          if [ ! -d lib/forge-std ]; then
+            forge install foundry-rs/forge-std --no-git
+          else
+            echo 'forge-std already present; skipping install.'
+          fi
+
       - name: Foundry tests
         run: forge test -vvvv --ffi --fuzz-runs 256 --match-contract 'CommitReveal|Stake|Fee|Slashing'
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -56,8 +56,7 @@ jobs:
           key: ${{ runner.os }}-foundry-${{ hashFiles('foundry.toml') }}
           restore-keys: ${{ runner.os }}-foundry-
 
-      - name: Install forge libraries
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Ensure forge libraries
         run: |
           mkdir -p lib
           if [ ! -d lib/forge-std ]; then

--- a/test/v2/ValidatorSelectionFuzz.t.sol
+++ b/test/v2/ValidatorSelectionFuzz.t.sol
@@ -156,7 +156,21 @@ contract ValidatorSelectionFuzz is Test {
             uint256 a = counts[i];
             uint256 b = countsRev[i];
             uint256 diff = a > b ? a - b : b - a;
-            assertLt(diff, iterations / 5);
+            assertLt(
+                diff,
+                iterations / 5,
+                string.concat(
+                    "order-independence drift at index ",
+                    vm.toString(i),
+                    " (forward=",
+                    vm.toString(a),
+                    ", reverse=",
+                    vm.toString(b),
+                    ", diff=",
+                    vm.toString(diff),
+                    ")"
+                )
+            );
         }
     }
 
@@ -196,7 +210,27 @@ contract ValidatorSelectionFuzz is Test {
         for (uint256 i; i < poolSize; i++) {
             uint256 a = counts[i];
             uint256 diff = a > expected ? a - expected : expected - a;
-            assertLe(diff, expected);
+            assertLe(
+                diff,
+                expected,
+                string.concat(
+                    "uniformity drift at index ",
+                    vm.toString(i),
+                    " (count=",
+                    vm.toString(a),
+                    ", expected=",
+                    vm.toString(expected),
+                    ", diff=",
+                    vm.toString(diff),
+                    ", iterations=",
+                    vm.toString(iterations),
+                    ", pool=",
+                    vm.toString(poolSize),
+                    ", select=",
+                    vm.toString(selectCount),
+                    ")"
+                )
+            );
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce spurious Foundry failures caused by cache/content drift (missing or corrupted `lib/forge-std`) that produce noisy CI signal without indicating product regressions.
- Preserve existing statistical safety checks in `ValidatorSelectionFuzz.t.sol` while making failures actionable for faster triage.
- Keep branch-protection/required-context manifests intact and avoid weakening meaningful safety coverage.

### Description
- Add an explicit `Ensure forge-std dependency` step to `.github/workflows/contracts.yml` so `lib/forge-std` is verified/installed before running Foundry tests.
- Make `.github/workflows/fuzz.yml` always verify/install Forge libraries (mkdir+install check) regardless of cache-hit to eliminate cache-only drift failures.
- Improve assertion diagnostics in `test/v2/ValidatorSelectionFuzz.t.sol` by adding descriptive failure messages (index, counts, expected, iterations, pool/select sizes) for the order‑independence and large‑pool uniformity checks without changing tolerances.

### Testing
- Ran `npm run ci:preflight` which passed (`Toolchain lock verification passed` and `package-lock` integrity OK).
- Installed Foundry and executed `forge test --ffi --match-path test/v2/ValidatorSelectionFuzz.t.sol` and `forge test --ffi --match-path test/v2/ValidatorStakeLock.t.sol`, both suites passed locally (all tests in those files succeeded).
- Ran CI manifest verification scripts `npm run ci:sync-contexts -- --check`, `npm run ci:verify-summary-needs`, `npm run ci:verify-contexts`, and `npm run ci:verify-companion-contexts`, all of which succeeded and reported alignment with `ci.yml` and companion manifests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d463353ffc83339e4106546457eec2)